### PR TITLE
Improve coding standards compliance

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_Admin {
 

--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_Demo {
     public function __construct() {

--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if (!class_exists('WP_List_Table')) {
     require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) {
     wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) {
     wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) wp_die(__('Insufficient permissions','bonus-hunt-guesser'));
 global $wpdb;
 $hunt_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -1,18 +1,23 @@
 <?php
-if (!defined('ABSPATH')) exit;
-if (!current_user_can('manage_options')) {
-    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Admin view for managing bonus hunts.
+ */
+
+if ( ! current_user_can( 'manage_options' ) ) {
+    wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 global $wpdb;
 $hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
 $guesses_table = $wpdb->prefix . 'bhg_guesses';
 
-$view = isset($_GET['view']) ? sanitize_text_field($_GET['view']) : 'list';
+$view = isset( $_GET['view'] ) ? sanitize_text_field( $_GET['view'] ) : 'list';
 
 /** LIST VIEW */
-if ($view === 'list') :
-    $hunts = $wpdb->get_results("SELECT * FROM `$hunts_table` ORDER BY id DESC");
+if ( 'list' === $view ) :
+    $hunts = $wpdb->get_results( "SELECT * FROM `$hunts_table` ORDER BY id DESC" );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Bonus Hunts', 'bonus-hunt-guesser'); ?></h1>
@@ -31,9 +36,9 @@ if ($view === 'list') :
       </tr>
     </thead>
     <tbody>
-      <?php if (empty($hunts)) : ?>
+      <?php if ( empty( $hunts ) ) : ?>
         <tr><td colspan="7"><?php echo esc_html__('No hunts found.', 'bonus-hunt-guesser'); ?></td></tr>
-      <?php else : foreach ($hunts as $h) : ?>
+      <?php else : foreach ( $hunts as $h ) : ?>
         <tr>
           <td><?php echo (int)$h->id; ?></td>
           <td><a href="<?php echo esc_url(add_query_arg(['view'=>'edit','id'=>(int)$h->id])); ?>"><?php echo esc_html($h->title); ?></a></td>

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) { wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
 
 if (!function_exists('bhg_get_latest_closed_hunts')) {

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if (!current_user_can('manage_options')) {
     wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));

--- a/admin/views/hunt-results.php
+++ b/admin/views/hunt-results.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) { wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
 
 $hunt_id = isset($_GET['id']) ? (int) $_GET['id'] : 0;

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) { wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
 
 $hunt_id = isset($_GET['id']) ? (int) $_GET['id'] : 0;

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) { wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
 
 global $wpdb;

--- a/admin/views/tools.php
+++ b/admin/views/tools.php
@@ -1,4 +1,6 @@
-<?php if (!defined('ABSPATH')) exit; ?>
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+?>
 <div class="wrap">
   <h1><?php echo esc_html__('BHG Tools', 'bonus-hunt-guesser'); ?></h1>
 

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) {
     wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if (!current_user_can('manage_options')) {
     wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));

--- a/admin/views/users.php
+++ b/admin/views/users.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) {
     wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 add_action('admin_post_bhg_save_hunt', function(){
   if (!current_user_can(bhg_admin_cap())) wp_die( esc_html__( 'Forbidden', 'bonus-hunt-guesser' ), 403 );

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_Ads {
 

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 /**
  * Helper functions for hunts and guesses used by admin dashboard, list and results.

--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -1,12 +1,22 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
+/**
+ * Bonus hunt data helpers.
+ */
 class BHG_Bonus_Hunts {
-    public static function get_latest_hunts_with_winners($limit = 3) {
+
+    /**
+     * Retrieve latest hunts with winners.
+     *
+     * @param int $limit Number of hunts to fetch. Default 3.
+     * @return array List of hunts and winners.
+     */
+    public static function get_latest_hunts_with_winners( $limit = 3 ) {
         global $wpdb;
         $hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
         $guesses_table = $wpdb->prefix . 'bhg_guesses';
-        $limit = max(1, (int)$limit);
+        $limit         = max( 1, (int) $limit );
 
         $hunts = $wpdb->get_results(
             $wpdb->prepare(
@@ -15,13 +25,16 @@ class BHG_Bonus_Hunts {
                  WHERE status = %s AND final_balance IS NOT NULL AND closed_at IS NOT NULL
                  ORDER BY closed_at DESC
                  LIMIT %d",
-                'closed', $limit
+                'closed',
+                $limit
             )
         );
-        $out = [];
-        foreach ((array)$hunts as $h) {
-            $winners_count = max(1, (int)$h->winners_count);
-            $winners = $wpdb->get_results(
+
+        $out = array();
+
+        foreach ( (array) $hunts as $h ) {
+            $winners_count = max( 1, (int) $h->winners_count );
+            $winners       = $wpdb->get_results(
                 $wpdb->prepare(
                     "SELECT g.user_id, u.display_name, g.guess,
                             ABS(g.guess - %f) AS diff
@@ -30,28 +43,49 @@ class BHG_Bonus_Hunts {
                      WHERE g.hunt_id = %d
                      ORDER BY diff ASC, g.id ASC
                      LIMIT %d",
-                    $h->final_balance, $h->id, $winners_count
+                    $h->final_balance,
+                    $h->id,
+                    $winners_count
                 )
             );
-            $out[] = [ 'hunt' => $h, 'winners' => $winners ];
+
+            $out[] = array(
+                'hunt'    => $h,
+                'winners' => $winners,
+            );
         }
+
         return $out;
     }
 
-    public static function get_hunt($hunt_id) {
+    /**
+     * Retrieve a hunt by ID.
+     *
+     * @param int $hunt_id Hunt ID.
+     * @return object|null Hunt data or null if not found.
+     */
+    public static function get_hunt( $hunt_id ) {
         global $wpdb;
         $hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
-        return $wpdb->get_row($wpdb->prepare("SELECT * FROM `$hunts_table` WHERE id=%d", (int)$hunt_id));
+
+        return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$hunts_table` WHERE id=%d", (int) $hunt_id ) );
     }
 
-    public static function get_hunt_guesses_ranked($hunt_id) {
+    /**
+     * Get ranked guesses for a hunt.
+     *
+     * @param int $hunt_id Hunt ID.
+     * @return array List of guesses.
+     */
+    public static function get_hunt_guesses_ranked( $hunt_id ) {
         global $wpdb;
         $hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
         $guesses_table = $wpdb->prefix . 'bhg_guesses';
-        $hunt = self::get_hunt($hunt_id);
-        if (!$hunt) return [];
+        $hunt          = self::get_hunt( $hunt_id );
 
-        if ($hunt->final_balance !== null) {
+        if ( ! $hunt ) { return array(); }
+
+        if ( null !== $hunt->final_balance ) {
             return $wpdb->get_results(
                 $wpdb->prepare(
                     "SELECT g.*, u.display_name, ABS(g.guess - %f) AS diff
@@ -59,10 +93,12 @@ class BHG_Bonus_Hunts {
                      LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
                      WHERE g.hunt_id = %d
                      ORDER BY diff ASC, g.id ASC",
-                    $hunt->final_balance, $hunt_id
+                    $hunt->final_balance,
+                    $hunt_id
                 )
             );
         }
+
         return $wpdb->get_results(
             $wpdb->prepare(
                 "SELECT g.*, u.display_name, NULL AS diff

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_DB {
 

--- a/includes/class-bhg-front-menus.php
+++ b/includes/class-bhg-front-menus.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_Front_Menus {
     public function __construct() {

--- a/includes/class-bhg-logger.php
+++ b/includes/class-bhg-logger.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 class BHG_Logger {
     public static function info($msg){ bhg_log($msg); }
     public static function error($msg){ bhg_log('ERROR: ' . $msg); }

--- a/includes/class-bhg-menus.php
+++ b/includes/class-bhg-menus.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if (!class_exists('BHG_Menus')) {
 class BHG_Menus {

--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_Models {
     public function __construct() {

--- a/includes/class-bhg-settings.php
+++ b/includes/class-bhg-settings.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 class BHG_Settings {
     public static function render(){
         BHG_Utils::require_cap();

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -5,7 +5,7 @@
  * This file is self-contained and safe on PHP 7.4.
  * It registers the required shortcodes on `init` and avoids "public function outside class" parse errors.
  */
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if (!class_exists('BHG_Shortcodes')) {
 

--- a/includes/class-bhg-utils.php
+++ b/includes/class-bhg-utils.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_Utils {
     public static function init_hooks(){

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function bhg_seed_demo_on_activation(){
     // Only seed once

--- a/includes/helpers-aff-dot.php
+++ b/includes/helpers-aff-dot.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 // Renders green/red dot based on affiliate status for current hunt/site context
 if (!function_exists('bhg_render_affiliate_dot')) {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function bhg_log($message) {
     if (!defined('WP_DEBUG') || !WP_DEBUG) return;

--- a/includes/upgrade/add-winners-limit.php
+++ b/includes/upgrade/add-winners-limit.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function bhg_upgrade_add_winners_limit_column(){
     global $wpdb;


### PR DESCRIPTION
## Summary
- Wrap ABSPATH checks in brace style and standardize formatting across plugin
- Add documentation blocks and spacing to bonus hunt helpers and admin views
- Use Yoda conditions and WordPress spacing in bonus hunt admin view

## Testing
- `phpcs --standard=WordPress` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8047a3588333be38d850a8eb41e1