### PR TITLE
Remove unnecessary prepare call when loading translations

### DIFF
--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -33,7 +33,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bhg_save_translation'
 }
 
 // Fetch rows
-$rows = $wpdb->get_results( $wpdb->prepare( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC" ) );
+$rows = $wpdb->get_results( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC" );
 ?>
 <div class="wrap">
   <h1><?php esc_html_e('Translations', 'bonus-hunt-guesser'); ?></h1>


### PR DESCRIPTION
## Summary
- simplify translation query by removing unneeded `$wpdb->prepare`

## Testing
- `php -l admin/views/translations.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba8e893fbc833392202d1a489bceea