### PR TITLE
Add nonce verification to hunt results page

### DIFF
--- a/admin/views/hunt-results.php
+++ b/admin/views/hunt-results.php
@@ -5,6 +5,8 @@ if (!current_user_can('manage_options')) { wp_die(__('You do not have sufficient
 $hunt_id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 if (!$hunt_id) { wp_die(__('Missing hunt id', 'bonus-hunt-guesser')); }
 
+check_admin_referer('bhg_view_results_' . $hunt_id, 'bhg_nonce');
+
 if (!function_exists('bhg_get_hunt') || !function_exists('bhg_get_all_ranked_guesses')) {
     wp_die(__('Required helper functions are missing. Please include class-bhg-bonus-hunts.php helpers.', 'bonus-hunt-guesser'));
 }


### PR DESCRIPTION
## Summary
- enforce nonce validation on hunt results view

## Testing
- `php -l admin/views/hunt-results.php`
- `php -r 'function wp_nonce_ays($a){echo "blocked\n";} function check_admin_referer($action,$arg){if(!isset($_REQUEST[$arg])||$_REQUEST[$arg]!="valid")wp_nonce_ays($action);else echo "allowed\n";} $_REQUEST=[]; check_admin_referer("bhg_view_results_1","bhg_nonce");'`
- `php -r 'function wp_nonce_ays($a){echo "blocked\n";} function check_admin_referer($action,$arg){if(!isset($_REQUEST[$arg])||$_REQUEST[$arg]!="valid")wp_nonce_ays($action);else echo "allowed\n";} $_REQUEST=["bhg_nonce"=>"valid"]; check_admin_referer("bhg_view_results_1","bhg_nonce");'`
- `php -r 'function wp_nonce_ays($a){echo "blocked\n";} function check_admin_referer($action,$arg){if(!isset($_REQUEST[$arg])||$_REQUEST[$arg]!="valid")wp_nonce_ays($action);else echo "allowed\n";} $_REQUEST=["bhg_nonce"=>"invalid"]; check_admin_referer("bhg_view_results_1","bhg_nonce");'`


------
https://chatgpt.com/codex/tasks/task_e_68ba6d13a09083339484f183c3c45973