### PR TITLE
Remove nonexistent menu class from autoloader

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -152,7 +152,6 @@ spl_autoload_register(function ($class) {
         'BHG_Logger' => 'includes/class-bhg-logger.php',
         'BHG_Settings' => 'includes/class-bhg-settings.php',
         'BHG_Utils' => 'includes/class-bhg-utils.php',
-        'BHG_Menus' => 'includes/class-bhg-menus.php',
         'BHG_Models' => 'includes/class-bhg-models.php',
         'BHG_Front_Menus' => 'includes/class-bhg-front-menus.php',
         'BHG_Demo' => 'admin/class-bhg-demo.php',


### PR DESCRIPTION
## Summary
- remove BHG_Menus from autoloader class map to reference only existing files

## Testing
- `php -l bonus-hunt-guesser.php`
- `phpcs bonus-hunt-guesser.php` *(fails: command not found)*
- `for f in admin/class-bhg-admin.php includes/class-bhg-shortcodes.php includes/class-bhg-logger.php includes/class-bhg-settings.php includes/class-bhg-utils.php includes/class-bhg-models.php includes/class-bhg-front-menus.php admin/class-bhg-demo.php; do [ -f "$f" ] && echo "$f ok" || echo "$f missing"; done`


------
https://chatgpt.com/codex/tasks/task_e_68bab6325158833381f42146bf76fd5f