### PR TITLE
Validate allowed sorting columns for user admin

### DIFF
--- a/admin/views/users.php
+++ b/admin/views/users.php
@@ -7,8 +7,12 @@ if (!current_user_can('manage_options')) {
 $paged    = max(1, isset($_GET['paged']) ? (int) $_GET['paged'] : 1);
 $per_page = 30;
 $search   = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
-$orderby  = isset($_GET['orderby']) ? sanitize_key($_GET['orderby']) : 'user_login';
-$order    = (isset($_GET['order']) && strtolower($_GET['order']) === 'desc') ? 'DESC' : 'ASC';
+$allowed_orderby = ['user_login', 'display_name', 'user_email'];
+$orderby         = isset($_GET['orderby']) ? sanitize_key($_GET['orderby']) : 'user_login';
+if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
+    $orderby = 'user_login';
+}
+$order = ( isset( $_GET['order'] ) && strtolower( $_GET['order'] ) === 'desc' ) ? 'DESC' : 'ASC';
 
 $args = [
     'number'   => $per_page,


### PR DESCRIPTION
## Summary
- guard the user admin query against invalid `orderby` parameters

## Testing
- `php -l admin/views/users.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba99a8a2008333905838e624c3cb92