### PR TITLE
Fix table row closures in Bonus Hunt forms

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -126,7 +126,7 @@ if ($view === 'add') : ?>
         <tr>
           <th scope="row"><label for="bhg_prizes"><?php echo esc_html__('Prizes', 'bonus-hunt-guesser'); ?></label></th>
           <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"></textarea></td>
-        
+        </tr>
         <tr>
           <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
           <td>
@@ -215,7 +215,7 @@ if ($view === 'edit') :
         <tr>
           <th scope="row"><label for="bhg_prizes"><?php echo esc_html__('Prizes', 'bonus-hunt-guesser'); ?></label></th>
           <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"><?php echo esc_textarea($hunt->prizes); ?></textarea></td>
-        
+        </tr>
         <tr>
           <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
           <td>


### PR DESCRIPTION
## Summary
- properly close table rows after the prizes textarea in the add/edit bonus hunt forms to maintain valid markup

## Testing
- `php -l admin/views/bonus-hunts.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad85b66808333a87cb362ad5e1b94