### PR TITLE
Remove prepare from static maintenance queries

### DIFF
--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -42,9 +42,9 @@ function bhg_database_cleanup() {
         $wpdb->prefix . 'bhg_ads'
     );
     
-    foreach ($tables as $table) {
-        if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table) {
-            $wpdb->query( $wpdb->prepare( "TRUNCATE TABLE $table" ) );
+    foreach ( $tables as $table ) {
+        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
+            $wpdb->query( "TRUNCATE TABLE {$table}" );
         }
     }
     
@@ -67,9 +67,9 @@ function bhg_database_optimize() {
         $wpdb->prefix . 'bhg_ads'
     );
     
-    foreach ($tables as $table) {
-        if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table) {
-            $wpdb->query( $wpdb->prepare( "OPTIMIZE TABLE $table" ) );
+    foreach ( $tables as $table ) {
+        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
+            $wpdb->query( "OPTIMIZE TABLE {$table}" );
         }
     }
 }
@@ -144,10 +144,10 @@ function bhg_insert_demo_data() {
                 'bhg_ads'
             );
             
-            foreach ($tables as $table) {
+            foreach ( $tables as $table ) {
                 $table_name = $wpdb->prefix . $table;
-                $exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table_name)) === $table_name;
-                $row_count = $exists ? $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM `{$table_name}`" ) ) : 0;
+                $exists     = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name;
+                $row_count  = $exists ? (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$table_name}`" ) : 0;
                 
                 echo '<tr>';
                 echo '<td>' . esc_html($table_name) . '</td>';


### PR DESCRIPTION
## Summary
- Execute TRUNCATE and OPTIMIZE statements directly in database tools
- Query row counts without wrapping static SQL in prepare

## Testing
- `php -l admin/views/database.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba8fe2c9ac8333a33e1517c63af15a