### PR TITLE
Sanitize table names and remove identifier placeholders

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -6,6 +6,11 @@ if (!current_user_can('manage_options')) {
 
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_ads';
+$allowed_tables = [ $wpdb->prefix . 'bhg_ads' ];
+if ( ! in_array( $table, $allowed_tables, true ) ) {
+    wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+}
+$table  = esc_sql( $table );
 
 $action = isset( $_GET['action'] ) ? sanitize_key( $_GET['action'] ) : '';
 $ad_id  = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
@@ -22,7 +27,7 @@ if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
 
 // Fetch ads
 $ads = $wpdb->get_results(
-    $wpdb->prepare( 'SELECT * FROM %i ORDER BY id DESC', $table )
+    "SELECT * FROM {$table} ORDER BY id DESC"
 );
 ?>
 <div class="wrap">
@@ -64,7 +69,7 @@ $ads = $wpdb->get_results(
     $ad = null;
     if (isset($_GET['edit'])) {
         $ad = $wpdb->get_row(
-            $wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, (int) $_GET['edit'] )
+            $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", (int) $_GET['edit'] )
         );
     }
   ?>

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -5,15 +5,18 @@ if (!current_user_can('manage_options')) {
 }
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_tournaments';
+$allowed_tables = [ $wpdb->prefix . 'bhg_tournaments' ];
+if ( ! in_array( $table, $allowed_tables, true ) ) {
+    wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+}
+$table   = esc_sql( $table );
 
 $edit_id = isset( $_GET['edit'] ) ? (int) $_GET['edit'] : 0;
 $row     = $edit_id
-    ? $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', $table, $edit_id ) )
+    ? $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id ) )
     : null;
 
-$rows = $wpdb->get_results(
-    $wpdb->prepare( 'SELECT * FROM %i ORDER BY id DESC', $table )
-);
+$rows = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY id DESC" );
 
 $labels = [
     'weekly'    => __( 'Weekly', 'bonus-hunt-guesser' ),


### PR DESCRIPTION
## Summary
- validate admin table names against expected identifiers and sanitize with `esc_sql`
- interpolate table names directly in bonus hunt, tournament and advertising queries
- retain `wpdb->prepare()` only for user-supplied values

## Testing
- `php -l admin/views/bonus-hunts.php`
- `php -l admin/views/tournaments.php`
- `php -l admin/views/advertising.php`


------
https://chatgpt.com/codex/tasks/task_e_68bae5dafc488333b1891962a6cd3516