### PR TITLE
chore: remove unused admin script

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -74,13 +74,16 @@ class BHG_Admin {
                 array(),
                 defined( 'BHG_VERSION' ) ? BHG_VERSION : null
             );
-            wp_enqueue_script(
-                'bhg-admin',
-                BHG_PLUGIN_URL . 'assets/js/admin.js',
-                array( 'jquery' ),
-                defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
-                true
-            );
+            $script_path = BHG_PLUGIN_DIR . 'assets/js/admin.js';
+            if ( file_exists( $script_path ) && filesize( $script_path ) > 0 ) {
+                wp_enqueue_script(
+                    'bhg-admin',
+                    BHG_PLUGIN_URL . 'assets/js/admin.js',
+                    array( 'jquery' ),
+                    defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
+                    true
+                );
+            }
         }
     }
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,1 +1,0 @@
-// Placeholder admin JS\n


### PR DESCRIPTION
## Summary
- remove placeholder admin.js
- enqueue admin script only when file exists and has content

## Testing
- `php -l admin/class-bhg-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad65e0bb48333a7ad8469538725bc