### PR TITLE
Fix ads query without prepare

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -17,7 +17,7 @@ if (isset($_GET['action'], $_GET['id']) && $_GET['action']==='delete' && isset($
 }
 
 // Fetch ads
-$ads = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$table` ORDER BY id DESC" ) );
+$ads = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Advertising', 'bonus-hunt-guesser'); ?></h1>


### PR DESCRIPTION
## Summary
- Query ads with direct get_results and descending order

## Testing
- `php -l admin/views/advertising.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba8ad861fc8333b6e43f9a4c375a4a