### PR TITLE
Add target page and active flags to ads

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -131,20 +131,24 @@ class BHG_Admin {
         global $wpdb;
         $table = $wpdb->prefix . 'bhg_ads';
 
-        $id    = isset($_POST['id']) ? (int) $_POST['id'] : 0;
-        $title = isset($_POST['title']) ? sanitize_text_field(wp_unslash($_POST['title'])) : '';
-        $msg   = isset($_POST['message']) ? wp_kses_post(wp_unslash($_POST['message'])) : '';
-        $link  = isset($_POST['link']) ? esc_url_raw(wp_unslash($_POST['link'])) : '';
-        $place = isset($_POST['placement']) ? sanitize_text_field($_POST['placement']) : 'none';
-        $vis   = isset($_POST['visibility']) ? sanitize_text_field($_POST['visibility']) : 'all';
+        $id       = isset($_POST['id']) ? (int) $_POST['id'] : 0;
+        $title    = isset($_POST['title']) ? sanitize_text_field(wp_unslash($_POST['title'])) : '';
+        $content  = isset($_POST['content']) ? wp_kses_post(wp_unslash($_POST['content'])) : '';
+        $link     = isset($_POST['link_url']) ? esc_url_raw(wp_unslash($_POST['link_url'])) : '';
+        $place    = isset($_POST['placement']) ? sanitize_text_field($_POST['placement']) : 'none';
+        $visible  = isset($_POST['visible_to']) ? sanitize_text_field($_POST['visible_to']) : 'all';
+        $targets  = isset($_POST['target_pages']) ? sanitize_text_field(wp_unslash($_POST['target_pages'])) : '';
+        $active   = isset($_POST['active']) ? 1 : 0;
 
         $data = [
-            'title'      => $title,
-            'content'    => $msg,
-            'link_url'   => $link,
-            'placement'  => $place,
-            'visible_to' => $vis,
-            'updated_at' => current_time('mysql'),
+            'title'        => $title,
+            'content'      => $content,
+            'link_url'     => $link,
+            'placement'    => $place,
+            'visible_to'   => $visible,
+            'target_pages' => $targets,
+            'active'       => $active,
+            'updated_at'   => current_time('mysql'),
         ];
 
         if ($id) { $wpdb->update($table, $data, ['id' => $id]); }

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -27,21 +27,23 @@ $ads = $wpdb->get_results("SELECT * FROM `$table` ORDER BY id DESC");
     <thead>
       <tr>
         <th><?php echo esc_html__('ID', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Title/Message', 'bonus-hunt-guesser'); ?></th>
+        <th><?php echo esc_html__('Title/Content', 'bonus-hunt-guesser'); ?></th>
         <th><?php echo esc_html__('Placement', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Visibility', 'bonus-hunt-guesser'); ?></th>
+        <th><?php echo esc_html__('Visible To', 'bonus-hunt-guesser'); ?></th>
+        <th><?php echo esc_html__('Active', 'bonus-hunt-guesser'); ?></th>
         <th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
       </tr>
     </thead>
     <tbody>
       <?php if (empty($ads)) : ?>
-        <tr><td colspan="5"><?php echo esc_html__('No ads yet.', 'bonus-hunt-guesser'); ?></td></tr>
+        <tr><td colspan="6"><?php echo esc_html__('No ads yet.', 'bonus-hunt-guesser'); ?></td></tr>
       <?php else : foreach ($ads as $ad) : ?>
         <tr>
           <td><?php echo (int)$ad->id; ?></td>
-          <td><?php echo isset($ad->title)? esc_html($ad->title) : wp_kses_post(wp_trim_words($ad->message, 12)); ?></td>
+          <td><?php echo isset($ad->title) && $ad->title !== '' ? esc_html($ad->title) : wp_kses_post(wp_trim_words($ad->content, 12)); ?></td>
           <td><?php echo esc_html(isset($ad->placement)? $ad->placement : 'none'); ?></td>
-          <td><?php echo esc_html(isset($ad->visibility)? $ad->visibility : 'all'); ?></td>
+          <td><?php echo esc_html(isset($ad->visible_to)? $ad->visible_to : 'all'); ?></td>
+          <td><?php echo (int)$ad->active === 1 ? esc_html__('Yes','bonus-hunt-guesser') : esc_html__('No','bonus-hunt-guesser'); ?></td>
           <td>
             <a class="button" href="<?php echo esc_url(add_query_arg(['edit'=> (int)$ad->id])); ?>"><?php echo esc_html__('Edit', 'bonus-hunt-guesser'); ?></a>
             <a class="button-link-delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['action'=>'delete','id'=>(int)$ad->id]), 'bhg_delete_ad')); ?>" onclick="return confirm('<?php echo esc_js( __( 'Delete this ad?', 'bonus-hunt-guesser' ) ); ?>');"><?php echo esc_html__('Remove', 'bonus-hunt-guesser'); ?></a>
@@ -72,12 +74,12 @@ $ads = $wpdb->get_results("SELECT * FROM `$table` ORDER BY id DESC");
           <td><input class="regular-text" id="bhg_ad_title" name="title" value="<?php echo esc_attr($ad ? ($ad->title ?? '') : ''); ?>"></td>
         </tr>
         <tr>
-          <th scope="row"><label for="bhg_ad_message"><?php echo esc_html__('Message', 'bonus-hunt-guesser'); ?></label></th>
-          <td><textarea class="large-text" rows="3" id="bhg_ad_message" name="message"><?php echo esc_textarea($ad ? ($ad->message ?? '') : ''); ?></textarea></td>
+          <th scope="row"><label for="bhg_ad_content"><?php echo esc_html__('Content', 'bonus-hunt-guesser'); ?></label></th>
+          <td><textarea class="large-text" rows="3" id="bhg_ad_content" name="content"><?php echo esc_textarea($ad ? ($ad->content ?? '') : ''); ?></textarea></td>
         </tr>
         <tr>
           <th scope="row"><label for="bhg_ad_link"><?php echo esc_html__('Link URL (optional)', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input class="regular-text" id="bhg_ad_link" name="link" value="<?php echo esc_attr($ad ? ($ad->link ?? '') : ''); ?>"></td>
+          <td><input class="regular-text" id="bhg_ad_link" name="link_url" value="<?php echo esc_attr($ad ? ($ad->link_url ?? '') : ''); ?>"></td>
         </tr>
         <tr>
           <th scope="row"><label for="bhg_ad_place"><?php echo esc_html__('Placement', 'bonus-hunt-guesser'); ?></label></th>
@@ -96,16 +98,24 @@ $ads = $wpdb->get_results("SELECT * FROM `$table` ORDER BY id DESC");
         <tr>
           <th scope="row"><label for="bhg_ad_vis"><?php echo esc_html__('Visible To', 'bonus-hunt-guesser'); ?></label></th>
           <td>
-            <select id="bhg_ad_vis" name="visibility">
+            <select id="bhg_ad_vis" name="visible_to">
               <?php
-                $opts = ['all','guests','logged','affiliates','non_affiliates'];
-                $sel  = $ad ? ($ad->visibility ?? 'all') : 'all';
+                $opts = ['all','guests','logged_in','affiliates','non_affiliates'];
+                $sel  = $ad ? ($ad->visible_to ?? 'all') : 'all';
                 foreach ($opts as $o) {
                     echo '<option value="'.esc_attr($o).'" '.selected($sel, $o, false).'>'.esc_html(ucfirst(str_replace('_',' ', $o))).'</option>';
                 }
               ?>
             </select>
           </td>
+        </tr>
+        <tr>
+          <th scope="row"><label for="bhg_ad_targets"><?php echo esc_html__('Target Page Slugs', 'bonus-hunt-guesser'); ?></label></th>
+          <td><input class="regular-text" id="bhg_ad_targets" name="target_pages" value="<?php echo esc_attr($ad ? ($ad->target_pages ?? '') : ''); ?>" placeholder="page-slug-1,page-slug-2"></td>
+        </tr>
+        <tr>
+          <th scope="row"><label for="bhg_ad_active"><?php echo esc_html__('Active', 'bonus-hunt-guesser'); ?></label></th>
+          <td><input type="checkbox" id="bhg_ad_active" name="active" value="1" <?php checked($ad ? ($ad->active ?? 1) : 1, 1); ?>></td>
         </tr>
       </tbody>
     </table>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -180,11 +180,14 @@ class BHG_DB_OLD {
         $sql = "CREATE TABLE $table_name (
             id int(11) NOT NULL AUTO_INCREMENT,
             title varchar(255) NOT NULL,
-            content text NOT NULL,
+            content text NULL,
+            link_url varchar(255) DEFAULT NULL,
             placement varchar(50) NOT NULL,
-            visibility varchar(20) DEFAULT 'all',
+            visible_to varchar(20) DEFAULT 'all',
+            target_pages text NULL,
             active tinyint(1) DEFAULT 1,
             created_at datetime NOT NULL,
+            updated_at datetime NOT NULL,
             PRIMARY KEY (id)
         ) $charset_collate;";
         dbDelta($sql);

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -66,9 +66,9 @@ class BHG_Ads {
 
     /** Render a single ad row to HTML */
     protected static function render_ad_row($row) {
-        $msg = isset($row->message) ? $row->message : '';
+        $msg = isset($row->content) ? $row->content : '';
         $msg = wp_kses_post($msg);
-        $link = isset($row->link) ? esc_url($row->link) : '';
+        $link = isset($row->link_url) ? esc_url($row->link_url) : '';
 
         if ($link) {
             $msg = '<a href="' . $link . '">' . $msg . '</a>';
@@ -82,7 +82,7 @@ class BHG_Ads {
         $table = $wpdb->prefix . 'bhg_ads';
         $placement = sanitize_text_field($placement);
         // Active ads ordered newest first
-        $sql = "SELECT id, message, link, placement, visibility, target_pages FROM {$table} WHERE active=1 AND placement=%s ORDER BY id DESC";
+        $sql = "SELECT id, content, link_url, placement, visible_to, target_pages FROM {$table} WHERE active=1 AND placement=%s ORDER BY id DESC";
         return $wpdb->get_results($wpdb->prepare($sql, $placement));
     }
 
@@ -96,7 +96,7 @@ class BHG_Ads {
 
         $out = [];
         foreach ($ads as $row) {
-            if (!self::visibility_ok($row->visibility)) continue;
+            if (!self::visibility_ok($row->visible_to)) continue;
             if (!self::page_target_ok($row->target_pages)) continue;
             $out[] = self::render_ad_row($row);
         }
@@ -115,10 +115,10 @@ class BHG_Ads {
         if ($id <= 0) return '';
         global $wpdb;
         $table = $wpdb->prefix . 'bhg_ads';
-        $row = $wpdb->get_row($wpdb->prepare("SELECT id, message, placement, visibility, target_pages, active FROM `$table` WHERE id=%d", $id));
+        $row = $wpdb->get_row($wpdb->prepare("SELECT id, content, placement, visible_to, target_pages, active, link_url FROM `$table` WHERE id=%d", $id));
         if (!$row) return '';
         if ((int)$row->active !== 1) return ''; // respect active flag
-        if (!self::visibility_ok($row->visibility)) return '';
+        if (!self::visibility_ok($row->visible_to)) return '';
         if (!self::page_target_ok($row->target_pages)) return '';
         return self::render_ad_row($row);
     }

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -79,6 +79,8 @@ class BHG_DB {
             link_url VARCHAR(255) NULL,
             placement VARCHAR(50) NOT NULL DEFAULT 'none',
             visible_to VARCHAR(30) NOT NULL DEFAULT 'all',
+            target_pages TEXT NULL,
+            active TINYINT(1) NOT NULL DEFAULT 1,
             created_at DATETIME NULL,
             updated_at DATETIME NULL,
             PRIMARY KEY  (id),
@@ -151,13 +153,15 @@ class BHG_DB {
 
             // Ads columns
             $aneed = [
-                'title'      => "ALTER TABLE `{$ads_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
-                'content'    => "ALTER TABLE `{$ads_table}` ADD COLUMN content TEXT NULL",
-                'link_url'   => "ALTER TABLE `{$ads_table}` ADD COLUMN link_url VARCHAR(255) NULL",
-                'placement'  => "ALTER TABLE `{$ads_table}` ADD COLUMN placement VARCHAR(50) NOT NULL DEFAULT 'none'",
-                'visible_to' => "ALTER TABLE `{$ads_table}` ADD COLUMN visible_to VARCHAR(30) NOT NULL DEFAULT 'all'",
-                'created_at' => "ALTER TABLE `{$ads_table}` ADD COLUMN created_at DATETIME NULL",
-                'updated_at' => "ALTER TABLE `{$ads_table}` ADD COLUMN updated_at DATETIME NULL",
+                'title'        => "ALTER TABLE `{$ads_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
+                'content'      => "ALTER TABLE `{$ads_table}` ADD COLUMN content TEXT NULL",
+                'link_url'     => "ALTER TABLE `{$ads_table}` ADD COLUMN link_url VARCHAR(255) NULL",
+                'placement'    => "ALTER TABLE `{$ads_table}` ADD COLUMN placement VARCHAR(50) NOT NULL DEFAULT 'none'",
+                'visible_to'   => "ALTER TABLE `{$ads_table}` ADD COLUMN visible_to VARCHAR(30) NOT NULL DEFAULT 'all'",
+                'target_pages' => "ALTER TABLE `{$ads_table}` ADD COLUMN target_pages TEXT NULL",
+                'active'       => "ALTER TABLE `{$ads_table}` ADD COLUMN active TINYINT(1) NOT NULL DEFAULT 1",
+                'created_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN created_at DATETIME NULL",
+                'updated_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN updated_at DATETIME NULL",
             ];
             forEach ($aneed as $c => $alter) {
                 $exists = $wpdb->get_var($wpdb->prepare(

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -103,7 +103,15 @@ function bhg_seed_demo_on_activation(){
     $wpdb->insert($trans, array('tkey'=>'email_results_title', 'tvalue'=>'The Bonus Hunt has been closed!'));
     $wpdb->insert($trans, array('tkey'=>'email_final_balance', 'tvalue'=>'Final Balance'));
     $wpdb->insert($trans, array('tkey'=>'email_winner', 'tvalue'=>'Winner'));
-    $wpdb->insert($ads, array('message'=>'Sponsored by Demo Casino – Play Now', 'link'=>'https://example.com', 'placement'=>'footer', 'visibility'=>'guests', 'active'=>1));
+    $wpdb->insert($ads, array(
+        'title'        => '',
+        'content'      => 'Sponsored by Demo Casino – Play Now',
+        'link_url'     => 'https://example.com',
+        'placement'    => 'footer',
+        'visible_to'   => 'guests',
+        'target_pages' => '',
+        'active'       => 1,
+    ));
 
     // Create demo pages with shortcodes (with (Demo) suffix)
     $pages = array(

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -153,7 +153,7 @@ function bhg_render_ads($placement = 'footer', $hunt_id = 0) {
     global $wpdb;
     $tbl = $wpdb->prefix . 'bhg_ads';
     $placement = sanitize_text_field($placement);
-    $rows = $wpdb->get_results($wpdb->prepare("SELECT * FROM {$tbl} WHERE active=1 AND placement=%s ORDER BY id DESC", $placement));
+    $rows = $wpdb->get_results($wpdb->prepare("SELECT content, link_url, visible_to FROM {$tbl} WHERE active=1 AND placement=%s ORDER BY id DESC", $placement));
     $hunt_site_id = 0;
     if ($hunt_id) {
         $hunt_site_id = (int) $wpdb->get_var(
@@ -164,7 +164,7 @@ function bhg_render_ads($placement = 'footer', $hunt_id = 0) {
 
     $out = '<div class="bhg-ads bhg-ads-' . esc_attr($placement) . '">';
     foreach ($rows as $r) {
-        $vis = $r->visibility ?: 'all';
+        $vis = $r->visible_to ?: 'all';
         $show = false;
         if ($vis === 'all') $show = true;
         elseif ($vis === 'guests' && !is_user_logged_in()) $show = true;
@@ -176,8 +176,8 @@ function bhg_render_ads($placement = 'footer', $hunt_id = 0) {
                 : (bool) get_user_meta($uid, 'bhg_affiliate_status', true);
         }
         if (!$show) continue;
-        $msg  = wp_kses_post($r->message);
-        $link = $r->link ? esc_url($r->link) : '';
+        $msg  = wp_kses_post($r->content);
+        $link = $r->link_url ? esc_url($r->link_url) : '';
         $out .= '<div class="bhg-ad" style="margin:10px 0;padding:10px;border:1px solid #e2e8f0;border-radius:6px;">';
         if ($link) { $out .= '<a href="' . $link . '">'; }
         $out .= $msg;
@@ -368,14 +368,16 @@ if (!function_exists('bhg_reset_demo_and_seed')) {
         if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $ads_tbl)) === $ads_tbl) {
             $now = current_time('mysql', 1);
             $wpdb->insert($ads_tbl, array(
-                'message' => '<strong>Play responsibly.</strong> <a href="'.esc_url(home_url('/promo')).'">See promo</a>',
-                'placement' => 'footer',
-                'visibility' => 'all',
-                'active' => 1,
+                'title'        => '',
+                'content'      => '<strong>Play responsibly.</strong> <a href="'.esc_url(home_url('/promo')).'">See promo</a>',
+                'link_url'     => '',
+                'placement'    => 'footer',
+                'visible_to'   => 'all',
                 'target_pages' => '',
-                'created_at' => $now,
-                'updated_at' => $now,
-            ), array('%s','%s','%s','%d','%s','%s','%s'));
+                'active'       => 1,
+                'created_at'   => $now,
+                'updated_at'   => $now,
+            ), array('%s','%s','%s','%s','%s','%s','%d','%s','%s'));
         }
 
         return true;


### PR DESCRIPTION
## Summary
- expand ads table with `target_pages` and `active` columns
- align admin advertising UI and save handler with new fields
- update frontend ad queries to use canonical column names

## Testing
- `php -l includes/class-bhg-db.php`
- `php -l admin/class-bhg-admin.php`
- `php -l admin/views/advertising.php`
- `php -l includes/class-bhg-ads.php`
- `php -l includes/helpers.php`
- `php -l includes/demo.php`
- `php -l bonus-hunt-guesser.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba73e14f208333b43d2b7f6215f291