### PR TITLE
Require bonus hunt helper functions

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -166,6 +166,7 @@ spl_autoload_register( function ( $class ) {
 
 // Include helper functions
 require_once BHG_PLUGIN_DIR . 'includes/helpers.php';
+require_once BHG_PLUGIN_DIR . 'includes/class-bhg-bonus-hunts-helpers.php';
 
 // Activation hook: create tables and set default options
 /**


### PR DESCRIPTION
## Summary
- load bonus hunt helper functions so Latest Hunts dashboard can show winners

## Testing
- `php -l bonus-hunt-guesser.php`
- `php -l includes/class-bhg-bonus-hunts-helpers.php`
- `php <<'PHP' ... ?>` (dashboard view shows winners)


------
https://chatgpt.com/codex/tasks/task_e_68baca258d2c83338576353e514a1002