### PR TITLE
Fix tournament list query

### DIFF
--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -9,7 +9,7 @@ $table = $wpdb->prefix . 'bhg_tournaments';
 $edit_id = isset($_GET['edit']) ? (int) $_GET['edit'] : 0;
 $row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$table` WHERE id=%d", $edit_id)) : null;
 
-$rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$table` ORDER BY id DESC" ) );
+$rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php esc_html_e('Tournaments', 'bonus-hunt-guesser'); ?></h1>


### PR DESCRIPTION
## Summary
- Use direct `get_results()` query to fetch tournaments ordered by ID descending

## Testing
- `php -l admin/views/tournaments.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba8e18d36483338b6941f43b5bbdbc