### PR TITLE
Add AJAX handler for guess submissions

### DIFF
--- a/assets/js/public.js
+++ b/assets/js/public.js
@@ -75,7 +75,8 @@ jQuery(document).ready(function($) {
                 data: {
                     action: 'submit_bhg_guess',
                     nonce: bhg_nonce,
-                    guess_amount: guessValue
+                    guess_amount: guessValue,
+                    hunt_id: form.find('input[name="hunt_id"]').val()
                 },
                 success: function(response) {
                     if (response.success) {


### PR DESCRIPTION
## Summary
- Register wp_ajax hooks for guess submissions
- Handle guess submission via AJAX or admin-post with JSON responses
- Send hunt ID along with AJAX guess request

## Testing
- `php -l bonus-hunt-guesser.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba7abb9f648333be59d8655255e93a