### PR TITLE
Refactor winner row styling

### DIFF
--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -26,7 +26,7 @@ $rows = $wpdb->get_results(
     </tr></thead>
     <tbody>
     <?php $pos=1; foreach($rows as $r): $wcount = (int)$hunt->winners_count; if ($wcount < 1) $wcount = 3; $isWinner = $pos <= $wcount; ?>
-      <tr <?php if($isWinner) echo 'style="background:#d1fae5;"'; ?>>
+      <tr <?php if($isWinner) echo 'class="bhg-winner-row"'; ?>>
         <td><?php echo (int)$pos; ?></td>
         <td><?php echo esc_html($r->display_name); ?></td>
         <td><?php echo esc_html(number_format_i18n((float)$r->guess,2)); ?></td>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -19,3 +19,7 @@
     padding: 6px 8px;
     box-shadow: inset 0 1px 2px rgba(0,0,0,.04);
 }
+
+.bhg-winner-row {
+    background-color: #d1fae5;
+}


### PR DESCRIPTION
## Summary
- add reusable `.bhg-winner-row` style for admin tables
- apply class on bonus hunt results rows instead of inline styling

## Testing
- `php -l admin/views/bonus-hunts-results.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baa792afd0833395d5a013e2f049be