### PR TITLE
Use direct COUNT query for hunts pagination

### DIFF
--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -19,7 +19,7 @@ $rows = $wpdb->get_results(
     $offset
   )
 );
-$total = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $t" ) );
+$total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $t" );
 $pages = max(1, (int) ceil($total / $per_page));
 
 ?>


### PR DESCRIPTION
## Summary
- Calculate total hunt count using a direct COUNT query for pagination.

## Testing
- `php -l admin/views/hunts-list.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba8f643a58833385f494d6a80a7c26