### PR TITLE
Fix missing Dashboard submenu for Bonus Hunt admin

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -49,9 +49,20 @@ class BHG_Admin {
         add_submenu_page($slug, __('Translations', 'bonus-hunt-guesser'),__('Translations', 'bonus-hunt-guesser'),$cap, 'bhg-translations',            [$this, 'translations']);
         add_submenu_page($slug, __('Database', 'bonus-hunt-guesser'),    __('Database', 'bonus-hunt-guesser'),    $cap, 'bhg-database',                [$this, 'database']);
         add_submenu_page($slug, __('Settings', 'bonus-hunt-guesser'),    __('Settings', 'bonus-hunt-guesser'),    $cap, 'bhg-settings',                [$this, 'settings']);
-        add_submenu_page($slug, __('BHG Tools', 'bonus-hunt-guesser'),   __('BHG Tools', 'bonus-hunt-guesser'),   $cap, 'bhg-tools',                   [$this, 'bhg_tools_page']);
+        add_submenu_page(
+            $slug,
+            __('BHG Tools', 'bonus-hunt-guesser'),
+            __('BHG Tools', 'bonus-hunt-guesser'),
+            $cap,
+            'bhg-tools',
+            [$this, 'bhg_tools_page']
+        );
 
-        remove_submenu_page($slug, $slug);
+        // NOTE: By default, WordPress adds a submenu item that duplicates the
+        // top-level “Bonus Hunt” menu. The previous `remove_submenu_page()`
+        // call removed this submenu, but it also inadvertently removed our
+        // custom “Dashboard” submenu. Removing the call ensures the Dashboard
+        // item remains visible under the "Bonus Hunt" menu.
     }
 
     /** Enqueue admin assets on BHG screens. */


### PR DESCRIPTION
## Summary
- ensure Bonus Hunt Dashboard submenu remains by removing `remove_submenu_page()` call
- document rationale for keeping Dashboard entry under Bonus Hunt menu

## Testing
- `php -l admin/class-bhg-admin.php`
- `php -r '$menu=$submenu=[];function add_menu_page($a,$b,$c,$d,$e="",$f="",$g=null){global $menu,$submenu;$menu[]=["menu_title"=>$b,"slug"=>$d];$submenu[$d][]=["menu_title"=>$b,"slug"=>$d];}function add_submenu_page($p,$a,$b,$c,$d,$e=""){global $submenu;$submenu[$p][]=["menu_title"=>$b,"slug"=>$d];} $cap="manage_options"; $slug="bhg"; add_menu_page("Bonus Hunt","Bonus Hunt",$cap,$slug); add_submenu_page($slug,"Dashboard","Dashboard",$cap,$slug); var_export($submenu[$slug]);'`


------
https://chatgpt.com/codex/tasks/task_e_68bac9868da88333b5f52792a8f49004