### PR TITLE
Fix guess validation settings option

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -74,9 +74,9 @@ function bhg_format_currency($amount) {
 
 // Helper function to validate guess value
 function bhg_validate_guess($guess) {
-    $settings = get_option('bhg_settings', []);
-    $min_guess = $settings['min_guess'] ?? 0;
-    $max_guess = $settings['max_guess'] ?? 100000;
+    $settings = get_option('bhg_plugin_settings', []);
+    $min_guess = isset($settings['min_guess_amount']) ? (float)$settings['min_guess_amount'] : 0;
+    $max_guess = isset($settings['max_guess_amount']) ? (float)$settings['max_guess_amount'] : 100000;
 
     if (!is_numeric($guess)) {
         return false;


### PR DESCRIPTION
## Summary
- Use `bhg_plugin_settings` option when validating guesses
- Align guess validation with `min_guess_amount` and `max_guess_amount` keys

## Testing
- `php -l includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68bab000da188333be9ee14ea3073263