### PR TITLE
Ensure winners count column migration

### DIFF
--- a/includes/upgrade/add-winners-limit.php
+++ b/includes/upgrade/add-winners-limit.php
@@ -3,22 +3,28 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function bhg_upgrade_add_winners_limit_column(){
     global $wpdb;
-    $hunts = $wpdb->prefix . 'bhg_hunts';
+    $hunts = $wpdb->prefix . 'bhg_bonus_hunts';
     $charset_collate = $wpdb->get_charset_collate();
 
     require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-    // Ensure table exists & has winners_limit
-    $sql = "CREATE TABLE $hunts (
-        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-        title varchar(200) NOT NULL,
-        start_balance decimal(18,2) NOT NULL DEFAULT 0,
-        final_balance decimal(18,2) DEFAULT NULL,
-        winners_limit int unsigned NOT NULL DEFAULT 3,
-        status varchar(20) NOT NULL DEFAULT 'open',
-        closed_at datetime DEFAULT NULL,
-        PRIMARY KEY  (id)
-    ) $charset_collate;";
+    // Ensure table exists & has winners_count column
+    $sql = "CREATE TABLE {$hunts} (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        title VARCHAR(190) NOT NULL,
+        starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+        num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
+        prizes TEXT NULL,
+        affiliate_site_id BIGINT UNSIGNED NULL,
+        winners_count INT UNSIGNED NOT NULL DEFAULT 3,
+        final_balance DECIMAL(12,2) NULL,
+        status VARCHAR(20) NOT NULL DEFAULT 'open',
+        created_at DATETIME NULL,
+        updated_at DATETIME NULL,
+        closed_at DATETIME NULL,
+        PRIMARY KEY  (id),
+        KEY status (status)
+    ) {$charset_collate};";
 
-    dbDelta($sql);
+    dbDelta( $sql );
 }


### PR DESCRIPTION
## Summary
- align upgrade script with current database schema
- use prefixed `bhg_bonus_hunts` table and add `winners_count`

## Testing
- `php -l includes/upgrade/add-winners-limit.php`
- `wp eval-file /tmp/upgrade-test.php --allow-root --path=/usr/share/wordpress --url=example.com`
- `wp db query "SHOW TABLES LIKE 'wp_bhg_bonus_hunts';" --allow-root --path=/usr/share/wordpress --url=example.com`


------
https://chatgpt.com/codex/tasks/task_e_68bae6af223c83338e431252f44d4ee7