### PR TITLE
Refactor guess submission handler

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -381,14 +381,6 @@ function bhg_handle_settings_save() {
     exit;
 }
 
-// Form handler for guess submission (frontend)
-/**
- * Proxy handler for guess submissions.
- *
- * @return void
- */
-function bhg_handle_guess_submission() { return bhg_handle_submit_guess(); }
-
 // Canonical guess submit handler
 /**
  * Process a guess submission from admin-post or AJAX.


### PR DESCRIPTION
## Summary
- centralize guess handling with `bhg_handle_submit_guess`
- remove redundant class-based guess submission logic

## Testing
- `php -l bonus-hunt-guesser.php`
- `php -l includes/class-bhg-models.php`
- `phpcs --standard=WordPress --report=summary bonus-hunt-guesser.php includes/class-bhg-models.php`


------
https://chatgpt.com/codex/tasks/task_e_68bab840d2888333a84b7a87bf5e629b