### PR TITLE
Unify affiliate status meta key

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -740,7 +740,7 @@ function bhg_is_affiliate( $user_id = null ) {
         return false;
     }
 
-    return (bool) get_user_meta($user_id, 'bhg_affiliate_status', true);
+    return (bool) get_user_meta($user_id, 'bhg_is_affiliate', true);
 }
 
 // Add user profile fields for affiliate status
@@ -758,14 +758,14 @@ function bhg_extra_user_profile_fields( $user ) {
         return;
     }
     
-    $affiliate_status = get_user_meta($user->ID, 'bhg_affiliate_status', true);
+    $affiliate_status = get_user_meta($user->ID, 'bhg_is_affiliate', true);
     ?>
     <h3><?php esc_html_e('Bonus Hunt Guesser Information', 'bonus-hunt-guesser'); ?></h3>
     <table class="form-table">
         <tr>
-            <th><label for="bhg_affiliate_status"><?php esc_html_e('Affiliate Status', 'bonus-hunt-guesser'); ?></label></th>
+            <th><label for="bhg_is_affiliate"><?php esc_html_e('Affiliate Status', 'bonus-hunt-guesser'); ?></label></th>
             <td>
-                <input type="checkbox" name="bhg_affiliate_status" id="bhg_affiliate_status" value="1" <?php checked($affiliate_status, 1); ?> />
+                <input type="checkbox" name="bhg_is_affiliate" id="bhg_is_affiliate" value="1" <?php checked($affiliate_status, 1); ?> />
                 <span class="description"><?php esc_html_e('Check if this user is an affiliate.', 'bonus-hunt-guesser'); ?></span>
             </td>
         </tr>
@@ -787,8 +787,8 @@ function bhg_save_extra_user_profile_fields( $user_id ) {
         return false;
     }
 
-    $affiliate_status = isset($_POST['bhg_affiliate_status']) ? 1 : 0;
-    update_user_meta($user_id, 'bhg_affiliate_status', $affiliate_status);
+    $affiliate_status = isset($_POST['bhg_is_affiliate']) ? 1 : 0;
+    update_user_meta($user_id, 'bhg_is_affiliate', $affiliate_status);
 }
 
 if (!function_exists('bhg_self_heal_db')) {

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -21,7 +21,7 @@ class BHG_Ads {
     protected static function user_is_affiliate() {
         if (!is_user_logged_in()) return false;
         $uid = get_current_user_id();
-        return (bool) get_user_meta($uid, 'bhg_affiliate_status', true);
+        return (bool) get_user_meta($uid, 'bhg_is_affiliate', true);
     }
 
     /** Whether current visitor matches the ad's visibility setting. */

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -195,7 +195,7 @@ class BHG_Shortcodes {
             $site_id = isset($r->affiliate_site_id) ? (int)$r->affiliate_site_id : 0;
             $is_aff  = $site_id > 0
                 ? (int)get_user_meta((int)$r->user_id, 'bhg_affiliate_website_' . $site_id, true)
-                : (int)get_user_meta((int)$r->user_id, 'bhg_affiliate_status', true);
+                : (int)get_user_meta((int)$r->user_id, 'bhg_is_affiliate', true);
             $aff = $is_aff ? 'green' : 'red';
             $user_label = $r->user_login ? $r->user_login : ('user#' . (int)$r->user_id);
 
@@ -439,7 +439,7 @@ class BHG_Shortcodes {
     public function user_profile_shortcode($atts) {
         if (!is_user_logged_in()) return '<p>' . esc_html__('Please log in to view this content.', 'bonus-hunt-guesser') . '</p>';
         $user_id = get_current_user_id();
-        $is_affiliate = (int)get_user_meta($user_id, 'bhg_affiliate_status', true);
+        $is_affiliate = (int)get_user_meta($user_id, 'bhg_is_affiliate', true);
         $badge = $is_affiliate ? '<span class="bhg-aff-green" aria-hidden="true"></span>' : '<span class="bhg-aff-red" aria-hidden="true"></span>';
         return '<div class="bhg-user-profile">' . $badge . ' ' . esc_html(wp_get_current_user()->display_name) . '</div>';
     }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -317,7 +317,7 @@ function bhg_render_ads( $placement = 'footer', $hunt_id = 0 ) {
             $uid = get_current_user_id();
             $show = $hunt_site_id > 0
                 ? bhg_is_user_affiliate_for_site($uid, $hunt_site_id)
-                : (bool) get_user_meta($uid, 'bhg_affiliate_status', true);
+                : (bool) get_user_meta($uid, 'bhg_is_affiliate', true);
         }
         if (!$show) continue;
         $msg  = wp_kses_post($r->content);


### PR DESCRIPTION
## Summary
- standardize all affiliate status checks to use the `bhg_is_affiliate` user meta key
- update helpers, shortcodes, ads, and profile handlers to read/write the unified key

## Testing
- `php -l bonus-hunt-guesser.php`
- `php -l includes/class-bhg-ads.php`
- `php -l includes/class-bhg-shortcodes.php`
- `php -l includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68babc9d57948333a0cd580e2aa25d08