### PR TITLE
Sanitize action and id parameters in advertising view

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -7,11 +7,14 @@ if (!current_user_can('manage_options')) {
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_ads';
 
+$action = isset( $_GET['action'] ) ? sanitize_key( $_GET['action'] ) : '';
+$ad_id  = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
+
 // Delete action
-if (isset($_GET['action'], $_GET['id']) && $_GET['action']==='delete' && isset($_GET['_wpnonce'])) {
-    if (wp_verify_nonce($_GET['_wpnonce'], 'bhg_delete_ad') && current_user_can('manage_options')) {
-        $wpdb->delete($table, ['id'=>(int)$_GET['id']], ['%d']);
-        wp_redirect(remove_query_arg(['action','id','_wpnonce']));
+if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
+    if ( wp_verify_nonce( $_GET['_wpnonce'], 'bhg_delete_ad' ) && current_user_can( 'manage_options' ) ) {
+        $wpdb->delete( $table, [ 'id' => $ad_id ], [ '%d' ] );
+        wp_redirect( remove_query_arg( [ 'action', 'id', '_wpnonce' ] ) );
         exit;
     }
 }


### PR DESCRIPTION
## Summary
- Sanitize `action` and `id` parameters in the advertising admin view
- Use sanitized variables for deletion comparisons and database operations

## Testing
- ⚠️ `php -l admin/views/advertising.php` *(php not installed; apt repositories returned 503 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68baa525c08c8333b3919491ff7c091c