### PR TITLE
Use safe redirects in admin modules

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -173,7 +173,7 @@ class BHG_Admin {
         if ( $guess_id ) {
             $wpdb->delete( $guesses_table, [ 'id' => $guess_id ], [ '%d' ] );
         }
-        wp_redirect( wp_get_referer() ?: admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+        wp_safe_redirect( wp_get_referer() ?: admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
         exit;
     }
 
@@ -279,7 +279,7 @@ class BHG_Admin {
             }
         }
 
-        wp_redirect(admin_url('admin.php?page=bhg-bonus-hunts'));
+        wp_safe_redirect(admin_url('admin.php?page=bhg-bonus-hunts'));
         exit;
     }
 
@@ -296,7 +296,7 @@ class BHG_Admin {
         $final_balance_raw  = isset( $_POST['final_balance'] ) ? sanitize_text_field( wp_unslash( $_POST['final_balance'] ) ) : '';
 
         if ( '' === $final_balance_raw || ! is_numeric( $final_balance_raw ) || (float) $final_balance_raw < 0 ) {
-            wp_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
+            wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
             exit;
         }
 
@@ -306,7 +306,7 @@ class BHG_Admin {
             BHG_Models::close_hunt( $hunt_id, $final_balance );
         }
 
-        wp_redirect( admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+        wp_safe_redirect( admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
         exit;
     }
 
@@ -350,7 +350,8 @@ class BHG_Admin {
             $wpdb->insert($table, $data, $format);
         }
 
-        wp_redirect(admin_url('admin.php?page=bhg-ads')); exit;
+        wp_safe_redirect( admin_url( 'admin.php?page=bhg-ads' ) );
+        exit;
     }
 
     /**
@@ -358,11 +359,11 @@ class BHG_Admin {
      */
     public function handle_save_tournament() {
         if ( ! current_user_can( 'manage_options' ) ) {
-            wp_redirect( add_query_arg( 'bhg_msg', 'noaccess', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+            wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
             exit;
         }
         if ( ! check_admin_referer( 'bhg_tournament_save_action' ) ) {
-            wp_redirect( add_query_arg( 'bhg_msg', 'nonce', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+            wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
             exit;
         }
         global $wpdb;
@@ -386,13 +387,13 @@ class BHG_Admin {
                 $format[]           = '%s';
                 $wpdb->insert( $t, $data, $format );
             }
-            wp_redirect( add_query_arg( 'bhg_msg', 't_saved', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+            wp_safe_redirect( add_query_arg( 'bhg_msg', 't_saved', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
             exit;
         } catch ( Throwable $e ) {
             if ( function_exists( 'error_log' ) ) {
                 error_log( '[BHG] tournament save error: ' . $e->getMessage() );
             }
-            wp_redirect( add_query_arg( 'bhg_msg', 't_error', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+            wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
             exit;
         }
     }
@@ -421,7 +422,7 @@ class BHG_Admin {
             $format[] = '%s';
             $wpdb->insert($table, $data, $format);
         }
-        wp_redirect(admin_url('admin.php?page=bhg-affiliates'));
+        wp_safe_redirect(admin_url('admin.php?page=bhg-affiliates'));
         exit;
     }
 
@@ -437,7 +438,7 @@ class BHG_Admin {
         $table = $wpdb->prefix . 'bhg_affiliates';
         $id = isset($_POST['id']) ? (int) $_POST['id'] : 0;
         if ($id) { $wpdb->delete($table, ['id'=>$id], ['%d']); }
-        wp_redirect(admin_url('admin.php?page=bhg-affiliates'));
+        wp_safe_redirect(admin_url('admin.php?page=bhg-affiliates'));
         exit;
     }
 
@@ -456,7 +457,7 @@ class BHG_Admin {
         foreach ($opts as $k => $v) {
             update_option('bhg_' . $k, $v, false);
         }
-        wp_redirect(admin_url('admin.php?page=bhg-settings&updated=1'));
+        wp_safe_redirect(admin_url('admin.php?page=bhg-settings&updated=1'));
         exit;
     }
 
@@ -475,7 +476,7 @@ class BHG_Admin {
             update_user_meta( $user_id, 'bhg_real_name', $real_name );
             update_user_meta( $user_id, 'bhg_is_affiliate', $is_affiliate );
         }
-        wp_redirect( admin_url( 'admin.php?page=bhg-users' ) );
+        wp_safe_redirect( admin_url( 'admin.php?page=bhg-users' ) );
         exit;
     }
 

--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -47,7 +47,7 @@ class BHG_Demo {
             'status'=>'active'
         ]);
 
-        wp_redirect(admin_url('admin.php?page=bhg_demo&demo_reset=1'));
+        wp_safe_redirect( admin_url( 'admin.php?page=bhg_demo&demo_reset=1' ) );
         exit;
     }
 }

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -14,7 +14,7 @@ $ad_id  = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
 if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
     if ( wp_verify_nonce( $_GET['_wpnonce'], 'bhg_delete_ad' ) && current_user_can( 'manage_options' ) ) {
         $wpdb->delete( $table, [ 'id' => $ad_id ], [ '%d' ] );
-        wp_redirect( remove_query_arg( [ 'action', 'id', '_wpnonce' ] ) );
+        wp_safe_redirect( remove_query_arg( [ 'action', 'id', '_wpnonce' ] ) );
         exit;
     }
 }


### PR DESCRIPTION
## Summary
- Replace `wp_redirect()` with `wp_safe_redirect()` across admin handlers and views
- Ensure execution stops with `exit` after each redirect

## Testing
- `php -l admin/class-bhg-admin.php`
- `php -l admin/views/advertising.php`
- `php -l admin/class-bhg-demo.php`


------
https://chatgpt.com/codex/tasks/task_e_68babfde41048333a36e8ce1cc9d47f9