### PR TITLE
Fix improper wpdb::prepare usage

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -20,7 +20,7 @@ if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
 }
 
 // Fetch ads
-$ads = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$table` ORDER BY id DESC" ) );
+$ads = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Advertising', 'bonus-hunt-guesser'); ?></h1>

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -11,7 +11,7 @@ $edit_id = isset($_GET['edit']) ? (int) $_GET['edit'] : 0;
 $row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$table` WHERE id=%d", $edit_id)) : null;
 
 // List
-$rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$table` ORDER BY id DESC" ) );
+$rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Affiliates', 'bonus-hunt-guesser'); ?></h1>

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -17,7 +17,7 @@ $view = isset( $_GET['view'] ) ? sanitize_text_field( $_GET['view'] ) : 'list';
 
 /** LIST VIEW */
 if ( 'list' === $view ) :
-    $hunts = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$hunts_table` ORDER BY id DESC" ) );
+    $hunts = $wpdb->get_results( "SELECT * FROM `$hunts_table` ORDER BY id DESC" );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Bonus Hunts', 'bonus-hunt-guesser'); ?></h1>
@@ -126,7 +126,7 @@ if ($view === 'add') : ?>
         <tr>
           <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
           <td>
-            <?php $affs = $wpdb->get_results( $wpdb->prepare( "SELECT id, name FROM `{$wpdb->prefix}bhg_affiliates` ORDER BY name ASC" ) ); $sel = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0; ?>
+            <?php $affs = $wpdb->get_results( "SELECT id, name FROM `{$wpdb->prefix}bhg_affiliates` ORDER BY name ASC" ); $sel = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0; ?>
             <select id="bhg_affiliate" name="affiliate_site_id">
               <option value="0"><?php echo esc_html__('None', 'bonus-hunt-guesser'); ?></option>
               <?php foreach ($affs as $a): ?>
@@ -199,7 +199,7 @@ if ($view === 'edit') :
         <tr>
           <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
           <td>
-            <?php $affs = $wpdb->get_results( $wpdb->prepare( "SELECT id, name FROM `{$wpdb->prefix}bhg_affiliates` ORDER BY name ASC" ) ); $sel = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0; ?>
+            <?php $affs = $wpdb->get_results( "SELECT id, name FROM `{$wpdb->prefix}bhg_affiliates` ORDER BY name ASC" ); $sel = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0; ?>
             <select id="bhg_affiliate" name="affiliate_site_id">
               <option value="0"><?php echo esc_html__('None', 'bonus-hunt-guesser'); ?></option>
               <?php foreach ($affs as $a): ?>

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -44,7 +44,7 @@ function bhg_database_cleanup() {
     
     foreach ( $tables as $table ) {
         if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
-            $wpdb->query( $wpdb->prepare( "TRUNCATE TABLE {$table}" ) );
+            $wpdb->query( "TRUNCATE TABLE {$table}" );
         }
     }
     
@@ -69,7 +69,7 @@ function bhg_database_optimize() {
     
     foreach ( $tables as $table ) {
         if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
-            $wpdb->query( $wpdb->prepare( "OPTIMIZE TABLE {$table}" ) );
+            $wpdb->query( "OPTIMIZE TABLE {$table}" );
         }
     }
 }
