### PR TITLE
Fix affiliate listing SQL query

### DIFF
--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -11,7 +11,7 @@ $edit_id = isset($_GET['edit']) ? (int) $_GET['edit'] : 0;
 $row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$table` WHERE id=%d", $edit_id)) : null;
 
 // List
-$rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$table` ORDER BY id DESC" ) );
+$rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Affiliates', 'bonus-hunt-guesser'); ?></h1>


### PR DESCRIPTION
## Summary
- remove unnecessary prepare call when retrieving affiliate websites

## Testing
- `php -l admin/views/affiliate-websites.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba8dabe6948333966616bd7deee7b5