### PR TITLE
Add quarterly and all-time tournament period options

### DIFF
--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -68,8 +68,14 @@ if (!empty($error)) {
                         <option value="monthly" <?php selected($current_settings['default_tournament_period'], 'monthly'); ?>>
                             <?php _e('Monthly', 'bonus-hunt-guesser'); ?>
                         </option>
+                        <option value="quarterly" <?php selected($current_settings['default_tournament_period'], 'quarterly'); ?>>
+                            <?php _e('Quarterly', 'bonus-hunt-guesser'); ?>
+                        </option>
                         <option value="yearly" <?php selected($current_settings['default_tournament_period'], 'yearly'); ?>>
                             <?php _e('Yearly', 'bonus-hunt-guesser'); ?>
+                        </option>
+                        <option value="alltime" <?php selected($current_settings['default_tournament_period'], 'alltime'); ?>>
+                            <?php _e('All-Time', 'bonus-hunt-guesser'); ?>
                         </option>
                     </select>
                     <p class="description">

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -338,7 +338,7 @@ function bhg_handle_settings_save() {
 
     if ( isset( $_POST['bhg_default_tournament_period'] ) ) {
         $period = sanitize_text_field( $_POST['bhg_default_tournament_period'] );
-        if ( in_array( $period, array( 'weekly', 'monthly', 'yearly' ) ) ) {
+        if ( in_array( $period, array( 'weekly', 'monthly', 'quarterly', 'yearly', 'alltime' ) ) ) {
             $settings['default_tournament_period'] = $period;
         }
     }


### PR DESCRIPTION
## Summary
- allow quarterly and all-time as default tournament periods
- expose quarterly and all-time options on settings page

## Testing
- `php -l bonus-hunt-guesser.php`
- `php -l admin/views/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad2f31a98833385a4ae79b33474d7