### PR TITLE
Add nonce validation to hunt editing

### DIFF
--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -5,6 +5,8 @@ if (!current_user_can('manage_options')) { wp_die(__('You do not have sufficient
 $hunt_id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 if (!$hunt_id) { wp_die(__('Missing hunt id','bonus-hunt-guesser')); }
 
+check_admin_referer('bhg_edit_hunt_' . $hunt_id, 'bhg_nonce');
+
 // Handle delete guess action
 if (isset($_POST['bhg_remove_guess']) && isset($_POST['bhg_remove_guess_nonce']) && wp_verify_nonce($_POST['bhg_remove_guess_nonce'], 'bhg_remove_guess_action')) {
     $guess_id = (int) ($_POST['guess_id'] ?? 0);

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -47,9 +47,10 @@ $pages = max(1, (int) ceil($total / $per_page));
           <td>
             <?php
               $results_url = wp_nonce_url( admin_url('admin.php?page=bhg-hunt-results&id='.(int)$r->id), 'bhg_view_results_'.(int)$r->id, 'bhg_nonce' );
+              $edit_url    = wp_nonce_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id), 'bhg_edit_hunt_'.(int)$r->id, 'bhg_nonce' );
             ?>
             <a class="button" href="<?php echo esc_url($results_url); ?>"><?php esc_html_e('Results','bonus-hunt-guesser'); ?></a>
-            <a class="button" href="<?php echo esc_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id) ); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
+            <a class="button" href="<?php echo esc_url($edit_url); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
           </td>
         </tr>
       <?php endforeach; else: ?>


### PR DESCRIPTION
## Summary
- secure hunt editing links using `wp_nonce_url`
- validate nonce in hunt edit handler with `check_admin_referer`

## Testing
- `php -l admin/views/hunts-list.php`
- `php -l admin/views/hunts-edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba6c2978fc83339cb2311308b323c8