### PR TITLE
Sanitize login redirect destinations

### DIFF
--- a/includes/class-bhg-login-redirect.php
+++ b/includes/class-bhg-login-redirect.php
@@ -1,34 +1,55 @@
 <?php
-if (!defined('ABSPATH')) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
-if (!class_exists('BHG_Login_Redirect')) {
-class BHG_Login_Redirect {
-    public function __construct() {
-        add_filter('login_redirect', array($this, 'core_login_redirect'), 10, 3);
+if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
+    class BHG_Login_Redirect {
 
-        // Nextend Social Login compatibility if plugin active
-        if (function_exists('NextendSocialLogin')) {
-            add_filter('nsl_login_redirect', array($this, 'nextend_redirect'), 10, 3);
+        public function __construct() {
+            add_filter( 'login_redirect', array( $this, 'core_login_redirect' ), 10, 3 );
+
+            // Nextend Social Login compatibility if plugin active.
+            if ( function_exists( 'NextendSocialLogin' ) ) {
+                add_filter( 'nsl_login_redirect', array( $this, 'nextend_redirect' ), 10, 3 );
+            }
+        }
+
+        public function core_login_redirect( $redirect_to, $requested, $user ) {
+            if ( ! empty( $_REQUEST['redirect_to'] ) ) {
+                $requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );
+                $validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
+                return esc_url_raw( $validated_redirect );
+            }
+
+            // Fall back to referer if safe.
+            $ref = wp_get_referer();
+            if ( $ref ) {
+                $validated_ref = wp_validate_redirect( $ref, home_url( '/' ) );
+                return esc_url_raw( $validated_ref );
+            }
+
+            $validated_default = wp_validate_redirect( $redirect_to, home_url( '/' ) );
+            return esc_url_raw( $validated_default );
+        }
+
+        public function nextend_redirect( $redirect_to, $user, $provider ) {
+            if ( ! empty( $_REQUEST['redirect_to'] ) ) {
+                $requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );
+                $validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
+                return esc_url_raw( $validated_redirect );
+            }
+
+            $ref = wp_get_referer();
+            if ( $ref ) {
+                $validated_ref = wp_validate_redirect( $ref, home_url( '/' ) );
+                return esc_url_raw( $validated_ref );
+            }
+
+            $validated_default = wp_validate_redirect( $redirect_to, home_url( '/' ) );
+            return esc_url_raw( $validated_default );
         }
     }
-
-    public function core_login_redirect($redirect_to, $requested, $user) {
-        if (!empty($_REQUEST['redirect_to'])) {
-            return esc_url_raw($_REQUEST['redirect_to']);
-        }
-        // Fall back to referer if safe
-        $ref = wp_get_referer();
-        if ($ref) { return esc_url_raw($ref); }
-        return $redirect_to ?: home_url('/');
-    }
-
-    public function nextend_redirect($redirect_to, $user, $provider) {
-        if (!empty($_REQUEST['redirect_to'])) {
-            return esc_url_raw($_REQUEST['redirect_to']);
-        }
-        $ref = wp_get_referer();
-        if ($ref) { return esc_url_raw($ref); }
-        return $redirect_to ?: home_url('/');
-    }
-}}
+}
 new BHG_Login_Redirect();
+


### PR DESCRIPTION
## Summary
- Sanitize and validate requested login redirects using `sanitize_text_field` and `wp_validate_redirect`
- Provide `home_url('/')` fallback for invalid or unsafe redirect targets

## Testing
- `php -l includes/class-bhg-login-redirect.php`


------
https://chatgpt.com/codex/tasks/task_e_68bac0892ba0833387de78dd28eabec6