### PR TITLE
Escape wp_die messages in admin views

### DIFF
--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) wp_die(__('Insufficient permissions','bonus-hunt-guesser'));
+if (!current_user_can('manage_options')) wp_die(esc_html__('Insufficient permissions','bonus-hunt-guesser'));
 global $wpdb;
 $hunt_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $hunts = $wpdb->prefix.'bhg_bonus_hunts';

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -2,14 +2,14 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if (!current_user_can('manage_options')) {
-    wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }
 
 // Handle form submissions
 if (isset($_POST['bhg_action'])) {
     if ($_POST['bhg_action'] === 'db_cleanup' && isset($_POST['bhg_db_cleanup'])) {
         if (!wp_verify_nonce($_POST['bhg_nonce'], 'bhg_db_cleanup_action')) {
-            wp_die(__('Security check failed', 'bonus-hunt-guesser'));
+            wp_die(esc_html__('Security check failed', 'bonus-hunt-guesser'));
         }
         
         // Perform database cleanup
@@ -18,7 +18,7 @@ if (isset($_POST['bhg_action'])) {
     } 
     elseif ($_POST['bhg_action'] === 'db_optimize' && isset($_POST['bhg_db_optimize'])) {
         if (!wp_verify_nonce($_POST['bhg_nonce'], 'bhg_db_optimize_action')) {
-            wp_die(__('Security check failed', 'bonus-hunt-guesser'));
+            wp_die(esc_html__('Security check failed', 'bonus-hunt-guesser'));
         }
         
         // Perform database optimization

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -1,9 +1,9 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) { wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
+if (!current_user_can('manage_options')) { wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
 
 $hunt_id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
-if (!$hunt_id) { wp_die(__('Missing hunt id','bonus-hunt-guesser')); }
+if (!$hunt_id) { wp_die(esc_html__('Missing hunt id','bonus-hunt-guesser')); }
 
 check_admin_referer('bhg_edit_hunt_' . $hunt_id, 'bhg_nonce');
 
@@ -17,11 +17,11 @@ if (isset($_POST['bhg_remove_guess']) && isset($_POST['bhg_remove_guess_nonce'])
 }
 
 if (!function_exists('bhg_get_hunt') || !function_exists('bhg_get_hunt_participants')) {
-    wp_die(__('Missing helper functions. Please include class-bhg-bonus-hunts-helpers.php.', 'bonus-hunt-guesser'));
+    wp_die(esc_html__('Missing helper functions. Please include class-bhg-bonus-hunts-helpers.php.', 'bonus-hunt-guesser'));
 }
 
 $hunt = bhg_get_hunt($hunt_id);
-if (!$hunt) { wp_die(__('Hunt not found','bonus-hunt-guesser')); }
+if (!$hunt) { wp_die(esc_html__('Hunt not found','bonus-hunt-guesser')); }
 
 $paged = max(1, isset($_GET['ppaged']) ? (int) $_GET['ppaged'] : 1);
 $per_page = 30;

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
-if (!current_user_can('manage_options')) { wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
+if (!current_user_can('manage_options')) { wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser')); }
 
 global $wpdb;
 $t = $wpdb->prefix . 'bhg_hunts';

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -5,7 +5,7 @@ if (!defined('ABSPATH')) {
 
 // Check user capabilities
 if (!current_user_can('manage_options')) {
-    wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }
 
 // Get current settings

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -2,7 +2,7 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if (!current_user_can('manage_options')) {
-    wp_die(__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }
 
 global $wpdb;
@@ -19,7 +19,7 @@ $default_keys        = array_keys( $default_translations );
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bhg_save_translation'])) {
     // Verify nonce
     if (!isset($_POST['bhg_nonce']) || !wp_verify_nonce($_POST['bhg_nonce'], 'bhg_save_translation_action')) {
-        wp_die(__('Security check failed.', 'bonus-hunt-guesser'));
+        wp_die(esc_html__('Security check failed.', 'bonus-hunt-guesser'));
     }
 
     // Sanitize input


### PR DESCRIPTION
## Summary
- ensure wp_die error messages are safely escaped via `esc_html__`
- update admin views to replace `__` with `esc_html__` in `wp_die`

## Testing
- `php -l admin/views/bonus-hunts-results.php admin/views/hunts-list.php admin/views/hunts-edit.php admin/views/translations.php admin/views/settings.php admin/views/database.php`


------
https://chatgpt.com/codex/tasks/task_e_68baec2a944c833388f6a401ea7e30b3