### PR TITLE
Remove wildcard selects for explicit column retrieval

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -20,7 +20,7 @@ if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
 }
 
 // Fetch ads
-$ads = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$table` ORDER BY id DESC" ) );
+$ads = $wpdb->get_results( $wpdb->prepare( "SELECT id, title, content, placement, visible_to, active FROM `$table` ORDER BY id DESC" ) );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Advertising', 'bonus-hunt-guesser'); ?></h1>
@@ -60,7 +60,7 @@ $ads = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$table` ORDER BY id D
   <?php
     $ad = null;
     if (isset($_GET['edit'])) {
-        $ad = $wpdb->get_row($wpdb->prepare("SELECT * FROM `$table` WHERE id = %d", (int)$_GET['edit']));
+        $ad = $wpdb->get_row($wpdb->prepare("SELECT id, title, content, link_url, placement, visible_to, target_pages, active FROM `$table` WHERE id = %d", (int)$_GET['edit']));
     }
   ?>
   <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="max-width:800px">

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -8,10 +8,10 @@ $table = $wpdb->prefix . 'bhg_affiliates';
 
 // Load for edit
 $edit_id = isset($_GET['edit']) ? (int) $_GET['edit'] : 0;
-$row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$table` WHERE id=%d", $edit_id)) : null;
+$row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT id, name, url, status FROM `$table` WHERE id=%d", $edit_id)) : null;
 
 // List
-$rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$table` ORDER BY id DESC" ) );
+$rows = $wpdb->get_results( $wpdb->prepare( "SELECT id, name, url, status FROM `$table` ORDER BY id DESC" ) );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Affiliates', 'bonus-hunt-guesser'); ?></h1>

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -5,11 +5,11 @@ global $wpdb;
 $hunt_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $hunts = $wpdb->prefix.'bhg_bonus_hunts';
 $guesses = $wpdb->prefix.'bhg_guesses';
-$hunt = $wpdb->get_row($wpdb->prepare("SELECT * FROM `$hunts` WHERE id=%d",$hunt_id));
+$hunt = $wpdb->get_row($wpdb->prepare("SELECT id, title, final_balance, winners_count FROM `$hunts` WHERE id=%d",$hunt_id));
 if(!$hunt) { echo '<div class="wrap"><h1>'.esc_html__('Hunt not found','bonus-hunt-guesser').'</h1></div>'; return; }
 $rows = $wpdb->get_results(
     $wpdb->prepare(
-        "SELECT g.*, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
+        "SELECT g.id, g.user_id, g.guess, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
         (float) $hunt->final_balance,
         $hunt_id
     )

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -17,7 +17,7 @@ $view = isset( $_GET['view'] ) ? sanitize_text_field( $_GET['view'] ) : 'list';
 
 /** LIST VIEW */
 if ( 'list' === $view ) :
-    $hunts = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$hunts_table` ORDER BY id DESC" ) );
+    $hunts = $wpdb->get_results( $wpdb->prepare( "SELECT id, title, starting_balance, final_balance, winners_count, status FROM `$hunts_table` ORDER BY id DESC" ) );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Bonus Hunts', 'bonus-hunt-guesser'); ?></h1>
@@ -69,7 +69,7 @@ if ( 'list' === $view ) :
 /** CLOSE VIEW */
 if ( 'close' === $view ) :
     $id   = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
-    $hunt = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$hunts_table` WHERE id = %d", $id ) );
+    $hunt = $wpdb->get_row( $wpdb->prepare( "SELECT id, title, status FROM `$hunts_table` WHERE id = %d", $id ) );
     if ( ! $hunt || 'open' !== $hunt->status ) :
         echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) . '</p></div>';
     else :
@@ -163,12 +163,12 @@ if ($view === 'add') : ?>
 /** EDIT VIEW */
 if ($view === 'edit') :
     $id    = isset($_GET['id']) ? (int) $_GET['id'] : 0;
