### PR TITLE
Remove obsolete period column from tournaments

### DIFF
--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -44,8 +44,6 @@ class BHG_Demo {
         // Insert demo tournament
         $wpdb->insert("{$wpdb->prefix}bhg_tournaments",[
             'title'=>'August Tournament (Demo)',
-            'period'=>'monthly',
-            'period_key'=>'2025-08',
             'status'=>'active'
         ]);
 

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -197,12 +197,10 @@ class BHG_DB_OLD {
         $sql = "CREATE TABLE $table_name (
             id mediumint(9) NOT NULL AUTO_INCREMENT,
             type varchar(20) NOT NULL,
-            period varchar(20) NOT NULL,
             created_at datetime NOT NULL,
             updated_at datetime NOT NULL,
             status varchar(20) DEFAULT 'active',
-            PRIMARY KEY  (id),
-            UNIQUE KEY type_period (type, period)
+            PRIMARY KEY  (id)
         ) $charset_collate;";
         dbDelta($sql);
         

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -90,11 +90,8 @@ function bhg_seed_demo_on_activation(){
     $wpdb->update($hunts, array('winner_user_id'=>$winner_id, 'winner_diff'=>$winner_diff), array('id'=>$closed_id));
 
     // Insert a demo tournament (monthly)
-    $period_key = gmdate('Y-m');
     $wpdb->insert($tournaments, array(
         'title' => 'Monthly Tournament (Demo)',
-        'period' => 'monthly',
-        'period_key' => $period_key,
         'status' => 'active',
         'created_at' => current_time('mysql')
     ));

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -304,8 +304,6 @@ if (!function_exists('bhg_reset_demo_and_seed')) {
                 $yearKey = date('Y', $ts);
 
                 $ensure = function($type, $period) use ($wpdb, $t_tbl) {
-                    $id = $wpdb->get_var($wpdb->prepare("SELECT id FROM {$t_tbl} WHERE type=%s AND period=%s", $type, $period));
-                    if ($id) return (int)$id;
                     $now = current_time('mysql', 1);
                     $start = $now; $end = $now;
                     if ($type === 'weekly') {
@@ -318,10 +316,17 @@ if (!function_exists('bhg_reset_demo_and_seed')) {
                         $start = $period . '-01-01';
                         $end   = $period . '-12-31';
                     }
+                    $id = $wpdb->get_var($wpdb->prepare(
+                        "SELECT id FROM {$t_tbl} WHERE type=%s AND start_date=%s AND end_date=%s",
+                        $type,
+                        $start,
+                        $end
+                    ));
+                    if ($id) return (int) $id;
                     $wpdb->insert($t_tbl, array(
-                        'type'=>$type,'period'=>$period,'start_date'=>$start,'end_date'=>$end,'status'=>'active',
+                        'type'=>$type,'start_date'=>$start,'end_date'=>$end,'status'=>'active',
                         'created_at'=>$now,'updated_at'=>$now
-                    ), array('%s','%s','%s','%s','%s','%s','%s'));
+                    ), array('%s','%s','%s','%s','%s','%s'));
                     return (int)$wpdb->insert_id;
                 };
 


### PR DESCRIPTION
## Summary
- drop `period` column and unique index during initial table creation
- adjust tournament logic to use start and end dates instead of `period`
- migrate existing installs by dropping legacy column

## Testing
- `php -l bonus-hunt-guesser.php`
- `php -l admin/class-bhg-demo.php`
- `php -l includes/demo.php`
- `php -l includes/class-bhg-db.php`
- `php -l includes/helpers.php`
- `php -l includes/class-bhg-shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba9789b1708333a8bbbb8b4d6a9a1e