### PR TITLE
Use wp_safe_redirect for admin redirects

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -436,7 +436,7 @@ function bhg_handle_settings_save() {
     
     // Verify nonce
     if (!isset($_POST['bhg_settings_nonce']) || !wp_verify_nonce($_POST['bhg_settings_nonce'], 'bhg_save_settings_nonce')) {
-        wp_redirect(admin_url('admin.php?page=bhg_settings&error=nonce_failed'));
+        wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_settings&error=nonce_failed' ) ) );
         exit;
     }
     
@@ -467,7 +467,7 @@ function bhg_handle_settings_save() {
     // Validate that min is not greater than max
     if (isset($settings['min_guess_amount']) && isset($settings['max_guess_amount']) && 
         $settings['min_guess_amount'] > $settings['max_guess_amount']) {
-        wp_redirect(admin_url('admin.php?page=bhg_settings&error=invalid_data'));
+        wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_settings&error=invalid_data' ) ) );
         exit;
     }
     
@@ -494,7 +494,7 @@ function bhg_handle_settings_save() {
     update_option('bhg_plugin_settings', $settings);
     
     // Redirect back to settings page
-    wp_redirect(admin_url('admin.php?page=bhg_settings&message=saved'));
+    wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_settings&message=saved' ) ) );
     exit;
 }
 
@@ -544,7 +544,7 @@ function bhg_handle_bonus_hunt_save() {
         $wpdb->insert( $table_name, $data );
     }
 
-    wp_redirect( admin_url( 'admin.php?page=bhg_bonus_hunts&message=saved' ) );
+    wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_bonus_hunts&message=saved' ) ) );
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Replace `wp_redirect` with `wp_safe_redirect` for settings and bonus hunt save handlers
- Sanitize redirect targets with `esc_url_raw( admin_url(...) )`

## Testing
- `php -l bonus-hunt-guesser.php`


------
https://chatgpt.com/codex/tasks/task_e_68baa1cb893083338cacefafbc251371