### PR TITLE
Avoid unneeded prepare call when counting leaderboard rows

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -846,7 +846,7 @@ function bhg_generate_leaderboard_html( $timeframe ) {
     if ( $args ) {
         $total = (int) $wpdb->get_var( $wpdb->prepare( $sql_total, $args ) );
     } else {
-        $total = (int) $wpdb->get_var( $wpdb->prepare( $sql_total ) );
+        $total = (int) $wpdb->get_var( $sql_total );
     }
 
     $sql = "


### PR DESCRIPTION
## Summary
- Avoid preparing SQL query when no placeholders are used in leaderboard total calculation

## Testing
- `php -l bonus-hunt-guesser.php`


------
https://chatgpt.com/codex/tasks/task_e_68baa2524cac8333b275a1144fe66c42