### PR TITLE
Use esc_js with translations in admin prompts

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -44,7 +44,7 @@ $ads = $wpdb->get_results("SELECT * FROM `$table` ORDER BY id DESC");
           <td><?php echo esc_html(isset($ad->visibility)? $ad->visibility : 'all'); ?></td>
           <td>
             <a class="button" href="<?php echo esc_url(add_query_arg(['edit'=> (int)$ad->id])); ?>"><?php echo esc_html__('Edit', 'bonus-hunt-guesser'); ?></a>
-            <a class="button-link-delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['action'=>'delete','id'=>(int)$ad->id]), 'bhg_delete_ad')); ?>" onclick="return confirm('Delete this ad?');"><?php echo esc_html__('Remove', 'bonus-hunt-guesser'); ?></a>
+            <a class="button-link-delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['action'=>'delete','id'=>(int)$ad->id]), 'bhg_delete_ad')); ?>" onclick="return confirm('<?php echo esc_js( __( 'Delete this ad?', 'bonus-hunt-guesser' ) ); ?>');"><?php echo esc_html__('Remove', 'bonus-hunt-guesser'); ?></a>
           </td>
         </tr>
       <?php endforeach; endif; ?>

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -113,8 +113,8 @@ function bhg_insert_demo_data() {
         <?php wp_nonce_field('bhg_db_cleanup_action', 'bhg_nonce'); ?>
         <input type="hidden" name="bhg_action" value="db_cleanup">
         <p>
-            <input type="submit" name="bhg_db_cleanup" class="button button-secondary" value="<?php esc_attr_e('Run Database Cleanup', 'bonus-hunt-guesser'); ?>" 
-                   onclick="return confirm('<?php esc_attr_e('Are you sure you want to run database cleanup? This action cannot be undone.', 'bonus-hunt-guesser'); ?>')">
+            <input type="submit" name="bhg_db_cleanup" class="button button-secondary" value="<?php esc_attr_e('Run Database Cleanup', 'bonus-hunt-guesser'); ?>"
+                   onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to run database cleanup? This action cannot be undone.', 'bonus-hunt-guesser' ) ); ?>')">
         </p>
         <p class="description">
             <?php esc_html_e('Note: This will remove any demo data and reset tables to their initial state.', 'bonus-hunt-guesser'); ?>

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -246,8 +246,8 @@ if (isset($_GET['message'])) {
                                     <?php wp_nonce_field('bhg_delete_bonus_hunt', 'bhg_nonce'); ?>
                                     <input type="hidden" name="bhg_action" value="delete_bonus_hunt">
                                     <input type="hidden" name="id" value="<?php echo esc_attr($hunt->id); ?>">
-                                    <button type="submit" class="button button-small button-danger" 
-                                            onclick="return confirm('<?php _e('Are you sure you want to delete this bonus hunt?', 'bonus-hunt-guesser'); ?>');">
+                                    <button type="submit" class="button button-small button-danger"
+                                            onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to delete this bonus hunt?', 'bonus-hunt-guesser' ) ); ?>');">
                                         <?php _e('Delete', 'bonus-hunt-guesser'); ?>
                                     </button>
                                 </form>


### PR DESCRIPTION
## Summary
- Escape advertising deletion prompt with `esc_js( __( 'Delete this ad?', 'bonus-hunt-guesser' ) )`
- Apply `esc_js( __( … ) )` to database cleanup and bonus hunt deletion confirmations for consistent i18n and safety

## Testing
- `php -l admin/views/advertising.php`
- `php -l admin/views/database.php`
- `php -l admin/views/header.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba72010bac833383c1a356de53706f