### PR TITLE
Sanitize admin notice page parameter

### DIFF
--- a/includes/class-bhg-front-menus.php
+++ b/includes/class-bhg-front-menus.php
@@ -47,7 +47,8 @@ class BHG_Front_Menus {
 /* STAGE-5 MENU HELP */
 if (is_admin()) {
     add_action('admin_notices', function(){
-        if (isset($_GET['page']) && strpos($_GET['page'],'bhg')!==false) {
+        $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+        if ( strpos( $page, 'bhg' ) !== false ) {
             echo '<div class="notice notice-info"><p>';
             esc_html_e('Reminder: Assign your BHG menus (Admin/Moderator, Logged-in, Guest) under Appearance → Menus → Manage Locations. Use shortcode [bhg_nav] to display.', 'bonus-hunt-guesser');
             echo '</p></div>';


### PR DESCRIPTION
## Summary
- Sanitize the `page` query parameter before using it in the admin notice callback

## Testing
- `php -l includes/class-bhg-front-menus.php`


------
https://chatgpt.com/codex/tasks/task_e_68bacad2a5f88333a02c7e7932fd321f