### PR TITLE
Standardize translation naming to tkey/tvalue

### DIFF
--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -16,16 +16,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bhg_save_translation'
     }
 
     // Sanitize input
-    $t_key   = isset($_POST['t_key']) ? sanitize_text_field(wp_unslash($_POST['t_key'])) : '';
-    $t_value = isset($_POST['t_value']) ? sanitize_textarea_field(wp_unslash($_POST['t_value'])) : '';
+    $tkey   = isset($_POST['tkey']) ? sanitize_text_field(wp_unslash($_POST['tkey'])) : '';
+    $tvalue = isset($_POST['tvalue']) ? sanitize_textarea_field(wp_unslash($_POST['tvalue'])) : '';
 
     // Validate input
-    if ($t_key === '') {
+    if ($tkey === '') {
         $error = __('Key field is required.', 'bonus-hunt-guesser');
     } else {
         $wpdb->replace(
             $table,
-            array('t_key' => $t_key, 't_value' => $t_value),
+            array('tkey' => $tkey, 'tvalue' => $tvalue),
             array('%s', '%s')
         );
         $notice = __('Translation saved.', 'bonus-hunt-guesser');
@@ -33,7 +33,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bhg_save_translation'
 }
 
 // Fetch rows
-$rows = $wpdb->get_results( "SELECT t_key, t_value FROM {$table} ORDER BY t_key ASC" );
+$rows = $wpdb->get_results( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC" );
 ?>
 <div class="wrap">
   <h1><?php esc_html_e('Translations', 'bonus-hunt-guesser'); ?></h1>
@@ -50,12 +50,12 @@ $rows = $wpdb->get_results( "SELECT t_key, t_value FROM {$table} ORDER BY t_key 
     <table class="form-table" role="presentation">
       <tbody>
         <tr>
-          <th scope="row"><label for="t_key"><?php esc_html_e('Key','bonus-hunt-guesser'); ?></label></th>
-          <td><input name="t_key" id="t_key" type="text" class="regular-text" required></td>
+          <th scope="row"><label for="tkey"><?php esc_html_e('Key','bonus-hunt-guesser'); ?></label></th>
+          <td><input name="tkey" id="tkey" type="text" class="regular-text" required></td>
         </tr>
         <tr>
-          <th scope="row"><label for="t_value"><?php esc_html_e('Value','bonus-hunt-guesser'); ?></label></th>
-          <td><textarea name="t_value" id="t_value" class="large-text" rows="4"></textarea></td>
+          <th scope="row"><label for="tvalue"><?php esc_html_e('Value','bonus-hunt-guesser'); ?></label></th>
+          <td><textarea name="tvalue" id="tvalue" class="large-text" rows="4"></textarea></td>
         </tr>
       </tbody>
     </table>
@@ -68,8 +68,8 @@ $rows = $wpdb->get_results( "SELECT t_key, t_value FROM {$table} ORDER BY t_key 
     <tbody>
       <?php if ($rows): foreach ($rows as $r): ?>
         <tr>
-          <td><code><?php echo esc_html($r->t_key); ?></code></td>
-          <td><?php echo esc_html($r->t_value); ?></td>
+          <td><code><?php echo esc_html($r->tkey); ?></code></td>
+          <td><?php echo esc_html($r->tvalue); ?></td>
         </tr>
       <?php endforeach; else: ?>
         <tr><td colspan="2"><?php esc_html_e('No translations yet.','bonus-hunt-guesser'); ?></td></tr>

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -100,9 +100,9 @@ function bhg_seed_demo_on_activation(){
     ));
 
     // Translations & Ads samples
-    $wpdb->insert($trans, array('t_key'=>'email_results_title', 't_value'=>'The Bonus Hunt has been closed!'));
-    $wpdb->insert($trans, array('t_key'=>'email_final_balance', 't_value'=>'Final Balance'));
-    $wpdb->insert($trans, array('t_key'=>'email_winner', 't_value'=>'Winner'));
+    $wpdb->insert($trans, array('tkey'=>'email_results_title', 'tvalue'=>'The Bonus Hunt has been closed!'));
+    $wpdb->insert($trans, array('tkey'=>'email_final_balance', 'tvalue'=>'Final Balance'));
+    $wpdb->insert($trans, array('tkey'=>'email_winner', 'tvalue'=>'Winner'));
     $wpdb->insert($ads, array('message'=>'Sponsored by Demo Casino – Play Now', 'link'=>'https://example.com', 'placement'=>'footer', 'visibility'=>'guests', 'active'=>1));
 
     // Create demo pages with shortcodes (with (Demo) suffix)

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -55,12 +55,12 @@ if (!function_exists('bhg_t')) {
 
         $table = $wpdb->prefix . 'bhg_translations';
         $row = $wpdb->get_row(
-            $wpdb->prepare("SELECT value FROM $table WHERE `key` = %s", $key)
+            $wpdb->prepare("SELECT tvalue FROM $table WHERE tkey = %s", $key)
         );
 
-        if ($row && isset($row->value)) {
-            $cache[$key] = $row->value;
-            return $row->value;
+        if ($row && isset($row->tvalue)) {
+            $cache[$key] = $row->tvalue;
+            return $row->tvalue;
         }
 
         return $default;
@@ -354,11 +354,11 @@ if (!function_exists('bhg_reset_demo_and_seed')) {
                 'email_hunt' => 'Hunt',
             );
             foreach ($pairs as $k=>$v) {
-                $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM {$tr_tbl} WHERE `key`=%s", $k));
+                $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM {$tr_tbl} WHERE tkey=%s", $k));
                 if ($exists) {
-                    $wpdb->update($tr_tbl, array('value'=>$v), array('id'=>$exists), array('%s'), array('%d'));
+                    $wpdb->update($tr_tbl, array('tvalue'=>$v), array('id'=>$exists), array('%s'), array('%d'));
                 } else {
-                    $wpdb->insert($tr_tbl, array('key'=>$k, 'value'=>$v), array('%s','%s'));
+                    $wpdb->insert($tr_tbl, array('tkey'=>$k, 'tvalue'=>$v), array('%s','%s'));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- unify translation naming to tkey/tvalue in admin interface and helpers
- adjust demo seed data to match new translation column names

## Testing
- `php -l admin/views/translations.php`
- `php -l includes/helpers.php`
- `php -l includes/demo.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba7303186c83339f696c65c2b61fe1