### PR TITLE
Use explicit format array for guesses insert

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -501,7 +501,8 @@ function bhg_handle_submit_guess() {
             'user_id'    => $user_id,
             'guess'      => $guess,
             'created_at' => current_time( 'mysql' ),
-        ]
+        ],
+        [ '%d', '%d', '%f', '%s' ]
     );
 
     if ( wp_doing_ajax() ) {


### PR DESCRIPTION
## Summary
- Ensure guess submissions insert data with explicit formats

## Testing
- `php -l bonus-hunt-guesser.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad8d084d48333a68915b4fbd9445e