### PR TITLE
Add documentation blocks and clean up formatting

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -3,21 +3,25 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_Admin {
 
+    /**
+     * Initialize admin hooks and actions.
+     */
     public function __construct() {
-        // Menus
-        add_action('admin_menu', [$this, 'menu']);
-        add_action('admin_notices', [$this, 'admin_notices']);
-        add_action('admin_enqueue_scripts', [$this, 'assets']);
-        // Handlers
-        add_action('admin_post_bhg_delete_guess',      [$this, 'handle_delete_guess']);
-        add_action('admin_post_bhg_save_hunt',         [$this, 'handle_save_hunt']);
-        add_action('admin_post_bhg_close_hunt',        [$this, 'handle_close_hunt']);
-        add_action('admin_post_bhg_save_ad',           [$this, 'handle_save_ad']);
-        add_action('admin_post_bhg_tournament_save',   [$this, 'handle_save_tournament']);
-        add_action('admin_post_bhg_save_affiliate',    [$this, 'handle_save_affiliate']);
-        add_action('admin_post_bhg_delete_affiliate',  [$this, 'handle_delete_affiliate']);
-        add_action('admin_post_bhg_save_settings',     [$this, 'handle_save_settings']);
-        add_action('admin_post_bhg_save_user_meta',    [$this, 'handle_save_user_meta']);
+        // Menus.
+        add_action( 'admin_menu', [ $this, 'menu' ] );
+        add_action( 'admin_notices', [ $this, 'admin_notices' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'assets' ] );
+
+        // Handlers.
+        add_action( 'admin_post_bhg_delete_guess', [ $this, 'handle_delete_guess' ] );
+        add_action( 'admin_post_bhg_save_hunt', [ $this, 'handle_save_hunt' ] );
+        add_action( 'admin_post_bhg_close_hunt', [ $this, 'handle_close_hunt' ] );
+        add_action( 'admin_post_bhg_save_ad', [ $this, 'handle_save_ad' ] );
+        add_action( 'admin_post_bhg_tournament_save', [ $this, 'handle_save_tournament' ] );
+        add_action( 'admin_post_bhg_save_affiliate', [ $this, 'handle_save_affiliate' ] );
+        add_action( 'admin_post_bhg_delete_affiliate', [ $this, 'handle_delete_affiliate' ] );
+        add_action( 'admin_post_bhg_save_settings', [ $this, 'handle_save_settings' ] );
+        add_action( 'admin_post_bhg_save_user_meta', [ $this, 'handle_save_user_meta' ] );
     }
 
     /** Register admin menus and pages */
@@ -51,60 +55,136 @@ class BHG_Admin {
     }
 
     /** Enqueue admin assets on BHG screens. */
-    public function assets($hook) {
-        if (strpos($hook, 'bhg') !== false) {
-            wp_enqueue_style('bhg-admin', BHG_PLUGIN_URL . 'assets/css/admin.css', array(), defined('BHG_VERSION') ? BHG_VERSION : null);
-            wp_enqueue_script('bhg-admin', BHG_PLUGIN_URL . 'assets/js/admin.js', array('jquery'), defined('BHG_VERSION') ? BHG_VERSION : null, true);
+    public function assets( $hook ) {
+        if ( strpos( $hook, 'bhg' ) !== false ) {
+            wp_enqueue_style(
+                'bhg-admin',
+                BHG_PLUGIN_URL . 'assets/css/admin.css',
+                array(),
+                defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+            );
+            wp_enqueue_script(
+                'bhg-admin',
+                BHG_PLUGIN_URL . 'assets/js/admin.js',
+                array( 'jquery' ),
+                defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
+                true
+            );
         }
     }
 
     // -------------------- Views --------------------
-    public function dashboard()           { require BHG_PLUGIN_DIR . 'admin/views/dashboard.php'; }
-    public function bonus_hunts()         { require BHG_PLUGIN_DIR . 'admin/views/bonus-hunts.php'; }
-    public function bonus_hunts_results() { require BHG_PLUGIN_DIR . 'admin/views/bonus-hunts-results.php'; }
-    public function tournaments()         { require BHG_PLUGIN_DIR . 'admin/views/tournaments.php'; }
-    public function users()               { require BHG_PLUGIN_DIR . 'admin/views/users.php'; }
-    public function affiliates()          { 
+    /**
+     * Render the dashboard page.
+     */
+    public function dashboard() {
+        require BHG_PLUGIN_DIR . 'admin/views/dashboard.php';
+    }
+
+    /**
+     * Render the bonus hunts page.
+     */
+    public function bonus_hunts() {
+        require BHG_PLUGIN_DIR . 'admin/views/bonus-hunts.php';
+    }
+
+    /**
+     * Render the bonus hunts results page.
+     */
+    public function bonus_hunts_results() {
+        require BHG_PLUGIN_DIR . 'admin/views/bonus-hunts-results.php';
+    }
+
+    /**
+     * Render the tournaments page.
+     */
+    public function tournaments() {
+        require BHG_PLUGIN_DIR . 'admin/views/tournaments.php';
+    }
+
+    /**
+     * Render the users page.
+     */
+    public function users() {
+        require BHG_PLUGIN_DIR . 'admin/views/users.php';
+    }
+
+    /**
+     * Render the affiliates management page.
+     */
+    public function affiliates() {
         $view = BHG_PLUGIN_DIR . 'admin/views/affiliate-websites.php';
         if (file_exists($view)) { require $view; }
         else { echo '<div class="wrap"><h1>' . esc_html__('Affiliates', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('Affiliate management UI not provided yet.', 'bonus-hunt-guesser') . '</p></div>'; }
     }
-    public function advertising()         { require BHG_PLUGIN_DIR . 'admin/views/advertising.php'; }
-    public function translations()        { 
+    /**
+     * Render the advertising page.
+     */
+    public function advertising() {
+        require BHG_PLUGIN_DIR . 'admin/views/advertising.php';
+    }
+
+    /**
+     * Render the translations page.
+     */
+    public function translations() {
         $view = BHG_PLUGIN_DIR . 'admin/views/translations.php';
         if (file_exists($view)) { require $view; }
         else { echo '<div class="wrap"><h1>' . esc_html__('Translations', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No translations UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
     }
-    public function database()            { 
+    /**
+     * Render the database maintenance page.
+     */
+    public function database() {
         $view = BHG_PLUGIN_DIR . 'admin/views/database.php';
         if (file_exists($view)) { require $view; }
         else { echo '<div class="wrap"><h1>' . esc_html__('Database', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No database UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
     }
-    public function settings()            { 
+    /**
+     * Render the settings page.
+     */
+    public function settings() {
         $view = BHG_PLUGIN_DIR . 'admin/views/settings.php';
         if (file_exists($view)) { require $view; }
         else { echo '<div class="wrap"><h1>' . esc_html__('Settings', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No settings UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
     }
-    public function bhg_tools_page()      { 
+    /**
+     * Render the tools demo page.
+     */
+    public function bhg_tools_page() {
         $view = BHG_PLUGIN_DIR . 'admin/views/demo-tools.php';
         if (file_exists($view)) { require $view; }
         else { echo '<div class="wrap"><h1>' . esc_html__('BHG Tools', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No tools UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
     }
 
     // -------------------- Handlers --------------------
+
+    /**
+     * Handle deletion of a guess from the admin screen.
+     */
     public function handle_delete_guess() {
-        if (!current_user_can('manage_options')) wp_die(esc_html__('No permission', 'bonus-hunt-guesser'));
-        check_admin_referer('bhg_delete_guess');
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+        }
+        check_admin_referer( 'bhg_delete_guess' );
         global $wpdb;
         $guesses_table = $wpdb->prefix . 'bhg_guesses';
-        $guess_id = isset($_POST['guess_id']) ? (int) $_POST['guess_id'] : 0;
-        if ($guess_id) { $wpdb->delete($guesses_table, ['id' => $guess_id], ['%d']); }
-        wp_redirect(wp_get_referer() ?: admin_url('admin.php?page=bhg-bonus-hunts')); exit;
+        $guess_id      = isset( $_POST['guess_id'] ) ? (int) $_POST['guess_id'] : 0;
+        if ( $guess_id ) {
+            $wpdb->delete( $guesses_table, [ 'id' => $guess_id ], [ '%d' ] );
+        }
+        wp_redirect( wp_get_referer() ?: admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+        exit;
     }
 
+    /**
+     * Handle creation and updating of a bonus hunt.
+     */
     public function handle_save_hunt() {
-        if (!current_user_can('manage_options')) wp_die(esc_html__('No permission', 'bonus-hunt-guesser'));
-        check_admin_referer('bhg_save_hunt');
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+        }
+        check_admin_referer( 'bhg_save_hunt' );
         global $wpdb;
         $hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 
@@ -203,23 +283,31 @@ class BHG_Admin {
         exit;
     }
 
+    /**
+     * Close an active bonus hunt.
+     */
     public function handle_close_hunt() {
-        if (!current_user_can('manage_options')) {
-            wp_die(esc_html__('No permission', 'bonus-hunt-guesser'));
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
         }
-        check_admin_referer('bhg_close_hunt');
-        $hunt_id       = isset($_POST['hunt_id']) ? (int) $_POST['hunt_id'] : 0;
-        $final_balance = isset($_POST['final_balance']) ? (float) $_POST['final_balance'] : 0;
-        if ($hunt_id) {
-            BHG_Models::close_hunt($hunt_id, $final_balance);
+        check_admin_referer( 'bhg_close_hunt' );
+        $hunt_id       = isset( $_POST['hunt_id'] ) ? (int) $_POST['hunt_id'] : 0;
+        $final_balance = isset( $_POST['final_balance'] ) ? (float) $_POST['final_balance'] : 0;
+        if ( $hunt_id ) {
+            BHG_Models::close_hunt( $hunt_id, $final_balance );
         }
-        wp_redirect(admin_url('admin.php?page=bhg-bonus-hunts'));
+        wp_redirect( admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
         exit;
     }
 
+    /**
+     * Save or update an advertising entry.
+     */
     public function handle_save_ad() {
-        if (!current_user_can('manage_options')) wp_die(esc_html__('No permission', 'bonus-hunt-guesser'));
-        check_admin_referer('bhg_save_ad');
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+        }
+        check_admin_referer( 'bhg_save_ad' );
         global $wpdb;
         $table = $wpdb->prefix . 'bhg_ads';
 
@@ -255,47 +343,58 @@ class BHG_Admin {
         wp_redirect(admin_url('admin.php?page=bhg-ads')); exit;
     }
 
+    /**
+     * Save a tournament record.
+     */
     public function handle_save_tournament() {
-    if (!current_user_can('manage_options')) {
-        wp_redirect(add_query_arg('bhg_msg','noaccess', admin_url('admin.php?page=bhg-tournaments')));
-        exit;
-    }
-    if (!check_admin_referer('bhg_tournament_save_action')) {
-        wp_redirect(add_query_arg('bhg_msg','nonce', admin_url('admin.php?page=bhg-tournaments')));
-        exit;
-    }
-    global $wpdb;
-    $t = $wpdb->prefix . 'bhg_tournaments';
-    $id    = isset($_POST['id']) ? (int)$_POST['id'] : 0;
-    $data  = [
-        'title'       => isset($_POST['title']) ? sanitize_text_field(wp_unslash($_POST['title'])) : '',
-        'description' => isset($_POST['description']) ? wp_kses_post(wp_unslash($_POST['description'])) : '',
-        'type'        => isset($_POST['type']) ? sanitize_text_field(wp_unslash($_POST['type'])) : 'weekly',
-        'start_date'  => isset($_POST['start_date']) ? sanitize_text_field(wp_unslash($_POST['start_date'])) : null,
-        'end_date'    => isset($_POST['end_date']) ? sanitize_text_field(wp_unslash($_POST['end_date'])) : null,
-        'status'      => isset($_POST['status']) ? sanitize_text_field(wp_unslash($_POST['status'])) : 'active',
-        'updated_at'  => current_time('mysql')
-    ];
-    try {
-        $format = ['%s','%s','%s','%s','%s','%s','%s'];
-        if ($id > 0) {
-            $wpdb->update($t, $data, ['id'=>$id], $format, ['%d']);
-        } else {
-            $data['created_at'] = current_time('mysql');
-            $format[] = '%s';
-            $wpdb->insert($t, $data, $format);
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_redirect( add_query_arg( 'bhg_msg', 'noaccess', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+            exit;
         }
-        wp_redirect(add_query_arg('bhg_msg','t_saved', admin_url('admin.php?page=bhg-tournaments')));
-        exit;
-    } catch (Throwable $e) {
-        if (function_exists('error_log')) error_log('[BHG] tournament save error: ' . $e->getMessage());
-        wp_redirect(add_query_arg('bhg_msg','t_error', admin_url('admin.php?page=bhg-tournaments')));
-        exit;
+        if ( ! check_admin_referer( 'bhg_tournament_save_action' ) ) {
+            wp_redirect( add_query_arg( 'bhg_msg', 'nonce', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+            exit;
+        }
+        global $wpdb;
+        $t  = $wpdb->prefix . 'bhg_tournaments';
+        $id = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
+        $data = [
+            'title'       => isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '',
+            'description' => isset( $_POST['description'] ) ? wp_kses_post( wp_unslash( $_POST['description'] ) ) : '',
+            'type'        => isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'weekly',
+            'start_date'  => isset( $_POST['start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['start_date'] ) ) : null,
+            'end_date'    => isset( $_POST['end_date'] ) ? sanitize_text_field( wp_unslash( $_POST['end_date'] ) ) : null,
+            'status'      => isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active',
+            'updated_at'  => current_time( 'mysql' ),
+        ];
+        try {
+            $format = [ '%s', '%s', '%s', '%s', '%s', '%s', '%s' ];
+            if ( $id > 0 ) {
+                $wpdb->update( $t, $data, [ 'id' => $id ], $format, [ '%d' ] );
+            } else {
+                $data['created_at'] = current_time( 'mysql' );
+                $format[]           = '%s';
+                $wpdb->insert( $t, $data, $format );
+            }
+            wp_redirect( add_query_arg( 'bhg_msg', 't_saved', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+            exit;
+        } catch ( Throwable $e ) {
+            if ( function_exists( 'error_log' ) ) {
+                error_log( '[BHG] tournament save error: ' . $e->getMessage() );
+            }
+            wp_redirect( add_query_arg( 'bhg_msg', 't_error', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+            exit;
+        }
     }
-}
-public function handle_save_affiliate() {
-        if (!current_user_can('manage_options')) wp_die(esc_html__('No permission', 'bonus-hunt-guesser'));
-        check_admin_referer('bhg_save_affiliate');
+
+    /**
+     * Save or update an affiliate record.
+     */
+    public function handle_save_affiliate() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+        }
+        check_admin_referer( 'bhg_save_affiliate' );
         global $wpdb;
         $table = $wpdb->prefix . 'bhg_affiliates';
         $id    = isset($_POST['id']) ? (int) $_POST['id'] : 0;
@@ -316,9 +415,14 @@ public function handle_save_affiliate() {
         exit;
     }
 
+    /**
+     * Delete an affiliate.
+     */
     public function handle_delete_affiliate() {
-        if (!current_user_can('manage_options')) wp_die(esc_html__('No permission', 'bonus-hunt-guesser'));
-        check_admin_referer('bhg_delete_affiliate');
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+        }
+        check_admin_referer( 'bhg_delete_affiliate' );
         global $wpdb;
         $table = $wpdb->prefix . 'bhg_affiliates';
         $id = isset($_POST['id']) ? (int) $_POST['id'] : 0;
@@ -327,9 +431,14 @@ public function handle_save_affiliate() {
         exit;
     }
 
+    /**
+     * Save plugin settings.
+     */
     public function handle_save_settings() {
-        if (!current_user_can('manage_options')) wp_die(esc_html__('No permission', 'bonus-hunt-guesser'));
-        check_admin_referer('bhg_save_settings');
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+        }
+        check_admin_referer( 'bhg_save_settings' );
         $opts = [
             'allow_guess_edit_until_close' => isset($_POST['allow_guess_edit_until_close']) ? 'yes' : 'no',
             'guesses_max' => isset($_POST['guesses_max']) ? max(1, (int) $_POST['guesses_max']) : 1,
@@ -341,35 +450,44 @@ public function handle_save_affiliate() {
         exit;
     }
 
+    /**
+     * Save custom user metadata from the admin screen.
+     */
     public function handle_save_user_meta() {
-        if (!current_user_can('manage_options')) {
-            wp_die(esc_html__('No permission', 'bonus-hunt-guesser'));
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
         }
-        check_admin_referer('bhg_save_user_meta');
-        $user_id = isset($_POST['user_id']) ? (int) $_POST['user_id'] : 0;
-        if ($user_id) {
-            $real_name    = isset($_POST['bhg_real_name']) ? sanitize_text_field(wp_unslash($_POST['bhg_real_name'])) : '';
-            $is_affiliate = isset($_POST['bhg_is_affiliate']) ? 1 : 0;
-            update_user_meta($user_id, 'bhg_real_name', $real_name);
-            update_user_meta($user_id, 'bhg_is_affiliate', $is_affiliate);
+        check_admin_referer( 'bhg_save_user_meta' );
+        $user_id = isset( $_POST['user_id'] ) ? (int) $_POST['user_id'] : 0;
+        if ( $user_id ) {
+            $real_name    = isset( $_POST['bhg_real_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bhg_real_name'] ) ) : '';
+            $is_affiliate = isset( $_POST['bhg_is_affiliate'] ) ? 1 : 0;
+            update_user_meta( $user_id, 'bhg_real_name', $real_name );
+            update_user_meta( $user_id, 'bhg_is_affiliate', $is_affiliate );
         }
-        wp_redirect(admin_url('admin.php?page=bhg-users'));
+        wp_redirect( admin_url( 'admin.php?page=bhg-users' ) );
         exit;
     }
 
-
+    /**
+     * Display admin notices for tournament actions.
+     */
     public function admin_notices() {
-        if (!current_user_can('manage_options')) return;
-        if (!isset($_GET['bhg_msg'])) return;
-        $msg = sanitize_text_field(wp_unslash($_GET['bhg_msg']));
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        if ( ! isset( $_GET['bhg_msg'] ) ) {
+            return;
+        }
+        $msg = sanitize_text_field( wp_unslash( $_GET['bhg_msg'] ) );
         $map = [
-            't_saved'   => __('Tournament saved.', 'bonus-hunt-guesser'),
-            't_error'   => __('Could not save tournament. Check logs.', 'bonus-hunt-guesser'),
-            'nonce'     => __('Security check failed. Please retry.', 'bonus-hunt-guesser'),
-            'noaccess'  => __('You do not have permission to do that.', 'bonus-hunt-guesser'),
+            't_saved'  => __( 'Tournament saved.', 'bonus-hunt-guesser' ),
+            't_error'  => __( 'Could not save tournament. Check logs.', 'bonus-hunt-guesser' ),
+            'nonce'    => __( 'Security check failed. Please retry.', 'bonus-hunt-guesser' ),
+            'noaccess' => __( 'You do not have permission to do that.', 'bonus-hunt-guesser' ),
         ];
-        $class = (strpos($msg, 'error') !== false || $msg === 'nonce' || $msg === 'noaccess') ? 'notice notice-error' : 'notice notice-success';
-        $text = isset($map[$msg]) ? $map[$msg] : esc_html($msg);
-        echo '<div class="' . esc_attr($class) . '"><p>' . esc_html($text) . '</p></div>';
+        $class = ( strpos( $msg, 'error' ) !== false || 'nonce' === $msg || 'noaccess' === $msg ) ? 'notice notice-error' : 'notice notice-success';
+        $text  = isset( $map[ $msg ] ) ? $map[ $msg ] : esc_html( $msg );
+        echo '<div class="' . esc_attr( $class ) . '"><p>' . esc_html( $text ) . '</p></div>';
     }
 }

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -11,20 +11,23 @@ if (!class_exists('BHG_Shortcodes')) {
 
 class BHG_Shortcodes {
 
+    /**
+     * Register plugin shortcodes.
+     */
     public function __construct() {
-        // Register shortcodes once
-        add_shortcode('bhg_active_hunt',        array($this, 'active_hunt_shortcode'));
-        add_shortcode('bhg_guess_form',         array($this, 'guess_form_shortcode'));
-        add_shortcode('bhg_leaderboard',        array($this, 'leaderboard_shortcode'));
-        add_shortcode('bhg_tournaments',        array($this, 'tournaments_shortcode'));
-        add_shortcode('bhg_winner_notifications', array($this, 'winner_notifications_shortcode'));
-        add_shortcode('bhg_user_profile',       array($this, 'user_profile_shortcode'));
-        add_shortcode('bhg_best_guessers',      array($this, 'best_guessers_shortcode'));
+        // Register shortcodes once.
+        add_shortcode( 'bhg_active_hunt', array( $this, 'active_hunt_shortcode' ) );
+        add_shortcode( 'bhg_guess_form', array( $this, 'guess_form_shortcode' ) );
+        add_shortcode( 'bhg_leaderboard', array( $this, 'leaderboard_shortcode' ) );
+        add_shortcode( 'bhg_tournaments', array( $this, 'tournaments_shortcode' ) );
+        add_shortcode( 'bhg_winner_notifications', array( $this, 'winner_notifications_shortcode' ) );
+        add_shortcode( 'bhg_user_profile', array( $this, 'user_profile_shortcode' ) );
+        add_shortcode( 'bhg_best_guessers', array( $this, 'best_guessers_shortcode' ) );
 
-        // Legacy/alias tags if your site used alternatives
-        add_shortcode('bonus_hunt_leaderboard', array($this, 'leaderboard_shortcode'));
-        add_shortcode('bonus_hunt_login',       array($this, 'login_hint_shortcode'));
-        add_shortcode('bhg_active',             array($this, 'active_hunt_shortcode'));
+        // Legacy/alias tags if your site used alternatives.
+        add_shortcode( 'bonus_hunt_leaderboard', array( $this, 'leaderboard_shortcode' ) );
+        add_shortcode( 'bonus_hunt_login', array( $this, 'login_hint_shortcode' ) );
+        add_shortcode( 'bhg_active', array( $this, 'active_hunt_shortcode' ) );
     }
 
     /** Minimal login hint used by some themes */


### PR DESCRIPTION
## Summary
- add missing PHPDoc blocks for admin handlers and pages
- document shortcode registrations and helper utilities
- apply WordPress-style spacing and line wrapping

## Testing
- `php -l admin/class-bhg-admin.php`
- `php -l includes/class-bhg-shortcodes.php`
- `php -l includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68bab2d7529083338ab88ed58ac2a49f