@@ -147,7 +147,7 @@ function bhg_insert_demo_data() {
             foreach ( $tables as $table ) {
                 $table_name = $wpdb->prefix . $table;
                 $exists     = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name;
-                $row_count  = $exists ? (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM `{$table_name}`" ) ) : 0;
+                $row_count  = $exists ? (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$table_name}`" ) : 0;
                 
                 echo '<tr>';
                 echo '<td>' . esc_html($table_name) . '</td>';

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -19,7 +19,7 @@ $rows = $wpdb->get_results(
     $offset
   )
 );
-$total = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $t" ) );
+$total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $t" );
 $pages = max(1, (int) ceil($total / $per_page));
 
 ?>

--- a/admin/views/tools.php
+++ b/admin/views/tools.php
@@ -6,11 +6,11 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
   <?php
   global $wpdb;
-  $hunts = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_bonus_hunts" ) );
-  $guesses = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_guesses" ) );
-  $users = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->users}" ) );
-  $ads = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_ads" ) );
-  $tournaments = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_tournaments" ) );
+  $hunts = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_bonus_hunts" );
+  $guesses = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_guesses" );
+  $users = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->users}" );
+  $ads = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_ads" );
+  $tournaments = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}bhg_tournaments" );
   ?>
 
   <div class="card" style="max-width:900px;padding:16px;margin-top:12px;">

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -9,7 +9,7 @@ $table = $wpdb->prefix . 'bhg_tournaments';
 $edit_id = isset($_GET['edit']) ? (int) $_GET['edit'] : 0;
 $row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$table` WHERE id=%d", $edit_id)) : null;
 
-$rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$table` ORDER BY id DESC" ) );
+$rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php esc_html_e('Tournaments', 'bonus-hunt-guesser'); ?></h1>

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -33,7 +33,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bhg_save_translation'
 }
 
 // Fetch rows
-$rows = $wpdb->get_results( $wpdb->prepare( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC" ) );
+$rows = $wpdb->get_results( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC" );
 ?>
 <div class="wrap">
   <h1><?php esc_html_e('Translations', 'bonus-hunt-guesser'); ?></h1>

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -247,7 +247,7 @@ if (!function_exists('bhg_reset_demo_and_seed')) {
                 'num_bonuses' => 10,
                 'prizes' => __('Gift card + swag', 'bonus-hunt-guesser'),
                 'status' => 'open',
-                'affiliate_site_id' => (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$p}bhg_affiliate_websites ORDER BY id ASC LIMIT 1" ) ),
+                'affiliate_site_id' => (int) $wpdb->get_var( "SELECT id FROM {$p}bhg_affiliate_websites ORDER BY id ASC LIMIT 1" ),
                 'created_at' => $now,
                 'updated_at' => $now,
             ), array('%s','%f','%d','%s','%s','%d','%s','%s'));
@@ -271,7 +271,7 @@ if (!function_exists('bhg_reset_demo_and_seed')) {
 
             // Seed guesses for open hunt
             $g_tbl = "{$p}bhg_guesses";
-            $users = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->users} ORDER BY ID ASC LIMIT 5" ) );
+            $users = $wpdb->get_col( "SELECT ID FROM {$wpdb->users} ORDER BY ID ASC LIMIT 5" );
             if (empty($users)) { $users = array(1); }
             $val = 2100.00;
             foreach ($users as $uid) {
@@ -294,7 +294,7 @@ if (!function_exists('bhg_reset_demo_and_seed')) {
             if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $r_tbl)) === $r_tbl) {
                 $wpdb->query( "DELETE FROM `{$r_tbl}`" );
             }
-            $closed = $wpdb->get_results( $wpdb->prepare( "SELECT winner_user_id, closed_at FROM {$hunts_tbl} WHERE status='closed' AND winner_user_id IS NOT NULL" ) );
+            $closed = $wpdb->get_results( "SELECT winner_user_id, closed_at FROM {$hunts_tbl} WHERE status='closed' AND winner_user_id IS NOT NULL" );
             foreach ($closed as $row) {
                 $ts = $row->closed_at ? strtotime($row->closed_at) : time();
                 $isoYear = date('o', $ts);


### PR DESCRIPTION
## Summary
- call $wpdb methods directly when queries have no placeholders
- clean up database, admin, and helper queries

## Testing
- `php -l includes/helpers.php admin/views/tournaments.php admin/views/hunts-list.php admin/views/translations.php admin/views/affiliate-websites.php admin/views/database.php admin/views/tools.php admin/views/bonus-hunts.php admin/views/advertising.php`
- `phpcs includes/helpers.php admin/views/tournaments.php admin/views/hunts-list.php admin/views/translations.php admin/views/affiliate-websites.php admin/views/database.php admin/views/tools.php admin/views/bonus-hunts.php admin/views/advertising.php | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68baaaa9072c833393953d4e4f35b531