### PR TITLE
Remove redundant prepare calls in tools diagnostics

### DIFF
--- a/admin/views/tools.php
+++ b/admin/views/tools.php
@@ -6,11 +6,11 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
   <?php
   global $wpdb;
-  $hunts = (int)$wpdb->get_var( $wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->prefix}bhg_bonus_hunts") );
-  $guesses = (int)$wpdb->get_var( $wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->prefix}bhg_guesses") );
-  $users = (int)$wpdb->get_var( $wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->users}") );
-  $ads = (int)$wpdb->get_var( $wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->prefix}bhg_ads") );
-  $tournaments = (int)$wpdb->get_var( $wpdb->prepare("SELECT COUNT(*) FROM {$wpdb->prefix}bhg_tournaments") );
+  $hunts = (int)$wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}bhg_bonus_hunts");
+  $guesses = (int)$wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}bhg_guesses");
+  $users = (int)$wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->users}");
+  $ads = (int)$wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}bhg_ads");
+  $tournaments = (int)$wpdb->get_var("SELECT COUNT(*) FROM {$wpdb->prefix}bhg_tournaments");
   ?>
 
   <div class="card" style="max-width:900px;padding:16px;margin-top:12px;">


### PR DESCRIPTION
## Summary
- streamline tools diagnostics counts by removing unnecessary `prepare()` calls

## Testing
- `php -l admin/views/tools.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba8efc7928833391db5eab328fa6b6