### PR TITLE
Add hunt closing logic with winner calculation

### DIFF
--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -76,6 +76,70 @@ class BHG_Models {
         wp_safe_redirect($redirect);
         exit;
     }
+
+    /**
+     * Close a bonus hunt and determine winners.
+     *
+     * @param int   $hunt_id       Hunt identifier.
+     * @param float $final_balance Final balance for the hunt.
+     *
+     * @return int[] Array of winning user IDs.
+     */
+    public static function close_hunt( $hunt_id, $final_balance ) {
+        global $wpdb;
+
+        $hunt_id       = (int) $hunt_id;
+        $final_balance = (float) $final_balance;
+
+        if ( $hunt_id <= 0 ) {
+            return array();
+        }
+
+        $hunts_tbl   = $wpdb->prefix . 'bhg_bonus_hunts';
+        $guesses_tbl = $wpdb->prefix . 'bhg_guesses';
+
+        // Determine number of winners for this hunt.
+        $winners_count = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT winners_count FROM {$hunts_tbl} WHERE id = %d",
+                $hunt_id
+            )
+        );
+        if ( $winners_count <= 0 ) {
+            $winners_count = 1;
+        }
+
+        // Update hunt status and final details.
+        $now = current_time( 'mysql' );
+        $wpdb->update(
+            $hunts_tbl,
+            array(
+                'status'        => 'closed',
+                'final_balance' => $final_balance,
+                'closed_at'     => $now,
+                'updated_at'    => $now,
+            ),
+            array( 'id' => $hunt_id ),
+            array( '%s', '%f', '%s', '%s' ),
+            array( '%d' )
+        );
+
+        // Fetch winners based on proximity to final balance.
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT user_id FROM {$guesses_tbl} WHERE hunt_id = %d ORDER BY ABS(guess - %f) ASC, id ASC LIMIT %d",
+                $hunt_id,
+                $final_balance,
+                $winners_count
+            )
+        );
+
+        if ( empty( $rows ) ) {
+            return array();
+        }
+
+        return array_map( 'intval', wp_list_pluck( $rows, 'user_id' ) );
+    }
 }
 
 new BHG_Models();


### PR DESCRIPTION
## Summary
- add `close_hunt()` to update hunt status and compute winners

## Testing
- `php -l includes/class-bhg-models.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba7f8872608333bd4a7b2b3e1746ae