### PR TITLE
Update demo seeding query

### DIFF
--- a/includes/demo.php
+++ b/includes/demo.php
@@ -77,7 +77,7 @@ function bhg_seed_demo_on_activation(){
     }
 
     // Compute winner for the closed hunt (closest)
-    $rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `{$closed_id}`" ) );
+    $rows = $wpdb->get_results( "SELECT * FROM `{$closed_id}`" );
     $final = 2420.00;
     $winner_id = 0; $winner_diff = null;
     foreach ($rows as $row){


### PR DESCRIPTION
## Summary
- remove unnecessary prepare call when fetching closed hunt rows

## Testing
- `php -l includes/demo.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpcs --standard=WordPress includes/demo.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba925014b08333b19e51518429346e