### PR TITLE
Wrap wp_die messages with translation and escaping

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -512,11 +512,11 @@ function bhg_handle_settings_save() {
 function bhg_handle_bonus_hunt_save() {
     // Verify nonce
     if (!isset($_POST['_wpnonce']) || !wp_verify_nonce($_POST['_wpnonce'], 'bhg_form_nonce')) {
-        wp_die('Security check failed');
+        wp_die( esc_html__( 'Security check failed', 'bonus-hunt-guesser' ) );
     }
-    
+
     if (!current_user_can('manage_options')) {
-        wp_die('Access denied');
+        wp_die( esc_html__( 'Access denied', 'bonus-hunt-guesser' ) );
     }
     
     // Process form data
@@ -559,7 +559,7 @@ function bhg_handle_bonus_hunt_save() {
  * @return void
  */
 function bhg_handle_bonus_hunt_save_unauth() {
-    wp_die('You must be logged in to submit this form');
+    wp_die( esc_html__( 'You must be logged in to submit this form', 'bonus-hunt-guesser' ) );
 }
 
 // Form handler for guess submission (frontend)

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -2,7 +2,7 @@
 if (!defined('ABSPATH')) exit;
 
 add_action('admin_post_bhg_save_hunt', function(){
-  if (!current_user_can(bhg_admin_cap())) wp_die('Forbidden', 403);
+  if (!current_user_can(bhg_admin_cap())) wp_die( esc_html__( 'Forbidden', 'bonus-hunt-guesser' ), 403 );
   check_admin_referer('bhg_save_hunt');
   $id = BHG_Models::save_hunt($_POST);
   wp_safe_redirect(add_query_arg(['page'=>'bhg-bonus-hunts','updated'=>'1','id'=>$id], admin_url('admin.php')));
@@ -10,7 +10,7 @@ add_action('admin_post_bhg_save_hunt', function(){
 });
 
 add_action('admin_post_bhg_close_hunt', function(){
-  if (!current_user_can(bhg_admin_cap())) wp_die('Forbidden', 403);
+  if (!current_user_can(bhg_admin_cap())) wp_die( esc_html__( 'Forbidden', 'bonus-hunt-guesser' ), 403 );
   check_admin_referer('bhg_close_hunt');
   $hunt_id = intval($_POST['hunt_id'] ?? 0);
   $final_balance = floatval($_POST['final_balance'] ?? 0);
@@ -40,7 +40,7 @@ add_action('admin_post_bhg_close_hunt', function(){
 });
 
 add_action('admin_post_bhg_add_affiliate', function(){
-  if (!current_user_can(bhg_admin_cap())) wp_die('Forbidden', 403);
+  if (!current_user_can(bhg_admin_cap())) wp_die( esc_html__( 'Forbidden', 'bonus-hunt-guesser' ), 403 );
   check_admin_referer('bhg_add_affiliate');
   global $wpdb; $t = BHG_DB::table('affiliate_websites');
   $wpdb->insert($t, ['name'=>sanitize_text_field($_POST['name']??''), 'slug'=>sanitize_title($_POST['slug']??'')]);
@@ -50,7 +50,7 @@ add_action('admin_post_bhg_add_affiliate', function(){
 
 
 add_action('admin_post_bhg_save_translations', function(){
-  if (!current_user_can(bhg_admin_cap())) wp_die('Forbidden', 403);
+  if (!current_user_can(bhg_admin_cap())) wp_die( esc_html__( 'Forbidden', 'bonus-hunt-guesser' ), 403 );
   check_admin_referer('bhg_save_translations');
   $strings = array_map('sanitize_text_field', $_POST['strings'] ?? []);
   update_option('bhg_translations', $strings);
@@ -59,7 +59,7 @@ add_action('admin_post_bhg_save_translations', function(){
 });
 
 add_action('admin_post_bhg_save_ads', function(){
-  if (!current_user_can(bhg_admin_cap())) wp_die('Forbidden', 403);
+  if (!current_user_can(bhg_admin_cap())) wp_die( esc_html__( 'Forbidden', 'bonus-hunt-guesser' ), 403 );
   check_admin_referer('bhg_save_ads');
   $ads = $_POST['ads'] ?? [];
   $clean = [];
@@ -83,7 +83,7 @@ add_action('admin_post_bhg_save_ads', function(){
 add_action( 'admin_post_bhg_save_user_affiliates', function () {
   // Verify capability and nonce.
   if ( ! current_user_can( bhg_admin_cap() ) ) {
-    wp_die( 'Forbidden', 403 );
+    wp_die( esc_html__( 'Forbidden', 'bonus-hunt-guesser' ), 403 );
   }
   check_admin_referer( 'bhg_save_user_affiliates' );
 


### PR DESCRIPTION
## Summary
- Ensure all `wp_die` calls in main plugin and admin handlers use `esc_html__` for safe, translatable output

## Testing
- `php -l bonus-hunt-guesser.php`
- `php -l includes/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba7b9eaaa083338bc43dbd5d89ea38