### PR TITLE
Refactor hunts list count query

### DIFF
--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -9,13 +9,17 @@ $paged = max(1, isset($_GET['paged']) ? (int) $_GET['paged'] : 1);
 $per_page = 20;
 $offset = ($paged - 1) * $per_page;
 
-$rows = $wpdb->get_results($wpdb->prepare(
-  "SELECT SQL_CALC_FOUND_ROWS id, title, start_balance, final_balance, status, winners_limit, closed_at
-   FROM $t
-   ORDER BY id DESC
-   LIMIT %d OFFSET %d", $per_page, $offset
-));
-$total = (int) $wpdb->get_var("SELECT FOUND_ROWS()");
+$rows = $wpdb->get_results(
+  $wpdb->prepare(
+    "SELECT id, title, start_balance, final_balance, status, winners_limit, closed_at
+     FROM $t
+     ORDER BY id DESC
+     LIMIT %d OFFSET %d",
+    $per_page,
+    $offset
+  )
+);
+$total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $t" );
 $pages = max(1, (int) ceil($total / $per_page));
 
 ?>


### PR DESCRIPTION
## Summary
- remove SQL_CALC_FOUND_ROWS from hunts list query
- compute total hunt count via separate COUNT(*) query

## Testing
- `php -l admin/views/hunts-list.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba6a9da1708333a206119d2068852e