### PR TITLE
Use direct FOUND_ROWS query in participants helper

### DIFF
--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -84,7 +84,7 @@ if (!function_exists('bhg_get_hunt_participants')) {
              LIMIT %d OFFSET %d",
             (int)$hunt_id, (int)$per_page, (int)$offset
         ));
-        $total = (int) $wpdb->get_var( $wpdb->prepare( "SELECT FOUND_ROWS()" ) );
+        $total = (int) $wpdb->get_var( "SELECT FOUND_ROWS()" );
         return array('rows' => $rows, 'total' => $total);
     }
 }


### PR DESCRIPTION
## Summary
- Remove unnecessary `$wpdb->prepare` when fetching `FOUND_ROWS` in `bhg_get_hunt_participants`

## Testing
- `php -l includes/class-bhg-bonus-hunts-helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba91def29083339ef52aa7dad14def