-    $hunt  = $wpdb->get_row($wpdb->prepare("SELECT * FROM `$hunts_table` WHERE id = %d", $id));
+    $hunt  = $wpdb->get_row($wpdb->prepare("SELECT id, title, starting_balance, num_bonuses, prizes, affiliate_site_id, winners_count, final_balance, status FROM `$hunts_table` WHERE id = %d", $id));
     if (!$hunt) {
         echo '<div class="notice notice-error"><p>'.esc_html__('Invalid hunt', 'bonus-hunt-guesser').'</p></div>';
         return;
     }
-    $guesses = $wpdb->get_results($wpdb->prepare("SELECT g.*, u.display_name FROM `$guesses_table` g LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC", $id));
+    $guesses = $wpdb->get_results($wpdb->prepare("SELECT g.id, g.user_id, g.guess, u.display_name FROM `$guesses_table` g LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC", $id));
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Edit Bonus Hunt', 'bonus-hunt-guesser'); ?> — <?php echo esc_html($hunt->title); ?></h1>

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -7,9 +7,9 @@ global $wpdb;
 $table = $wpdb->prefix . 'bhg_tournaments';
 
 $edit_id = isset($_GET['edit']) ? (int) $_GET['edit'] : 0;
-$row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$table` WHERE id=%d", $edit_id)) : null;
+$row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT id, title, description, type, start_date, end_date, status FROM `$table` WHERE id=%d", $edit_id)) : null;
 
-$rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `$table` ORDER BY id DESC" ) );
+$rows = $wpdb->get_results( $wpdb->prepare( "SELECT id, title, type, start_date, end_date, status FROM `$table` ORDER BY id DESC" ) );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php esc_html_e('Tournaments', 'bonus-hunt-guesser'); ?></h1>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -565,7 +565,7 @@ function bhg_build_ads_query( $table, $placement = 'footer' ) {
 
     // Use prepare for the placement value
     $query = $wpdb->prepare(
-        "SELECT * FROM `{$safe_table}` WHERE placement = %s AND active = %d",
+        "SELECT id, title, content, link_url, placement, visible_to, target_pages FROM `{$safe_table}` WHERE placement = %s AND active = %d",
         $placement,
         1
     );

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -12,7 +12,7 @@ if (!function_exists('bhg_get_hunt')) {
     function bhg_get_hunt($hunt_id){
         global $wpdb;
         $t = $wpdb->prefix . 'bhg_bonus_hunts';
-        return $wpdb->get_row($wpdb->prepare("SELECT * FROM $t WHERE id=%d", (int)$hunt_id));
+        return $wpdb->get_row($wpdb->prepare("SELECT id, title, starting_balance, final_balance, winners_count, status, closed_at FROM $t WHERE id=%d", (int)$hunt_id));
     }
 }
 

--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -68,7 +68,7 @@ class BHG_Bonus_Hunts {
         global $wpdb;
         $hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 
-        return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$hunts_table` WHERE id=%d", (int) $hunt_id ) );
+        return $wpdb->get_row( $wpdb->prepare( "SELECT id, title, starting_balance, final_balance, winners_count, status, closed_at FROM `$hunts_table` WHERE id=%d", (int) $hunt_id ) );
     }
 
     /**
@@ -88,7 +88,7 @@ class BHG_Bonus_Hunts {
         if ( null !== $hunt->final_balance ) {
             return $wpdb->get_results(
                 $wpdb->prepare(
-                    "SELECT g.*, u.display_name, ABS(g.guess - %f) AS diff
+                    "SELECT g.id, g.user_id, g.guess, g.created_at, u.display_name, ABS(g.guess - %f) AS diff
                      FROM `$guesses_table` g
                      LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
                      WHERE g.hunt_id = %d
@@ -101,7 +101,7 @@ class BHG_Bonus_Hunts {
 
         return $wpdb->get_results(
             $wpdb->prepare(
-                "SELECT g.*, u.display_name, NULL AS diff
+                "SELECT g.id, g.user_id, g.guess, g.created_at, u.display_name, NULL AS diff
                  FROM `$guesses_table` g
                  LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
                  WHERE g.hunt_id = %d

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -42,7 +42,7 @@ class BHG_Shortcodes {
     /** [bhg_active_hunt] — list all open hunts */
     public function active_hunt_shortcode($atts) {
         global $wpdb;
-        $hunts = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='open' ORDER BY created_at DESC" );
+        $hunts = $wpdb->get_results( "SELECT title, starting_balance, num_bonuses, prizes FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='open' ORDER BY created_at DESC" );
         if (!$hunts) {
             return '<div class="bhg-active-hunt"><p>' . esc_html__('No active bonus hunts at the moment.', 'bonus-hunt-guesser') . '</p></div>';
         }
@@ -168,7 +168,7 @@ class BHG_Shortcodes {
         }
 
         $rows = $wpdb->get_results($wpdb->prepare(
-            "SELECT g.*, u.user_login, h.affiliate_site_id
+            "SELECT g.id, g.user_id, g.guess, u.user_login, h.affiliate_site_id
              FROM {$g} g
              LEFT JOIN {$u} u ON u.ID = g.user_id
              LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id
@@ -315,7 +315,7 @@ class BHG_Shortcodes {
             $args[]  = $a['status'];
         }
 
-        $sql = "SELECT * FROM {$t}";
+        $sql = "SELECT id, type, start_date, end_date, status FROM {$t}";
         if ($where) {
             $sql .= " WHERE " . implode(" AND ", $where);
         }

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -61,27 +61,27 @@ function bhg_seed_demo_on_activation(){
 
     // Add demo guesses for closed hunt
     $grows = array(
-        array('hunt_id'=>$closed_id,'user_id'=>$user_ids['alice_demo'],'guess_amount'=>2450.00),
-        array('hunt_id'=>$closed_id,'user_id'=>$user_ids['bob_demo'],'guess_amount'=>2400.00),
-        array('hunt_id'=>$closed_id,'user_id'=>$user_ids['charlie_demo'],'guess_amount'=>1800.00),
+        array('hunt_id'=>$closed_id,'user_id'=>$user_ids['alice_demo'],'guess'=>2450.00),
+        array('hunt_id'=>$closed_id,'user_id'=>$user_ids['bob_demo'],'guess'=>2400.00),
+        array('hunt_id'=>$closed_id,'user_id'=>$user_ids['charlie_demo'],'guess'=>1800.00),
     );
     foreach ($grows as $r){
         if ($r['user_id']) {
             $wpdb->insert($guesses, array(
                 'hunt_id'=>$r['hunt_id'],
                 'user_id'=>$r['user_id'],
-                'guess_amount'=>$r['guess_amount'],
+                'guess'=>$r['guess'],
                 'created_at'=> current_time('mysql')
             ));
         }
     }
 
     // Compute winner for the closed hunt (closest)
-    $rows = $wpdb->get_results( "SELECT * FROM `{$closed_id}`" );
+    $rows = $wpdb->get_results( $wpdb->prepare( "SELECT user_id, guess FROM `$guesses` WHERE hunt_id=%d", $closed_id ) );
     $final = 2420.00;
     $winner_id = 0; $winner_diff = null;
     foreach ($rows as $row){
-        $diff = abs(floatval($row->guess_amount) - $final);
+        $diff = abs(floatval($row->guess) - $final);
         if ($winner_diff === null || $diff < $winner_diff){
             $winner_diff = $diff;
             $winner_id = intval($row->user_id);


### PR DESCRIPTION
## Summary
- Replace `SELECT *` with explicit column lists in shortcodes and helpers
- Limit admin queries to required fields for hunts, tournaments, affiliates, ads, and results
- Constrain ad lookup to specific columns for safer data handling

## Testing
- `php -l includes/class-bhg-shortcodes.php`
- `php -l includes/demo.php`
- `php -l includes/class-bhg-bonus-hunts-helpers.php`
- `php -l includes/class-bhg-bonus-hunts.php`
- `php -l admin/views/bonus-hunts-results.php`
- `php -l bonus-hunt-guesser.php`
- `php -l admin/views/advertising.php`
- `php -l admin/views/tournaments.php`
- `php -l admin/views/affiliate-websites.php`
- `php -l admin/views/bonus-hunts.php`


------
https://chatgpt.com/codex/tasks/task_e_68baabff54e08333b541fa20153d2032