### PR TITLE
Fix guess submission hunt selection

### DIFF
--- a/assets/js/public.js
+++ b/assets/js/public.js
@@ -76,7 +76,7 @@ jQuery(document).ready(function($) {
                     action: 'submit_bhg_guess',
                     nonce: bhg_nonce,
                     guess_amount: guessValue,
-                    hunt_id: form.find('input[name="hunt_id"]').val()
+                    hunt_id: form.find('[name="hunt_id"]').val()
                 },
                 success: function(response) {
                     if (response.success) {

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -120,8 +120,9 @@ class BHG_Shortcodes {
             <label for="bhg-guess" style="display:block;margin-top:10px;"><?php esc_html_e('Your guess (final balance):', 'bonus-hunt-guesser'); ?></label>
             <input type="number" step="0.01" min="<?php echo esc_attr($min); ?>" max="<?php echo esc_attr($max); ?>"
                    id="bhg-guess" name="guess" value="<?php echo esc_attr($existing_guess); ?>" required>
-
-            <button type="submit" class="button button-primary" style="margin-top:20px;"><?php echo esc_html__('Submit Guess', 'bonus-hunt-guesser'); ?></button>
+            <div class="bhg-error-message" style="color:#dc2626;margin-top:10px;display:none;"></div>
+            <button type="submit" class="bhg-submit-btn button button-primary" style="margin-top:20px;">
+                <?php echo esc_html__('Submit Guess', 'bonus-hunt-guesser'); ?></button>
         </form>
         <?php
         return ob_get_clean();


### PR DESCRIPTION
## Summary
- ensure JS captures hunt choice from select or hidden field
- add error message container and button class in guess form

## Testing
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs --standard=WordPress includes/class-bhg-shortcodes.php` (errors: coding standards violations)
- `node --check assets/js/public.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba9bebe0c88333979aecd409deecc6