### PR TITLE
refactor: replace inline admin styles with classes

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -27,7 +27,7 @@ if ( 'list' === $view ) :
     <div class="notice notice-success is-dismissible"><p><?php echo esc_html__( 'Hunt closed successfully.', 'bonus-hunt-guesser' ); ?></p></div>
   <?php endif; ?>
 
-  <table class="widefat striped" style="margin-top:1em">
+  <table class="widefat striped bhg-margin-top-small">
     <thead>
       <tr>
         <th><?php echo esc_html__('ID', 'bonus-hunt-guesser'); ?></th>
@@ -76,7 +76,7 @@ if ( 'close' === $view ) :
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__( 'Close Bonus Hunt', 'bonus-hunt-guesser' ); ?> — <?php echo esc_html( $hunt->title ); ?></h1>
-  <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="max-width:400px;margin-top:1em">
+  <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-400 bhg-margin-top-small">
     <?php wp_nonce_field( 'bhg_close_hunt' ); ?>
     <input type="hidden" name="action" value="bhg_close_hunt" />
     <input type="hidden" name="hunt_id" value="<?php echo (int) $hunt->id; ?>" />
@@ -101,7 +101,7 @@ endif;
 if ($view === 'add') : ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Add New Bonus Hunt', 'bonus-hunt-guesser'); ?></h1>
-  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="max-width:900px;margin-top:1em">
+  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900 bhg-margin-top-small">
     <?php wp_nonce_field('bhg_save_hunt'); ?>
     <input type="hidden" name="action" value="bhg_save_hunt" />
 
@@ -173,7 +173,7 @@ if ($view === 'edit') :
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Edit Bonus Hunt', 'bonus-hunt-guesser'); ?> — <?php echo esc_html($hunt->title); ?></h1>
 
-  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="max-width:900px;margin-top:1em">
+  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900 bhg-margin-top-small">
     <?php wp_nonce_field('bhg_save_hunt'); ?>
     <input type="hidden" name="action" value="bhg_save_hunt" />
     <input type="hidden" name="id" value="<?php echo (int)$hunt->id; ?>" />
@@ -230,7 +230,7 @@ if ($view === 'edit') :
     <?php submit_button(__('Save Hunt', 'bonus-hunt-guesser')); ?>
   </form>
 
-  <h2 style="margin-top:2em"><?php echo esc_html__('Participants', 'bonus-hunt-guesser'); ?></h2>
+  <h2 class="bhg-margin-top-large"><?php echo esc_html__('Participants', 'bonus-hunt-guesser'); ?></h2>
   <table class="widefat striped">
     <thead>
       <tr>
@@ -253,7 +253,7 @@ if ($view === 'edit') :
           </td>
           <td><?php echo esc_html(number_format_i18n((float)($g->guess ?? 0), 2)); ?></td>
           <td>
-            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" onsubmit="return confirm('<?php echo esc_js(__('Delete this guess?', 'bonus-hunt-guesser')); ?>');" style="display:inline">
+            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" onsubmit="return confirm('<?php echo esc_js(__('Delete this guess?', 'bonus-hunt-guesser')); ?>');" class="bhg-inline-form">
               <?php wp_nonce_field('bhg_delete_guess'); ?>
               <input type="hidden" name="action" value="bhg_delete_guess">
               <input type="hidden" name="guess_id" value="<?php echo (int)$g->id; ?>">

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -14,7 +14,7 @@ $rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php esc_html_e('Tournaments', 'bonus-hunt-guesser'); ?></h1>
 
-  <h2 style="margin-top:1em"><?php esc_html_e('All Tournaments', 'bonus-hunt-guesser'); ?></h2>
+  <h2 class="bhg-margin-top-small"><?php esc_html_e('All Tournaments', 'bonus-hunt-guesser'); ?></h2>
   <table class="widefat striped">
     <thead>
       <tr>
@@ -46,8 +46,8 @@ $rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
     </tbody>
   </table>
 
-  <h2 style="margin-top:2em"><?php echo $row ? esc_html__('Edit Tournament', 'bonus-hunt-guesser') : esc_html__('Add Tournament', 'bonus-hunt-guesser'); ?></h2>
-  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="max-width:900px">
+  <h2 class="bhg-margin-top-large"><?php echo $row ? esc_html__('Edit Tournament', 'bonus-hunt-guesser') : esc_html__('Add Tournament', 'bonus-hunt-guesser'); ?></h2>
+  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900">
     <?php wp_nonce_field('bhg_tournament_save_action'); ?>
     <input type="hidden" name="action" value="bhg_tournament_save" />
     <?php if ($row): ?><input type="hidden" name="id" value="<?php echo (int)$row->id; ?>" /><?php endif; ?>

--- a/admin/views/users.php
+++ b/admin/views/users.php
@@ -32,7 +32,7 @@ $base_url = remove_query_arg(['paged']);
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Users', 'bonus-hunt-guesser'); ?></h1>
 
-  <form method="get" style="margin-top:1em">
+  <form method="get" class="bhg-margin-top-small">
     <input type="hidden" name="page" value="bhg-users" />
     <p class="search-box">
       <label class="screen-reader-text" for="user-search-input"><?php echo esc_html__('Search Users', 'bonus-hunt-guesser'); ?></label>
@@ -65,7 +65,7 @@ $base_url = remove_query_arg(['paged']);
           <td><?php echo esc_html($u->display_name); ?></td>
           <td><input type="text" name="bhg_real_name" form="<?php echo esc_attr($form_id); ?>" value="<?php echo esc_attr($real_name); ?>" /></td>
           <td><?php echo esc_html($u->user_email); ?></td>
-          <td style="text-align:center;"><input type="checkbox" name="bhg_is_affiliate" value="1" form="<?php echo esc_attr($form_id); ?>" <?php checked( $is_aff, 1 ); ?> /></td>
+          <td class="bhg-text-center"><input type="checkbox" name="bhg_is_affiliate" value="1" form="<?php echo esc_attr($form_id); ?>" <?php checked( $is_aff, 1 ); ?> /></td>
           <td>
             <form id="<?php echo esc_attr($form_id); ?>" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
               <input type="hidden" name="action" value="bhg_save_user_meta" />

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -23,3 +23,28 @@
 .bhg-winner-row {
     background-color: #d1fae5;
 }
+
+/* Utility classes */
+.bhg-margin-top-small {
+    margin-top: 1em;
+}
+
+.bhg-margin-top-large {
+    margin-top: 2em;
+}
+
+.bhg-max-width-400 {
+    max-width: 400px;
+}
+
+.bhg-max-width-900 {
+    max-width: 900px;
+}
+
+.bhg-inline-form {
+    display: inline;
+}
+
+.bhg-text-center {
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- replace inline styles in Bonus Hunts admin page with utility classes
- use new classes for Tournaments and Users admin views
- add reusable spacing and layout utilities in admin CSS

## Testing
- `php -l admin/views/bonus-hunts.php`
- `php -l admin/views/tournaments.php`
- `php -l admin/views/users.php`
- `php -l admin/views/bonus-hunts-results.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad3dac41883338493c04a6ceee243