### PR TITLE
Sanitize login redirect parameter

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -52,7 +52,7 @@ function bhg_admin_cap() {
 
 // Smart login redirect back to referring page.
 add_filter( 'login_redirect', function( $redirect_to, $requested_redirect_to, $user ) {
-    $r = isset( $_REQUEST['bhg_redirect'] ) ? $_REQUEST['bhg_redirect'] : '';
+    $r = isset( $_REQUEST['bhg_redirect'] ) ? wp_unslash( $_REQUEST['bhg_redirect'] ) : '';
     if ( ! empty( $r ) ) {
         $safe     = esc_url_raw( $r );
         $home_host = wp_parse_url( home_url(), PHP_URL_HOST );


### PR DESCRIPTION
## Summary
- sanitize `bhg_redirect` request parameter with `wp_unslash` before `esc_url_raw`

## Testing
- `php -l includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad170c8c08333994827ebad5d0810