### PR TITLE
Switch to `guess` column for guesses

### DIFF
--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -7,10 +7,13 @@ $hunts = $wpdb->prefix.'bhg_bonus_hunts';
 $guesses = $wpdb->prefix.'bhg_guesses';
 $hunt = $wpdb->get_row($wpdb->prepare("SELECT * FROM `$hunts` WHERE id=%d",$hunt_id));
 if(!$hunt) { echo '<div class="wrap"><h1>'.esc_html__('Hunt not found','bonus-hunt-guesser').'</h1></div>'; return; }
-$rows = $wpdb->get_results($wpdb->prepare(
-    "SELECT g.*, u.display_name, ABS(g.guess_value - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
-    (float)$hunt->final_balance, $hunt_id
-));
+$rows = $wpdb->get_results(
+    $wpdb->prepare(
+        "SELECT g.*, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
+        (float) $hunt->final_balance,
+        $hunt_id
+    )
+);
 ?>
 <div class="wrap">
   <h1><?php echo esc_html__('Results for ','bonus-hunt-guesser').esc_html($hunt->title); ?></h1>

--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -18,7 +18,7 @@ class BHG_Models {
 
         $user_id = get_current_user_id();
         $hunt_id = isset($_POST['hunt_id']) ? (int) $_POST['hunt_id'] : 0;
-        $guess   = isset($_POST['guess_value']) ? (float) $_POST['guess_value'] : 0;
+        $guess   = isset($_POST['guess']) ? (float) $_POST['guess'] : 0;
 
         if ($hunt_id <= 0) {
             wp_die( esc_html__('Invalid hunt.', 'bonus-hunt-guesser') );
@@ -53,18 +53,22 @@ class BHG_Models {
 
         $now = current_time('mysql');
         if ($existing_id) {
-            $wpdb->update($guesses_tbl,
-                array('guess_value' => $guess, 'updated_at' => $now),
+            $wpdb->update(
+                $guesses_tbl,
+                array('guess' => $guess, 'updated_at' => $now),
                 array('id' => $existing_id)
             );
         } else {
-            $wpdb->insert($guesses_tbl, array(
-                'hunt_id'     => $hunt_id,
-                'user_id'     => $user_id,
-                'guess_value' => $guess,
-                'created_at'  => $now,
-                'updated_at'  => $now,
-            ));
+            $wpdb->insert(
+                $guesses_tbl,
+                array(
+                    'hunt_id'    => $hunt_id,
+                    'user_id'    => $user_id,
+                    'guess'      => $guess,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                )
+            );
         }
 
         // Redirect back

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -92,7 +92,7 @@ class BHG_Shortcodes {
         $user_id = get_current_user_id();
         $table = $wpdb->prefix . 'bhg_guesses';
         $existing_id = $hunt_id > 0 ? (int)$wpdb->get_var($wpdb->prepare("SELECT id FROM {$table} WHERE user_id=%d AND hunt_id=%d", $user_id, $hunt_id)) : 0;
-        $existing_guess = $existing_id ? (float)$wpdb->get_var($wpdb->prepare("SELECT guess_value FROM {$table} WHERE id=%d", $existing_id)) : '';
+        $existing_guess = $existing_id ? (float) $wpdb->get_var($wpdb->prepare("SELECT guess FROM {$table} WHERE id=%d", $existing_id)) : '';
 
         $settings = get_option('bhg_plugin_settings');
         $min = isset($settings['min_guess_amount']) ? (float)$settings['min_guess_amount'] : 0;
@@ -119,7 +119,7 @@ class BHG_Shortcodes {
 
             <label for="bhg-guess" style="display:block;margin-top:10px;"><?php esc_html_e('Your guess (final balance):', 'bonus-hunt-guesser'); ?></label>
             <input type="number" step="0.01" min="<?php echo esc_attr($min); ?>" max="<?php echo esc_attr($max); ?>"
-                   id="bhg-guess" name="guess_value" value="<?php echo esc_attr($existing_guess); ?>" required>
+                   id="bhg-guess" name="guess" value="<?php echo esc_attr($existing_guess); ?>" required>
 
             <button type="submit" class="button button-primary" style="margin-top:20px;"><?php echo esc_html__('Submit Guess', 'bonus-hunt-guesser'); ?></button>
         </form>
@@ -151,7 +151,7 @@ class BHG_Shortcodes {
 
         $order = strtoupper($a['order']) === 'DESC' ? 'DESC' : 'ASC';
         $map = array(
-            'guess'      => 'g.guess_value',
+            'guess'      => 'g.guess',
             'user'       => 'u.user_login',
             'position'   => 'g.id', // stable proxy
         );
@@ -196,7 +196,7 @@ class BHG_Shortcodes {
             echo '<tr>';
             echo '<td>' . (int)$pos++ . '</td>';
             echo '<td>' . esc_html($user_label) . ' <span class="bhg-aff-dot bhg-aff-' . esc_attr($aff) . '" aria-hidden="true"></span></td>';
-            echo '<td>' . esc_html(number_format_i18n((float)$r->guess_value, 2)) . '</td>';
+            echo '<td>' . esc_html(number_format_i18n((float) $r->guess, 2)) . '</td>';
             echo '</tr>';
         }
         echo '</tbody></table>';

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -278,7 +278,7 @@ if (!function_exists('bhg_reset_demo_and_seed')) {
                 $wpdb->insert($g_tbl, array(
                     'hunt_id' => $open_id,
                     'user_id' => (int)$uid,
-                    'guess_value' => $val,
+                    'guess' => $val,
                     'created_at' => $now,
                     'updated_at' => $now,
                 ), array('%d','%d','%f','%s','%s'));

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -129,7 +129,7 @@ add_shortcode('bhg_user_guesses', function($atts) {
                     <?php foreach ($rows as $r): ?>
                         <tr>
                             <td><?php echo esc_html($r->hunt_title ?: ('#' . $r->hunt_id)); ?></td>
-                            <td><?php echo esc_html(number_format_i18n($r->guess_value, 2)); ?></td>
+                            <td><?php echo esc_html(number_format_i18n($r->guess, 2)); ?></td>
                             <td><?php echo esc_html(ucfirst($r->hunt_status ?: 'open')); ?></td>
                             <td><?php echo esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format'), strtotime($r->created_at))); ?></td>
                         </tr>


### PR DESCRIPTION
## Summary
- Read and write guesses via the new `guess` column
- Update guess form, leaderboard and admin results to use `guess`
- Align helper/demo code with `guess` column

## Testing
- `php -l includes/class-bhg-models.php`
- `php -l includes/class-bhg-shortcodes.php`
- `php -l admin/views/bonus-hunts-results.php`
- `php -l includes/helpers.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba61f30fc0833399b8f5d3bb466cb5