### PR TITLE
Use tabs for PHP indentation

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -3,519 +3,519 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_Admin {
 
-    /**
-     * Initialize admin hooks and actions.
-     */
-    public function __construct() {
-        // Menus.
-        add_action( 'admin_menu', [ $this, 'menu' ] );
-        add_action( 'admin_notices', [ $this, 'admin_notices' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'assets' ] );
+	/**
+	 * Initialize admin hooks and actions.
+	 */
+	public function __construct() {
+		// Menus.
+		add_action( 'admin_menu', [ $this, 'menu' ] );
+		add_action( 'admin_notices', [ $this, 'admin_notices' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'assets' ] );
 
-        // Handlers.
-        add_action( 'admin_post_bhg_delete_guess', [ $this, 'handle_delete_guess' ] );
-        add_action( 'admin_post_bhg_save_hunt', [ $this, 'handle_save_hunt' ] );
-        add_action( 'admin_post_bhg_close_hunt', [ $this, 'handle_close_hunt' ] );
-        add_action( 'admin_post_bhg_save_ad', [ $this, 'handle_save_ad' ] );
-        add_action( 'admin_post_bhg_tournament_save', [ $this, 'handle_save_tournament' ] );
-        add_action( 'admin_post_bhg_save_affiliate', [ $this, 'handle_save_affiliate' ] );
-        add_action( 'admin_post_bhg_delete_affiliate', [ $this, 'handle_delete_affiliate' ] );
-        add_action( 'admin_post_bhg_save_settings', [ $this, 'handle_save_settings' ] );
-        add_action( 'admin_post_bhg_save_user_meta', [ $this, 'handle_save_user_meta' ] );
-    }
+		// Handlers.
+		add_action( 'admin_post_bhg_delete_guess', [ $this, 'handle_delete_guess' ] );
+		add_action( 'admin_post_bhg_save_hunt', [ $this, 'handle_save_hunt' ] );
+		add_action( 'admin_post_bhg_close_hunt', [ $this, 'handle_close_hunt' ] );
+		add_action( 'admin_post_bhg_save_ad', [ $this, 'handle_save_ad' ] );
+		add_action( 'admin_post_bhg_tournament_save', [ $this, 'handle_save_tournament' ] );
+		add_action( 'admin_post_bhg_save_affiliate', [ $this, 'handle_save_affiliate' ] );
+		add_action( 'admin_post_bhg_delete_affiliate', [ $this, 'handle_delete_affiliate' ] );
+		add_action( 'admin_post_bhg_save_settings', [ $this, 'handle_save_settings' ] );
+		add_action( 'admin_post_bhg_save_user_meta', [ $this, 'handle_save_user_meta' ] );
+	}
 
-    /** Register admin menus and pages */
-    public function menu() {
-        $cap  = 'manage_options';
-        $slug = 'bhg';
+	/** Register admin menus and pages */
+	public function menu() {
+		$cap  = 'manage_options';
+		$slug = 'bhg';
 
-        add_menu_page(
-            __('Bonus Hunt', 'bonus-hunt-guesser'),
-            __('Bonus Hunt', 'bonus-hunt-guesser'),
-            $cap,
-            $slug,
-            [$this, 'dashboard'],
-            'dashicons-awards',
-            55
-        );
+		add_menu_page(
+			__('Bonus Hunt', 'bonus-hunt-guesser'),
+			__('Bonus Hunt', 'bonus-hunt-guesser'),
+			$cap,
+			$slug,
+			[$this, 'dashboard'],
+			'dashicons-awards',
+			55
+		);
 
-        add_submenu_page($slug, __('Dashboard', 'bonus-hunt-guesser'),   __('Dashboard', 'bonus-hunt-guesser'),   $cap, $slug,                         [$this, 'dashboard']);
-        add_submenu_page($slug, __('Bonus Hunts', 'bonus-hunt-guesser'), __('Bonus Hunts', 'bonus-hunt-guesser'), $cap, 'bhg-bonus-hunts',             [$this, 'bonus_hunts']);
-        add_submenu_page($slug, __('Results', 'bonus-hunt-guesser'),     __('Results', 'bonus-hunt-guesser'),     $cap, 'bhg-bonus-hunts-results',     [$this, 'bonus_hunts_results']);
-        add_submenu_page($slug, __('Tournaments', 'bonus-hunt-guesser'), __('Tournaments', 'bonus-hunt-guesser'), $cap, 'bhg-tournaments',             [$this, 'tournaments']);
-        add_submenu_page($slug, __('Users', 'bonus-hunt-guesser'),       __('Users', 'bonus-hunt-guesser'),       $cap, 'bhg-users',                   [$this, 'users']);
-        add_submenu_page($slug, __('Affiliates', 'bonus-hunt-guesser'),  __('Affiliates', 'bonus-hunt-guesser'),  $cap, 'bhg-affiliates',              [$this, 'affiliates']);
-        add_submenu_page($slug, __('Advertising', 'bonus-hunt-guesser'), __('Advertising', 'bonus-hunt-guesser'), $cap, 'bhg-ads',                     [$this, 'advertising']);
-        add_submenu_page($slug, __('Translations', 'bonus-hunt-guesser'),__('Translations', 'bonus-hunt-guesser'),$cap, 'bhg-translations',            [$this, 'translations']);
-        add_submenu_page($slug, __('Database', 'bonus-hunt-guesser'),    __('Database', 'bonus-hunt-guesser'),    $cap, 'bhg-database',                [$this, 'database']);
-        add_submenu_page($slug, __('Settings', 'bonus-hunt-guesser'),    __('Settings', 'bonus-hunt-guesser'),    $cap, 'bhg-settings',                [$this, 'settings']);
-        add_submenu_page(
-            $slug,
-            __('BHG Tools', 'bonus-hunt-guesser'),
-            __('BHG Tools', 'bonus-hunt-guesser'),
-            $cap,
-            'bhg-tools',
-            [$this, 'bhg_tools_page']
-        );
+		add_submenu_page($slug, __('Dashboard', 'bonus-hunt-guesser'),   __('Dashboard', 'bonus-hunt-guesser'),   $cap, $slug,                         [$this, 'dashboard']);
+		add_submenu_page($slug, __('Bonus Hunts', 'bonus-hunt-guesser'), __('Bonus Hunts', 'bonus-hunt-guesser'), $cap, 'bhg-bonus-hunts',             [$this, 'bonus_hunts']);
+		add_submenu_page($slug, __('Results', 'bonus-hunt-guesser'),     __('Results', 'bonus-hunt-guesser'),     $cap, 'bhg-bonus-hunts-results',     [$this, 'bonus_hunts_results']);
+		add_submenu_page($slug, __('Tournaments', 'bonus-hunt-guesser'), __('Tournaments', 'bonus-hunt-guesser'), $cap, 'bhg-tournaments',             [$this, 'tournaments']);
+		add_submenu_page($slug, __('Users', 'bonus-hunt-guesser'),       __('Users', 'bonus-hunt-guesser'),       $cap, 'bhg-users',                   [$this, 'users']);
+		add_submenu_page($slug, __('Affiliates', 'bonus-hunt-guesser'),  __('Affiliates', 'bonus-hunt-guesser'),  $cap, 'bhg-affiliates',              [$this, 'affiliates']);
+		add_submenu_page($slug, __('Advertising', 'bonus-hunt-guesser'), __('Advertising', 'bonus-hunt-guesser'), $cap, 'bhg-ads',                     [$this, 'advertising']);
+		add_submenu_page($slug, __('Translations', 'bonus-hunt-guesser'),__('Translations', 'bonus-hunt-guesser'),$cap, 'bhg-translations',            [$this, 'translations']);
+		add_submenu_page($slug, __('Database', 'bonus-hunt-guesser'),    __('Database', 'bonus-hunt-guesser'),    $cap, 'bhg-database',                [$this, 'database']);
+		add_submenu_page($slug, __('Settings', 'bonus-hunt-guesser'),    __('Settings', 'bonus-hunt-guesser'),    $cap, 'bhg-settings',                [$this, 'settings']);
+		add_submenu_page(
+			$slug,
+			__('BHG Tools', 'bonus-hunt-guesser'),
+			__('BHG Tools', 'bonus-hunt-guesser'),
+			$cap,
+			'bhg-tools',
+			[$this, 'bhg_tools_page']
+		);
 
-        // NOTE: By default, WordPress adds a submenu item that duplicates the
-        // top-level “Bonus Hunt” menu. The previous `remove_submenu_page()`
-        // call removed this submenu, but it also inadvertently removed our
-        // custom “Dashboard” submenu. Removing the call ensures the Dashboard
-        // item remains visible under the "Bonus Hunt" menu.
-    }
+		// NOTE: By default, WordPress adds a submenu item that duplicates the
+		// top-level “Bonus Hunt” menu. The previous `remove_submenu_page()`
+		// call removed this submenu, but it also inadvertently removed our
+		// custom “Dashboard” submenu. Removing the call ensures the Dashboard
+		// item remains visible under the "Bonus Hunt" menu.
+	}
 
-    /** Enqueue admin assets on BHG screens. */
-    public function assets( $hook ) {
-        if ( strpos( $hook, 'bhg' ) !== false ) {
-            wp_enqueue_style(
-                'bhg-admin',
-                BHG_PLUGIN_URL . 'assets/css/admin.css',
-                array(),
-                defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-            );
-            $script_path = BHG_PLUGIN_DIR . 'assets/js/admin.js';
-            if ( file_exists( $script_path ) && filesize( $script_path ) > 0 ) {
-                wp_enqueue_script(
-                    'bhg-admin',
-                    BHG_PLUGIN_URL . 'assets/js/admin.js',
-                    array( 'jquery' ),
-                    defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
-                    true
-                );
-            }
-        }
-    }
+	/** Enqueue admin assets on BHG screens. */
+	public function assets( $hook ) {
+		if ( strpos( $hook, 'bhg' ) !== false ) {
+			wp_enqueue_style(
+				'bhg-admin',
+				BHG_PLUGIN_URL . 'assets/css/admin.css',
+				array(),
+				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+			);
+			$script_path = BHG_PLUGIN_DIR . 'assets/js/admin.js';
+			if ( file_exists( $script_path ) && filesize( $script_path ) > 0 ) {
+				wp_enqueue_script(
+					'bhg-admin',
+					BHG_PLUGIN_URL . 'assets/js/admin.js',
+					array( 'jquery' ),
+					defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
+					true
+				);
+			}
+		}
+	}
 
-    // -------------------- Views --------------------
-    /**
-     * Render the dashboard page.
-     */
-    public function dashboard() {
-        require BHG_PLUGIN_DIR . 'admin/views/dashboard.php';
-    }
+	// -------------------- Views --------------------
+	/**
+	 * Render the dashboard page.
+	 */
+	public function dashboard() {
+		require BHG_PLUGIN_DIR . 'admin/views/dashboard.php';
+	}
 
-    /**
-     * Render the bonus hunts page.
-     */
-    public function bonus_hunts() {
-        require BHG_PLUGIN_DIR . 'admin/views/bonus-hunts.php';
-    }
+	/**
+	 * Render the bonus hunts page.
+	 */
+	public function bonus_hunts() {
+		require BHG_PLUGIN_DIR . 'admin/views/bonus-hunts.php';
+	}
 
-    /**
-     * Render the bonus hunts results page.
-     */
-    public function bonus_hunts_results() {
-        require BHG_PLUGIN_DIR . 'admin/views/bonus-hunts-results.php';
-    }
+	/**
+	 * Render the bonus hunts results page.
+	 */
+	public function bonus_hunts_results() {
+		require BHG_PLUGIN_DIR . 'admin/views/bonus-hunts-results.php';
+	}
 
-    /**
-     * Render the tournaments page.
-     */
-    public function tournaments() {
-        require BHG_PLUGIN_DIR . 'admin/views/tournaments.php';
-    }
+	/**
+	 * Render the tournaments page.
+	 */
+	public function tournaments() {
+		require BHG_PLUGIN_DIR . 'admin/views/tournaments.php';
+	}
 
-    /**
-     * Render the users page.
-     */
-    public function users() {
-        require BHG_PLUGIN_DIR . 'admin/views/users.php';
-    }
+	/**
+	 * Render the users page.
+	 */
+	public function users() {
+		require BHG_PLUGIN_DIR . 'admin/views/users.php';
+	}
 
-    /**
-     * Render the affiliates management page.
-     */
-    public function affiliates() {
-        $view = BHG_PLUGIN_DIR . 'admin/views/affiliate-websites.php';
-        if (file_exists($view)) { require $view; }
-        else { echo '<div class="wrap"><h1>' . esc_html__('Affiliates', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('Affiliate management UI not provided yet.', 'bonus-hunt-guesser') . '</p></div>'; }
-    }
-    /**
-     * Render the advertising page.
-     */
-    public function advertising() {
-        require BHG_PLUGIN_DIR . 'admin/views/advertising.php';
-    }
+	/**
+	 * Render the affiliates management page.
+	 */
+	public function affiliates() {
+		$view = BHG_PLUGIN_DIR . 'admin/views/affiliate-websites.php';
+		if (file_exists($view)) { require $view; }
+		else { echo '<div class="wrap"><h1>' . esc_html__('Affiliates', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('Affiliate management UI not provided yet.', 'bonus-hunt-guesser') . '</p></div>'; }
+	}
+	/**
+	 * Render the advertising page.
+	 */
+	public function advertising() {
+		require BHG_PLUGIN_DIR . 'admin/views/advertising.php';
+	}
 
-    /**
-     * Render the translations page.
-     */
-    public function translations() {
-        $view = BHG_PLUGIN_DIR . 'admin/views/translations.php';
-        if (file_exists($view)) { require $view; }
-        else { echo '<div class="wrap"><h1>' . esc_html__('Translations', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No translations UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
-    }
-    /**
-     * Render the database maintenance page.
-     */
-    public function database() {
-        $view = BHG_PLUGIN_DIR . 'admin/views/database.php';
-        if (file_exists($view)) { require $view; }
-        else { echo '<div class="wrap"><h1>' . esc_html__('Database', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No database UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
-    }
-    /**
-     * Render the settings page.
-     */
-    public function settings() {
-        $view = BHG_PLUGIN_DIR . 'admin/views/settings.php';
-        if (file_exists($view)) { require $view; }
-        else { echo '<div class="wrap"><h1>' . esc_html__('Settings', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No settings UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
-    }
-    /**
-     * Render the tools demo page.
-     */
-    public function bhg_tools_page() {
-        $view = BHG_PLUGIN_DIR . 'admin/views/demo-tools.php';
-        if (file_exists($view)) { require $view; }
-        else { echo '<div class="wrap"><h1>' . esc_html__('BHG Tools', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No tools UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
-    }
+	/**
+	 * Render the translations page.
+	 */
+	public function translations() {
+		$view = BHG_PLUGIN_DIR . 'admin/views/translations.php';
+		if (file_exists($view)) { require $view; }
+		else { echo '<div class="wrap"><h1>' . esc_html__('Translations', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No translations UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
+	}
+	/**
+	 * Render the database maintenance page.
+	 */
+	public function database() {
+		$view = BHG_PLUGIN_DIR . 'admin/views/database.php';
+		if (file_exists($view)) { require $view; }
+		else { echo '<div class="wrap"><h1>' . esc_html__('Database', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No database UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
+	}
+	/**
+	 * Render the settings page.
+	 */
+	public function settings() {
+		$view = BHG_PLUGIN_DIR . 'admin/views/settings.php';
+		if (file_exists($view)) { require $view; }
+		else { echo '<div class="wrap"><h1>' . esc_html__('Settings', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No settings UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
+	}
+	/**
+	 * Render the tools demo page.
+	 */
+	public function bhg_tools_page() {
+		$view = BHG_PLUGIN_DIR . 'admin/views/demo-tools.php';
+		if (file_exists($view)) { require $view; }
+		else { echo '<div class="wrap"><h1>' . esc_html__('BHG Tools', 'bonus-hunt-guesser') . '</h1><p>' . esc_html__('No tools UI found.', 'bonus-hunt-guesser') . '</p></div>'; }
+	}
 
-    // -------------------- Handlers --------------------
+	// -------------------- Handlers --------------------
 
-    /**
-     * Handle deletion of a guess from the admin screen.
-     */
-    public function handle_delete_guess() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
-        }
-        check_admin_referer( 'bhg_delete_guess' );
-        global $wpdb;
-        $guesses_table = $wpdb->prefix . 'bhg_guesses';
-        $guess_id      = isset( $_POST['guess_id'] ) ? absint( wp_unslash( $_POST['guess_id'] ) ) : 0;
-        if ( $guess_id ) {
-            $wpdb->delete( $guesses_table, [ 'id' => $guess_id ], [ '%d' ] );
-        }
-        wp_safe_redirect( wp_get_referer() ?: admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
-        exit;
-    }
+	/**
+	 * Handle deletion of a guess from the admin screen.
+	 */
+	public function handle_delete_guess() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+		}
+		check_admin_referer( 'bhg_delete_guess' );
+		global $wpdb;
+		$guesses_table = $wpdb->prefix . 'bhg_guesses';
+		$guess_id      = isset( $_POST['guess_id'] ) ? absint( wp_unslash( $_POST['guess_id'] ) ) : 0;
+		if ( $guess_id ) {
+			$wpdb->delete( $guesses_table, [ 'id' => $guess_id ], [ '%d' ] );
+		}
+		wp_safe_redirect( wp_get_referer() ?: admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+		exit;
+	}
 
-    /**
-     * Handle creation and updating of a bonus hunt.
-     */
-    public function handle_save_hunt() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
-        }
-        check_admin_referer( 'bhg_save_hunt' );
-        global $wpdb;
-        $hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
+	/**
+	 * Handle creation and updating of a bonus hunt.
+	 */
+	public function handle_save_hunt() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+		}
+		check_admin_referer( 'bhg_save_hunt' );
+		global $wpdb;
+		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 
-        $id             = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-        $title          = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
-        $starting       = isset( $_POST['starting_balance'] ) ? floatval( wp_unslash( $_POST['starting_balance'] ) ) : 0;
-        $num_bonuses    = isset( $_POST['num_bonuses'] ) ? absint( wp_unslash( $_POST['num_bonuses'] ) ) : 0;
-        $prizes         = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
-        $winners_count  = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
-        $affiliate_site = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
-        $final_balance  = ( isset( $_POST['final_balance'] ) && $_POST['final_balance'] !== '' ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
-        $status         = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
+		$id             = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$title          = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
+		$starting       = isset( $_POST['starting_balance'] ) ? floatval( wp_unslash( $_POST['starting_balance'] ) ) : 0;
+		$num_bonuses    = isset( $_POST['num_bonuses'] ) ? absint( wp_unslash( $_POST['num_bonuses'] ) ) : 0;
+		$prizes         = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
+		$winners_count  = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
+		$affiliate_site = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
+		$final_balance  = ( isset( $_POST['final_balance'] ) && $_POST['final_balance'] !== '' ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
+		$status         = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
 
-        $data = [
-            'title'            => $title,
-            'starting_balance' => $starting,
-            'num_bonuses'      => $num_bonuses,
-            'prizes'           => $prizes,
-            'winners_count'    => $winners_count,
-            'affiliate_site_id'=> $affiliate_site,
-            'final_balance'    => $final_balance,
-            'status'           => $status,
-            'updated_at'       => current_time('mysql'),
-        ];
+		$data = [
+			'title'            => $title,
+			'starting_balance' => $starting,
+			'num_bonuses'      => $num_bonuses,
+			'prizes'           => $prizes,
+			'winners_count'    => $winners_count,
+			'affiliate_site_id'=> $affiliate_site,
+			'final_balance'    => $final_balance,
+			'status'           => $status,
+			'updated_at'       => current_time('mysql'),
+		];
 
-        $format = ['%s','%f','%d','%s','%d','%d','%f','%s','%s'];
-        if ($id) {
-            $wpdb->update($hunts_table, $data, ['id' => $id], $format, ['%d']);
-        } else {
-            $data['created_at'] = current_time('mysql');
-            $format[] = '%s';
-            $wpdb->insert($hunts_table, $data, $format);
-            $id = (int) $wpdb->insert_id;
-        }
+		$format = ['%s','%f','%d','%s','%d','%d','%f','%s','%s'];
+		if ($id) {
+			$wpdb->update($hunts_table, $data, ['id' => $id], $format, ['%d']);
+		} else {
+			$data['created_at'] = current_time('mysql');
+			$format[] = '%s';
+			$wpdb->insert($hunts_table, $data, $format);
+			$id = (int) $wpdb->insert_id;
+		}
 
-        if ($status === 'closed' && $final_balance !== null) {
-            $winners = BHG_Models::close_hunt($id, $final_balance);
+		if ($status === 'closed' && $final_balance !== null) {
+			$winners = BHG_Models::close_hunt($id, $final_balance);
 
-            $emails_enabled = (int) get_option('bhg_email_enabled', 1);
-            if ($emails_enabled) {
-                $guesses_table = $wpdb->prefix . 'bhg_guesses';
-                $rows = $wpdb->get_results(
-                    $wpdb->prepare(
-                        "SELECT DISTINCT user_id FROM {$guesses_table} WHERE hunt_id=%d",
-                        $id
-                    )
-                );
+			$emails_enabled = (int) get_option('bhg_email_enabled', 1);
+			if ($emails_enabled) {
+				$guesses_table = $wpdb->prefix . 'bhg_guesses';
+				$rows = $wpdb->get_results(
+					$wpdb->prepare(
+						"SELECT DISTINCT user_id FROM {$guesses_table} WHERE hunt_id=%d",
+						$id
+					)
+				);
 
-                $template = get_option(
-                    'bhg_email_template',
-                    'Hi {{username}},\nThe Bonus Hunt "{{hunt}}" is closed. Final balance: €{{final}}. Winners: {{winners}}. Thanks for playing!'
-                );
+				$template = get_option(
+					'bhg_email_template',
+					'Hi {{username}},\nThe Bonus Hunt "{{hunt}}" is closed. Final balance: €{{final}}. Winners: {{winners}}. Thanks for playing!'
+				);
 
-                $hunt_title = (string) $wpdb->get_var(
-                    $wpdb->prepare(
-                        "SELECT title FROM {$hunts_table} WHERE id=%d",
-                        $id
-                    )
-                );
+				$hunt_title = (string) $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT title FROM {$hunts_table} WHERE id=%d",
+						$id
+					)
+				);
 
-                $winner_names = array();
-                foreach ((array) $winners as $winner_id) {
-                    $wu = get_userdata((int) $winner_id);
-                    if ($wu) {
-                        $winner_names[] = $wu->user_login;
-                    }
-                }
-                $winner_first = $winner_names ? $winner_names[0] : '—';
-                $winner_list  = $winner_names ? implode(', ', $winner_names) : '—';
+				$winner_names = array();
+				foreach ((array) $winners as $winner_id) {
+					$wu = get_userdata((int) $winner_id);
+					if ($wu) {
+						$winner_names[] = $wu->user_login;
+					}
+				}
+				$winner_first = $winner_names ? $winner_names[0] : '—';
+				$winner_list  = $winner_names ? implode(', ', $winner_names) : '—';
 
-                foreach ($rows as $r) {
-                    $u = get_userdata((int) $r->user_id);
-                    if (! $u) {
-                        continue;
-                    }
-                    $body = strtr(
-                        $template,
-                        array(
-                            '{{username}}' => $u->user_login,
-                            '{{hunt}}'     => $hunt_title,
-                            '{{final}}'    => number_format($final_balance, 2),
-                            '{{winner}}'   => $winner_first,
-                            '{{winners}}'  => $winner_list,
-                        )
-                    );
-                    wp_mail(
-                        $u->user_email,
-                        sprintf(__('Results for %s', 'bonus-hunt-guesser'), $hunt_title ?: 'Bonus Hunt'),
-                        $body
-                    );
-                }
-            }
-        }
+				foreach ($rows as $r) {
+					$u = get_userdata((int) $r->user_id);
+					if (! $u) {
+						continue;
+					}
+					$body = strtr(
+						$template,
+						array(
+							'{{username}}' => $u->user_login,
+							'{{hunt}}'     => $hunt_title,
+							'{{final}}'    => number_format($final_balance, 2),
+							'{{winner}}'   => $winner_first,
+							'{{winners}}'  => $winner_list,
+						)
+					);
+					wp_mail(
+						$u->user_email,
+						sprintf(__('Results for %s', 'bonus-hunt-guesser'), $hunt_title ?: 'Bonus Hunt'),
+						$body
+					);
+				}
+			}
+		}
 
-        wp_safe_redirect(admin_url('admin.php?page=bhg-bonus-hunts'));
-        exit;
-    }
+		wp_safe_redirect(admin_url('admin.php?page=bhg-bonus-hunts'));
+		exit;
+	}
 
-    /**
-     * Close an active bonus hunt.
-     */
-    public function handle_close_hunt() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
-        }
-        check_admin_referer( 'bhg_close_hunt' );
+	/**
+	 * Close an active bonus hunt.
+	 */
+	public function handle_close_hunt() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+		}
+		check_admin_referer( 'bhg_close_hunt' );
 
-        $hunt_id            = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
-        $final_balance_raw  = isset( $_POST['final_balance'] ) ? sanitize_text_field( wp_unslash( $_POST['final_balance'] ) ) : '';
+		$hunt_id            = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
+		$final_balance_raw  = isset( $_POST['final_balance'] ) ? sanitize_text_field( wp_unslash( $_POST['final_balance'] ) ) : '';
 
-        if ( '' === $final_balance_raw || ! is_numeric( $final_balance_raw ) || (float) $final_balance_raw < 0 ) {
-            wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
-            exit;
-        }
+		if ( '' === $final_balance_raw || ! is_numeric( $final_balance_raw ) || (float) $final_balance_raw < 0 ) {
+			wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
+			exit;
+		}
 
-        $final_balance = (float) $final_balance_raw;
+		$final_balance = (float) $final_balance_raw;
 
-        if ( $hunt_id ) {
-            BHG_Models::close_hunt( $hunt_id, $final_balance );
-        }
+		if ( $hunt_id ) {
+			BHG_Models::close_hunt( $hunt_id, $final_balance );
+		}
 
-        wp_safe_redirect( admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
-        exit;
-    }
+		wp_safe_redirect( admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+		exit;
+	}
 
-    /**
-     * Save or update an advertising entry.
-     */
-    public function handle_save_ad() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
-        }
-        check_admin_referer( 'bhg_save_ad' );
-        global $wpdb;
-        $table = $wpdb->prefix . 'bhg_ads';
+	/**
+	 * Save or update an advertising entry.
+	 */
+	public function handle_save_ad() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+		}
+		check_admin_referer( 'bhg_save_ad' );
+		global $wpdb;
+		$table = $wpdb->prefix . 'bhg_ads';
 
-        $id       = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-        $title    = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
-        $content  = isset( $_POST['content'] ) ? wp_kses_post( wp_unslash( $_POST['content'] ) ) : '';
-        $link     = isset( $_POST['link_url'] ) ? esc_url_raw( wp_unslash( $_POST['link_url'] ) ) : '';
-        $place    = isset( $_POST['placement'] ) ? sanitize_text_field( wp_unslash( $_POST['placement'] ) ) : 'none';
-        $visible  = isset( $_POST['visible_to'] ) ? sanitize_text_field( wp_unslash( $_POST['visible_to'] ) ) : 'all';
-        $targets  = isset( $_POST['target_pages'] ) ? sanitize_text_field( wp_unslash( $_POST['target_pages'] ) ) : '';
-        $active   = isset($_POST['active']) ? 1 : 0;
+		$id       = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$title    = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
+		$content  = isset( $_POST['content'] ) ? wp_kses_post( wp_unslash( $_POST['content'] ) ) : '';
+		$link     = isset( $_POST['link_url'] ) ? esc_url_raw( wp_unslash( $_POST['link_url'] ) ) : '';
+		$place    = isset( $_POST['placement'] ) ? sanitize_text_field( wp_unslash( $_POST['placement'] ) ) : 'none';
+		$visible  = isset( $_POST['visible_to'] ) ? sanitize_text_field( wp_unslash( $_POST['visible_to'] ) ) : 'all';
+		$targets  = isset( $_POST['target_pages'] ) ? sanitize_text_field( wp_unslash( $_POST['target_pages'] ) ) : '';
+		$active   = isset($_POST['active']) ? 1 : 0;
 
-        $data = [
-            'title'        => $title,
-            'content'      => $content,
-            'link_url'     => $link,
-            'placement'    => $place,
-            'visible_to'   => $visible,
-            'target_pages' => $targets,
-            'active'       => $active,
-            'updated_at'   => current_time('mysql'),
-        ];
+		$data = [
+			'title'        => $title,
+			'content'      => $content,
+			'link_url'     => $link,
+			'placement'    => $place,
+			'visible_to'   => $visible,
+			'target_pages' => $targets,
+			'active'       => $active,
+			'updated_at'   => current_time('mysql'),
+		];
 
-        $format = ['%s','%s','%s','%s','%s','%s','%d','%s'];
-        if ($id) {
-            $wpdb->update($table, $data, ['id' => $id], $format, ['%d']);
-        } else {
-            $data['created_at'] = current_time('mysql');
-            $format[] = '%s';
-            $wpdb->insert($table, $data, $format);
-        }
+		$format = ['%s','%s','%s','%s','%s','%s','%d','%s'];
+		if ($id) {
+			$wpdb->update($table, $data, ['id' => $id], $format, ['%d']);
+		} else {
+			$data['created_at'] = current_time('mysql');
+			$format[] = '%s';
+			$wpdb->insert($table, $data, $format);
+		}
 
-        wp_safe_redirect( admin_url( 'admin.php?page=bhg-ads' ) );
-        exit;
-    }
+		wp_safe_redirect( admin_url( 'admin.php?page=bhg-ads' ) );
+		exit;
+	}
 
-    /**
-     * Save a tournament record.
-     */
-    public function handle_save_tournament() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
-            exit;
-        }
-        if ( ! check_admin_referer( 'bhg_tournament_save_action' ) ) {
-            wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
-            exit;
-        }
-        global $wpdb;
-        $t  = $wpdb->prefix . 'bhg_tournaments';
-        $id = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-        $data = [
-            'title'       => isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '',
-            'description' => isset( $_POST['description'] ) ? wp_kses_post( wp_unslash( $_POST['description'] ) ) : '',
-            'type'        => isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'weekly',
-            'start_date'  => isset( $_POST['start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['start_date'] ) ) : null,
-            'end_date'    => isset( $_POST['end_date'] ) ? sanitize_text_field( wp_unslash( $_POST['end_date'] ) ) : null,
-            'status'      => isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active',
-            'updated_at'  => current_time( 'mysql' ),
-        ];
-        try {
-            $format = [ '%s', '%s', '%s', '%s', '%s', '%s', '%s' ];
-            if ( $id > 0 ) {
-                $wpdb->update( $t, $data, [ 'id' => $id ], $format, [ '%d' ] );
-            } else {
-                $data['created_at'] = current_time( 'mysql' );
-                $format[]           = '%s';
-                $wpdb->insert( $t, $data, $format );
-            }
-            wp_safe_redirect( add_query_arg( 'bhg_msg', 't_saved', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
-            exit;
-        } catch ( Throwable $e ) {
-            if ( function_exists( 'error_log' ) ) {
-                error_log( '[BHG] tournament save error: ' . $e->getMessage() );
-            }
-            wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
-            exit;
-        }
-    }
+	/**
+	 * Save a tournament record.
+	 */
+	public function handle_save_tournament() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+			exit;
+		}
+		if ( ! check_admin_referer( 'bhg_tournament_save_action' ) ) {
+			wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+			exit;
+		}
+		global $wpdb;
+		$t  = $wpdb->prefix . 'bhg_tournaments';
+		$id = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$data = [
+			'title'       => isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '',
+			'description' => isset( $_POST['description'] ) ? wp_kses_post( wp_unslash( $_POST['description'] ) ) : '',
+			'type'        => isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'weekly',
+			'start_date'  => isset( $_POST['start_date'] ) ? sanitize_text_field( wp_unslash( $_POST['start_date'] ) ) : null,
+			'end_date'    => isset( $_POST['end_date'] ) ? sanitize_text_field( wp_unslash( $_POST['end_date'] ) ) : null,
+			'status'      => isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active',
+			'updated_at'  => current_time( 'mysql' ),
+		];
+		try {
+			$format = [ '%s', '%s', '%s', '%s', '%s', '%s', '%s' ];
+			if ( $id > 0 ) {
+				$wpdb->update( $t, $data, [ 'id' => $id ], $format, [ '%d' ] );
+			} else {
+				$data['created_at'] = current_time( 'mysql' );
+				$format[]           = '%s';
+				$wpdb->insert( $t, $data, $format );
+			}
+			wp_safe_redirect( add_query_arg( 'bhg_msg', 't_saved', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+			exit;
+		} catch ( Throwable $e ) {
+			if ( function_exists( 'error_log' ) ) {
+				error_log( '[BHG] tournament save error: ' . $e->getMessage() );
+			}
+			wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
+			exit;
+		}
+	}
 
-    /**
-     * Save or update an affiliate record.
-     */
-    public function handle_save_affiliate() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
-        }
-        check_admin_referer( 'bhg_save_affiliate' );
-        global $wpdb;
-        $table = $wpdb->prefix . 'bhg_affiliates';
-        $id    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-        $name  = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
-        $url   = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
-        $status= isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active';
+	/**
+	 * Save or update an affiliate record.
+	 */
+	public function handle_save_affiliate() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+		}
+		check_admin_referer( 'bhg_save_affiliate' );
+		global $wpdb;
+		$table = $wpdb->prefix . 'bhg_affiliates';
+		$id    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$name  = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+		$url   = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
+		$status= isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active';
 
-        $data = ['name'=>$name, 'url'=>$url, 'status'=>$status, 'updated_at'=> current_time('mysql')];
-        $format = ['%s','%s','%s','%s'];
-        if ($id) {
-            $wpdb->update($table, $data, ['id'=>$id], $format, ['%d']);
-        } else {
-            $data['created_at'] = current_time('mysql');
-            $format[] = '%s';
-            $wpdb->insert($table, $data, $format);
-        }
-        wp_safe_redirect(admin_url('admin.php?page=bhg-affiliates'));
-        exit;
-    }
+		$data = ['name'=>$name, 'url'=>$url, 'status'=>$status, 'updated_at'=> current_time('mysql')];
+		$format = ['%s','%s','%s','%s'];
+		if ($id) {
+			$wpdb->update($table, $data, ['id'=>$id], $format, ['%d']);
+		} else {
+			$data['created_at'] = current_time('mysql');
+			$format[] = '%s';
+			$wpdb->insert($table, $data, $format);
+		}
+		wp_safe_redirect(admin_url('admin.php?page=bhg-affiliates'));
+		exit;
+	}
 
-    /**
-     * Delete an affiliate.
-     */
-    public function handle_delete_affiliate() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
-        }
-        check_admin_referer( 'bhg_delete_affiliate' );
-        global $wpdb;
-        $table = $wpdb->prefix . 'bhg_affiliates';
-        $id = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-        if ( $id ) {
-            $wpdb->delete( $table, [ 'id' => $id ], [ '%d' ] );
-        }
-        wp_safe_redirect(admin_url('admin.php?page=bhg-affiliates'));
-        exit;
-    }
+	/**
+	 * Delete an affiliate.
+	 */
+	public function handle_delete_affiliate() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+		}
+		check_admin_referer( 'bhg_delete_affiliate' );
+		global $wpdb;
+		$table = $wpdb->prefix . 'bhg_affiliates';
+		$id = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		if ( $id ) {
+			$wpdb->delete( $table, [ 'id' => $id ], [ '%d' ] );
+		}
+		wp_safe_redirect(admin_url('admin.php?page=bhg-affiliates'));
+		exit;
+	}
 
-    /**
-     * Save plugin settings.
-     */
-    public function handle_save_settings() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
-        }
-        check_admin_referer( 'bhg_save_settings' );
-        $opts = [
-            'allow_guess_edit_until_close' => isset( $_POST['allow_guess_edit_until_close'] ) ? 'yes' : 'no',
-            'guesses_max' => isset( $_POST['guesses_max'] ) ? max( 1, absint( wp_unslash( $_POST['guesses_max'] ) ) ) : 1,
-        ];
-        foreach ($opts as $k => $v) {
-            update_option('bhg_' . $k, $v, false);
-        }
-        wp_safe_redirect(admin_url('admin.php?page=bhg-settings&updated=1'));
-        exit;
-    }
+	/**
+	 * Save plugin settings.
+	 */
+	public function handle_save_settings() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+		}
+		check_admin_referer( 'bhg_save_settings' );
+		$opts = [
+			'allow_guess_edit_until_close' => isset( $_POST['allow_guess_edit_until_close'] ) ? 'yes' : 'no',
+			'guesses_max' => isset( $_POST['guesses_max'] ) ? max( 1, absint( wp_unslash( $_POST['guesses_max'] ) ) ) : 1,
+		];
+		foreach ($opts as $k => $v) {
+			update_option('bhg_' . $k, $v, false);
+		}
+		wp_safe_redirect(admin_url('admin.php?page=bhg-settings&updated=1'));
+		exit;
+	}
 
-    /**
-     * Save custom user metadata from the admin screen.
-     */
-    public function handle_save_user_meta() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
-        }
-        check_admin_referer( 'bhg_save_user_meta' );
-        $user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;
-        if ( $user_id ) {
-            $real_name    = isset( $_POST['bhg_real_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bhg_real_name'] ) ) : '';
-            $is_affiliate = isset( $_POST['bhg_is_affiliate'] ) ? 1 : 0;
-            update_user_meta( $user_id, 'bhg_real_name', $real_name );
-            update_user_meta( $user_id, 'bhg_is_affiliate', $is_affiliate );
-        }
-        wp_safe_redirect( admin_url( 'admin.php?page=bhg-users' ) );
-        exit;
-    }
+	/**
+	 * Save custom user metadata from the admin screen.
+	 */
+	public function handle_save_user_meta() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+		}
+		check_admin_referer( 'bhg_save_user_meta' );
+		$user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;
+		if ( $user_id ) {
+			$real_name    = isset( $_POST['bhg_real_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bhg_real_name'] ) ) : '';
+			$is_affiliate = isset( $_POST['bhg_is_affiliate'] ) ? 1 : 0;
+			update_user_meta( $user_id, 'bhg_real_name', $real_name );
+			update_user_meta( $user_id, 'bhg_is_affiliate', $is_affiliate );
+		}
+		wp_safe_redirect( admin_url( 'admin.php?page=bhg-users' ) );
+		exit;
+	}
 
-    /**
-     * Display admin notices for tournament actions.
-     */
-    public function admin_notices() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            return;
-        }
-        if ( ! isset( $_GET['bhg_msg'] ) ) {
-            return;
-        }
-        $msg = sanitize_text_field( wp_unslash( $_GET['bhg_msg'] ) );
-        $map = [
-            't_saved'  => __( 'Tournament saved.', 'bonus-hunt-guesser' ),
-            't_error'  => __( 'Could not save tournament. Check logs.', 'bonus-hunt-guesser' ),
-            'nonce'    => __( 'Security check failed. Please retry.', 'bonus-hunt-guesser' ),
-            'noaccess' => __( 'You do not have permission to do that.', 'bonus-hunt-guesser' ),
-            'invalid_final_balance' => __( 'Invalid final balance. Please enter a non-negative number.', 'bonus-hunt-guesser' ),
-        ];
-        $class = ( strpos( $msg, 'error' ) !== false || 'nonce' === $msg || 'noaccess' === $msg ) ? 'notice notice-error' : 'notice notice-success';
-        $text  = isset( $map[ $msg ] ) ? $map[ $msg ] : esc_html( $msg );
-        echo '<div class="' . esc_attr( $class ) . '"><p>' . esc_html( $text ) . '</p></div>';
-    }
+	/**
+	 * Display admin notices for tournament actions.
+	 */
+	public function admin_notices() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		if ( ! isset( $_GET['bhg_msg'] ) ) {
+			return;
+		}
+		$msg = sanitize_text_field( wp_unslash( $_GET['bhg_msg'] ) );
+		$map = [
+			't_saved'  => __( 'Tournament saved.', 'bonus-hunt-guesser' ),
+			't_error'  => __( 'Could not save tournament. Check logs.', 'bonus-hunt-guesser' ),
+			'nonce'    => __( 'Security check failed. Please retry.', 'bonus-hunt-guesser' ),
+			'noaccess' => __( 'You do not have permission to do that.', 'bonus-hunt-guesser' ),
+			'invalid_final_balance' => __( 'Invalid final balance. Please enter a non-negative number.', 'bonus-hunt-guesser' ),
+		];
+		$class = ( strpos( $msg, 'error' ) !== false || 'nonce' === $msg || 'noaccess' === $msg ) ? 'notice notice-error' : 'notice notice-success';
+		$text  = isset( $map[ $msg ] ) ? $map[ $msg ] : esc_html( $msg );
+		echo '<div class="' . esc_attr( $class ) . '"><p>' . esc_html( $text ) . '</p></div>';
+	}
 }

--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -2,53 +2,53 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_Demo {
-    public function __construct() {
-        add_action('admin_menu', [$this,'demo_menu']);
-        add_action('admin_post_bhg_demo_reseed', [$this,'reseed']);
-    }
+	public function __construct() {
+		add_action('admin_menu', [$this,'demo_menu']);
+		add_action('admin_post_bhg_demo_reseed', [$this,'reseed']);
+	}
 
-    public function demo_menu() {
-        add_submenu_page(
-            'bhg_dashboard',
-            __('Demo Tools','bonus-hunt-guesser'),
-            __('Demo Tools','bonus-hunt-guesser'),
-            'manage_options',
-            'bhg_demo',
-            [$this,'render_demo']
-        );
-    }
+	public function demo_menu() {
+		add_submenu_page(
+			'bhg_dashboard',
+			__('Demo Tools','bonus-hunt-guesser'),
+			__('Demo Tools','bonus-hunt-guesser'),
+			'manage_options',
+			'bhg_demo',
+			[$this,'render_demo']
+		);
+	}
 
-    public function render_demo() {
-        echo '<div class="wrap"><h1>Demo Tools</h1>';
-        echo '<form method="post" action="'.admin_url('admin-post.php').'">';
-        echo '<input type="hidden" name="action" value="bhg_demo_reseed" />';
-        submit_button(__('Reset & Reseed Demo','bonus-hunt-guesser'));
-        echo '</form></div>';
-    }
+	public function render_demo() {
+		echo '<div class="wrap"><h1>Demo Tools</h1>';
+		echo '<form method="post" action="'.admin_url('admin-post.php').'">';
+		echo '<input type="hidden" name="action" value="bhg_demo_reseed" />';
+		submit_button(__('Reset & Reseed Demo','bonus-hunt-guesser'));
+		echo '</form></div>';
+	}
 
-    public function reseed() {
-        global $wpdb;
+	public function reseed() {
+		global $wpdb;
 
-        // Wipe demo data
-        $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}bhg_bonus_hunts WHERE title LIKE '%(Demo)%'" ) );
-        $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}bhg_tournaments WHERE title LIKE '%(Demo)%'" ) );
+		// Wipe demo data
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}bhg_bonus_hunts WHERE title LIKE '%(Demo)%'" ) );
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}bhg_tournaments WHERE title LIKE '%(Demo)%'" ) );
 
-        // Insert demo hunt
-        $wpdb->insert("{$wpdb->prefix}bhg_bonus_hunts",[
-            'title'=>'Sample Hunt (Demo)',
-            'starting_balance'=>1000,
-            'num_bonuses'=>5,
-            'status'=>'open'
-        ]);
+		// Insert demo hunt
+		$wpdb->insert("{$wpdb->prefix}bhg_bonus_hunts",[
+			'title'=>'Sample Hunt (Demo)',
+			'starting_balance'=>1000,
+			'num_bonuses'=>5,
+			'status'=>'open'
+		]);
 
-        // Insert demo tournament
-        $wpdb->insert("{$wpdb->prefix}bhg_tournaments",[
-            'title'=>'August Tournament (Demo)',
-            'status'=>'active'
-        ]);
+		// Insert demo tournament
+		$wpdb->insert("{$wpdb->prefix}bhg_tournaments",[
+			'title'=>'August Tournament (Demo)',
+			'status'=>'active'
+		]);
 
-        wp_safe_redirect( admin_url( 'admin.php?page=bhg_demo&demo_reset=1' ) );
-        exit;
-    }
+		wp_safe_redirect( admin_url( 'admin.php?page=bhg_demo&demo_reset=1' ) );
+		exit;
+	}
 }
 new BHG_Demo();

--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -2,169 +2,169 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if (!class_exists('WP_List_Table')) {
-    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }
 
 class BHG_Users_Table extends WP_List_Table {
 
-    private $items_data = [];
-    private $total_items = 0;
-    private $per_page = 30;
+	private $items_data = [];
+	private $total_items = 0;
+	private $per_page = 30;
 
-    public function __construct() {
-        parent::__construct([
-            'singular' => 'bhg_user',
-            'plural'   => 'bhg_users',
-            'ajax'     => false
-        ]);
-    }
+	public function __construct() {
+		parent::__construct([
+			'singular' => 'bhg_user',
+			'plural'   => 'bhg_users',
+			'ajax'     => false
+		]);
+	}
 
-    public function get_columns() {
-        return [
-            'id'       => __('ID', 'bonus-hunt-guesser'),
-            'username' => __('Username', 'bonus-hunt-guesser'),
-            'email'    => __('Email', 'bonus-hunt-guesser'),
-            'role'     => __('Role', 'bonus-hunt-guesser'),
-            'guesses'  => __('Guesses', 'bonus-hunt-guesser'),
-            'wins'     => __('Wins', 'bonus-hunt-guesser'),
-            'profile'  => __('Profile', 'bonus-hunt-guesser'),
-        ];
-    }
+	public function get_columns() {
+		return [
+			'id'       => __('ID', 'bonus-hunt-guesser'),
+			'username' => __('Username', 'bonus-hunt-guesser'),
+			'email'    => __('Email', 'bonus-hunt-guesser'),
+			'role'     => __('Role', 'bonus-hunt-guesser'),
+			'guesses'  => __('Guesses', 'bonus-hunt-guesser'),
+			'wins'     => __('Wins', 'bonus-hunt-guesser'),
+			'profile'  => __('Profile', 'bonus-hunt-guesser'),
+		];
+	}
 
-    public function get_sortable_columns() {
-        return [
-            'username' => ['username', true],
-            'email'    => ['email', false],
-            'role'     => ['role', false],
-            'guesses'  => ['guesses', false],
-            'wins'     => ['wins', false],
-        ];
-    }
+	public function get_sortable_columns() {
+		return [
+			'username' => ['username', true],
+			'email'    => ['email', false],
+			'role'     => ['role', false],
+			'guesses'  => ['guesses', false],
+			'wins'     => ['wins', false],
+		];
+	}
 
-    public function column_default($item, $column_name) {
-        switch ($column_name) {
-            case 'id':
-                return (int)$item['id'];
-            case 'username':
-                return esc_html($item['username']);
-            case 'email':
-                return esc_html($item['email']);
-            case 'role':
-                return esc_html($item['role']);
-            case 'guesses':
-                return (int)$item['guesses'];
-            case 'wins':
-                return (int)$item['wins'];
-            case 'profile':
-                $url = esc_url(admin_url('user-edit.php?user_id='.(int)$item['id']));
-                return '<a class="button" href="'.$url.'">'.esc_html__('Edit', 'bonus-hunt-guesser').'</a>';
-        }
-        return '';
-    }
+	public function column_default($item, $column_name) {
+		switch ($column_name) {
+			case 'id':
+				return (int)$item['id'];
+			case 'username':
+				return esc_html($item['username']);
+			case 'email':
+				return esc_html($item['email']);
+			case 'role':
+				return esc_html($item['role']);
+			case 'guesses':
+				return (int)$item['guesses'];
+			case 'wins':
+				return (int)$item['wins'];
+			case 'profile':
+				$url = esc_url(admin_url('user-edit.php?user_id='.(int)$item['id']));
+				return '<a class="button" href="'.$url.'">'.esc_html__('Edit', 'bonus-hunt-guesser').'</a>';
+		}
+		return '';
+	}
 
-    public function prepare_items() {
-        $paged   = isset($_REQUEST['paged']) ? max(1, (int)$_REQUEST['paged']) : 1;
-        $orderby = isset($_REQUEST['orderby']) ? sanitize_key($_REQUEST['orderby']) : 'username';
-        $order   = isset($_REQUEST['order']) && in_array(strtolower($_REQUEST['order']), ['asc','desc'], true) ? strtoupper($_REQUEST['order']) : 'ASC';
-        $search  = isset($_REQUEST['s']) ? sanitize_text_field(wp_unslash($_REQUEST['s'])) : '';
+	public function prepare_items() {
+		$paged   = isset($_REQUEST['paged']) ? max(1, (int)$_REQUEST['paged']) : 1;
+		$orderby = isset($_REQUEST['orderby']) ? sanitize_key($_REQUEST['orderby']) : 'username';
+		$order   = isset($_REQUEST['order']) && in_array(strtolower($_REQUEST['order']), ['asc','desc'], true) ? strtoupper($_REQUEST['order']) : 'ASC';
+		$search  = isset($_REQUEST['s']) ? sanitize_text_field(wp_unslash($_REQUEST['s'])) : '';
 
-        // Whitelist orderby
-        $allowed = ['username','email','role','guesses','wins'];
-        if (!in_array($orderby, $allowed, true)) $orderby = 'username';
+		// Whitelist orderby
+		$allowed = ['username','email','role','guesses','wins'];
+		if (!in_array($orderby, $allowed, true)) $orderby = 'username';
 
-        // Fetch users via WP_User_Query
-        $args = [
-            'number' => $this->per_page,
-            'offset' => ($paged - 1) * $this->per_page,
-            'fields' => ['ID','user_login','user_email','roles'],
-            'orderby'=> in_array($orderby, ['username','email']) ? ($orderby === 'username' ? 'login' : 'email') : 'login',
-            'order'  => $order,
-        ];
-        if ($search) {
-            $args['search'] = '*' . $search . '*';
-            $args['search_columns'] = ['user_login','user_email'];
-        }
+		// Fetch users via WP_User_Query
+		$args = [
+			'number' => $this->per_page,
+			'offset' => ($paged - 1) * $this->per_page,
+			'fields' => ['ID','user_login','user_email','roles'],
+			'orderby'=> in_array($orderby, ['username','email']) ? ($orderby === 'username' ? 'login' : 'email') : 'login',
+			'order'  => $order,
+		];
+		if ($search) {
+			$args['search'] = '*' . $search . '*';
+			$args['search_columns'] = ['user_login','user_email'];
+		}
 
-        $query = new WP_User_Query($args);
-        $users = (array)$query->get_results();
-        $this->total_items = (int)$query->get_total();
+		$query = new WP_User_Query($args);
+		$users = (array)$query->get_results();
+		$this->total_items = (int)$query->get_total();
 
-        // Build base items
-        $items = [];
-        $ids = [];
-        foreach ($users as $u) {
-            if ($u instanceof WP_User) {
-                $roles = (array) $u->roles;
-                $role = $roles ? reset($roles) : '';
-                $uid = (int)$u->ID;
-                $ids[] = $uid;
-                $items[$uid] = [
-                    'id'       => $uid,
-                    'username' => $u->user_login,
-                    'email'    => $u->user_email,
-                    'role'     => $role,
-                    'guesses'  => 0,
-                    'wins'     => 0,
-                ];
-            }
-        }
+		// Build base items
+		$items = [];
+		$ids = [];
+		foreach ($users as $u) {
+			if ($u instanceof WP_User) {
+				$roles = (array) $u->roles;
+				$role = $roles ? reset($roles) : '';
+				$uid = (int)$u->ID;
+				$ids[] = $uid;
+				$items[$uid] = [
+					'id'       => $uid,
+					'username' => $u->user_login,
+					'email'    => $u->user_email,
+					'role'     => $role,
+					'guesses'  => 0,
+					'wins'     => 0,
+				];
+			}
+		}
 
-        global $wpdb;
-        if (!empty($ids)) {
-            $in = implode(',', array_map('intval', $ids));
-            $g_table = $wpdb->prefix . 'bhg_guesses';
-            $w_table = $wpdb->prefix . 'bhg_tournament_results';
+		global $wpdb;
+		if (!empty($ids)) {
+			$in = implode(',', array_map('intval', $ids));
+			$g_table = $wpdb->prefix . 'bhg_guesses';
+			$w_table = $wpdb->prefix . 'bhg_tournament_results';
 
-            // Guesses per user
-            $placeholders = implode(',', array_fill(0, count($ids), '%d'));
-            $sql_g = "SELECT user_id, COUNT(*) c FROM `$g_table` WHERE user_id IN ($placeholders) GROUP BY user_id";
-            $g_counts = $wpdb->get_results( $wpdb->prepare( $sql_g, $ids ) );
-            foreach ( (array) $g_counts as $row ) {
-                $uid = (int)$row->user_id;
-                if (isset($items[ $uid ])) $items[$uid]['guesses'] = (int)$row->c;
-            }
+			// Guesses per user
+			$placeholders = implode(',', array_fill(0, count($ids), '%d'));
+			$sql_g = "SELECT user_id, COUNT(*) c FROM `$g_table` WHERE user_id IN ($placeholders) GROUP BY user_id";
+			$g_counts = $wpdb->get_results( $wpdb->prepare( $sql_g, $ids ) );
+			foreach ( (array) $g_counts as $row ) {
+				$uid = (int)$row->user_id;
+				if (isset($items[ $uid ])) $items[$uid]['guesses'] = (int)$row->c;
+			}
 
-            // Wins per user (if table exists)
-            $exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $w_table));
-            if ($exists) {
-                $placeholders = implode(',', array_fill(0, count($ids), '%d'));
-                $sql_w = "SELECT user_id, SUM(wins) c FROM `$w_table` WHERE user_id IN ($placeholders) GROUP BY user_id";
-                $w_counts = $wpdb->get_results( $wpdb->prepare( $sql_w, $ids ) );
-                foreach ( (array) $w_counts as $row ) {
-                    $uid = (int)$row->user_id;
-                    if (isset($items[ $uid ])) $items[$uid]['wins'] = (int)$row->c;
-                }
-            }
-        }
+			// Wins per user (if table exists)
+			$exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $w_table));
+			if ($exists) {
+				$placeholders = implode(',', array_fill(0, count($ids), '%d'));
+				$sql_w = "SELECT user_id, SUM(wins) c FROM `$w_table` WHERE user_id IN ($placeholders) GROUP BY user_id";
+				$w_counts = $wpdb->get_results( $wpdb->prepare( $sql_w, $ids ) );
+				foreach ( (array) $w_counts as $row ) {
+					$uid = (int)$row->user_id;
+					if (isset($items[ $uid ])) $items[$uid]['wins'] = (int)$row->c;
+				}
+			}
+		}
 
-        // Server-side sort for role/guesses/wins
-        if (in_array($orderby, ['role','guesses','wins'], true)) {
-            $items = array_values($items);
-            usort($items, function($a,$b) use ($orderby,$order) {
-                $av = $a[$orderby]; $bv = $b[$orderby];
-                if ($av == $bv) return 0;
-                if ($order === 'ASC') return ($av < $bv) ? -1 : 1;
-                return ($av > $bv) ? -1 : 1;
-            });
-        } else {
-            $items = array_values($items);
-        }
+		// Server-side sort for role/guesses/wins
+		if (in_array($orderby, ['role','guesses','wins'], true)) {
+			$items = array_values($items);
+			usort($items, function($a,$b) use ($orderby,$order) {
+				$av = $a[$orderby]; $bv = $b[$orderby];
+				if ($av == $bv) return 0;
+				if ($order === 'ASC') return ($av < $bv) ? -1 : 1;
+				return ($av > $bv) ? -1 : 1;
+			});
+		} else {
+			$items = array_values($items);
+		}
 
-        $this->items = $items;
-        $this->_column_headers = [$this->get_columns(), [], $this->get_sortable_columns(), 'username'];
+		$this->items = $items;
+		$this->_column_headers = [$this->get_columns(), [], $this->get_sortable_columns(), 'username'];
 
-        $this->set_pagination_args([
-            'total_items' => $this->total_items,
-            'per_page'    => $this->per_page,
-            'total_pages' => ceil($this->total_items / $this->per_page),
-        ]);
-    }
+		$this->set_pagination_args([
+			'total_items' => $this->total_items,
+			'per_page'    => $this->per_page,
+			'total_pages' => ceil($this->total_items / $this->per_page),
+		]);
+	}
 
-    public function extra_tablenav($which) {
-        if ($which === 'top') {
-            echo '<div class="alignleft actions">';
-            $this->search_box( __('Search users','bonus-hunt-guesser'), 'bhg-users' );
-            echo '</div>';
-        }
-    }
+	public function extra_tablenav($which) {
+		if ($which === 'top') {
+			echo '<div class="alignleft actions">';
+			$this->search_box( __('Search users','bonus-hunt-guesser'), 'bhg-users' );
+			echo '</div>';
+		}
+	}
 }

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -1,14 +1,14 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) {
-    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }
 
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_ads';
 $allowed_tables = [ $wpdb->prefix . 'bhg_ads' ];
 if ( ! in_array( $table, $allowed_tables, true ) ) {
-    wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+	wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
 $table  = esc_sql( $table );
 
@@ -17,17 +17,17 @@ $ad_id  = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
 
 // Delete action
 if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
-    $nonce = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
-    if ( wp_verify_nonce( $nonce, 'bhg_delete_ad' ) && current_user_can( 'manage_options' ) ) {
-        $wpdb->delete( $table, [ 'id' => $ad_id ], [ '%d' ] );
-        wp_safe_redirect( remove_query_arg( [ 'action', 'id', '_wpnonce' ] ) );
-        exit;
-    }
+	$nonce = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
+	if ( wp_verify_nonce( $nonce, 'bhg_delete_ad' ) && current_user_can( 'manage_options' ) ) {
+		$wpdb->delete( $table, [ 'id' => $ad_id ], [ '%d' ] );
+		wp_safe_redirect( remove_query_arg( [ 'action', 'id', '_wpnonce' ] ) );
+		exit;
+	}
 }
 
 // Fetch ads
 $ads = $wpdb->get_results(
-    "SELECT * FROM {$table} ORDER BY id DESC"
+	"SELECT * FROM {$table} ORDER BY id DESC"
 );
 ?>
 <div class="wrap">
@@ -35,119 +35,119 @@ $ads = $wpdb->get_results(
 
   <h2 style="margin-top:1em"><?php echo esc_html__('Existing Ads', 'bonus-hunt-guesser'); ?></h2>
   <table class="widefat striped">
-    <thead>
-      <tr>
-        <th><?php echo esc_html__('ID', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Title/Content', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Placement', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Visible To', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Active', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php if (empty($ads)) : ?>
-        <tr><td colspan="6"><?php echo esc_html__('No ads yet.', 'bonus-hunt-guesser'); ?></td></tr>
-      <?php else : foreach ($ads as $ad) : ?>
-        <tr>
-          <td><?php echo (int)$ad->id; ?></td>
-          <td><?php echo isset($ad->title) && $ad->title !== '' ? esc_html($ad->title) : wp_kses_post(wp_trim_words($ad->content, 12)); ?></td>
-          <td><?php echo esc_html(isset($ad->placement)? $ad->placement : 'none'); ?></td>
-          <td><?php echo esc_html(isset($ad->visible_to)? $ad->visible_to : 'all'); ?></td>
-          <td><?php echo (int)$ad->active === 1 ? esc_html__('Yes','bonus-hunt-guesser') : esc_html__('No','bonus-hunt-guesser'); ?></td>
-          <td>
-            <a class="button" href="<?php echo esc_url(add_query_arg(['edit'=> (int)$ad->id])); ?>"><?php echo esc_html__('Edit', 'bonus-hunt-guesser'); ?></a>
-            <a class="button-link-delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['action'=>'delete','id'=>(int)$ad->id]), 'bhg_delete_ad')); ?>" onclick="return confirm('<?php echo esc_js( __( 'Delete this ad?', 'bonus-hunt-guesser' ) ); ?>');"><?php echo esc_html__('Remove', 'bonus-hunt-guesser'); ?></a>
-          </td>
-        </tr>
-      <?php endforeach; endif; ?>
-    </tbody>
+	<thead>
+	  <tr>
+		<th><?php echo esc_html__('ID', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Title/Content', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Placement', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Visible To', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Active', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
+	  </tr>
+	</thead>
+	<tbody>
+	  <?php if (empty($ads)) : ?>
+		<tr><td colspan="6"><?php echo esc_html__('No ads yet.', 'bonus-hunt-guesser'); ?></td></tr>
+	  <?php else : foreach ($ads as $ad) : ?>
+		<tr>
+		  <td><?php echo (int)$ad->id; ?></td>
+		  <td><?php echo isset($ad->title) && $ad->title !== '' ? esc_html($ad->title) : wp_kses_post(wp_trim_words($ad->content, 12)); ?></td>
+		  <td><?php echo esc_html(isset($ad->placement)? $ad->placement : 'none'); ?></td>
+		  <td><?php echo esc_html(isset($ad->visible_to)? $ad->visible_to : 'all'); ?></td>
+		  <td><?php echo (int)$ad->active === 1 ? esc_html__('Yes','bonus-hunt-guesser') : esc_html__('No','bonus-hunt-guesser'); ?></td>
+		  <td>
+			<a class="button" href="<?php echo esc_url(add_query_arg(['edit'=> (int)$ad->id])); ?>"><?php echo esc_html__('Edit', 'bonus-hunt-guesser'); ?></a>
+			<a class="button-link-delete" href="<?php echo esc_url(wp_nonce_url(add_query_arg(['action'=>'delete','id'=>(int)$ad->id]), 'bhg_delete_ad')); ?>" onclick="return confirm('<?php echo esc_js( __( 'Delete this ad?', 'bonus-hunt-guesser' ) ); ?>');"><?php echo esc_html__('Remove', 'bonus-hunt-guesser'); ?></a>
+		  </td>
+		</tr>
+	  <?php endforeach; endif; ?>
+	</tbody>
   </table>
 
   <h2 style="margin-top:2em"><?php echo isset($_GET['edit']) ? esc_html__('Edit Ad', 'bonus-hunt-guesser') : esc_html__('Add Ad', 'bonus-hunt-guesser'); ?></h2>
   <?php
-    $ad = null;
-    if (isset($_GET['edit'])) {
-        $ad = $wpdb->get_row(
-            $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", (int) $_GET['edit'] )
-        );
-    }
+	$ad = null;
+	if (isset($_GET['edit'])) {
+		$ad = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", (int) $_GET['edit'] )
+		);
+	}
   ?>
   <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="max-width:800px">
-    <?php wp_nonce_field('bhg_save_ad'); ?>
-    <input type="hidden" name="action" value="bhg_save_ad">
-    <?php if ($ad) : ?>
-      <input type="hidden" name="id" value="<?php echo (int)$ad->id; ?>">
-    <?php endif; ?>
+	<?php wp_nonce_field('bhg_save_ad'); ?>
+	<input type="hidden" name="action" value="bhg_save_ad">
+	<?php if ($ad) : ?>
+	  <input type="hidden" name="id" value="<?php echo (int)$ad->id; ?>">
+	<?php endif; ?>
 
-    <table class="form-table" role="presentation">
-      <tbody>
-        <tr>
-          <th scope="row"><label for="bhg_ad_title"><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input class="regular-text" id="bhg_ad_title" name="title" value="<?php echo esc_attr($ad ? ($ad->title ?? '') : ''); ?>"></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_ad_content"><?php echo esc_html__('Content', 'bonus-hunt-guesser'); ?></label></th>
-          <td><textarea class="large-text" rows="3" id="bhg_ad_content" name="content"><?php echo esc_textarea($ad ? ($ad->content ?? '') : ''); ?></textarea></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_ad_link"><?php echo esc_html__('Link URL (optional)', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input class="regular-text" id="bhg_ad_link" name="link_url" value="<?php echo esc_attr($ad ? ($ad->link_url ?? '') : ''); ?>"></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_ad_place"><?php echo esc_html__('Placement', 'bonus-hunt-guesser'); ?></label></th>
-          <td>
-            <select id="bhg_ad_place" name="placement">
-              <?php
-                $placement_opts   = ['none', 'footer', 'bottom', 'sidebar', 'shortcode'];
-                $placement_labels = [
-                    'none'      => __('None', 'bonus-hunt-guesser'),
-                    'footer'    => __('Footer', 'bonus-hunt-guesser'),
-                    'bottom'    => __('Bottom', 'bonus-hunt-guesser'),
-                    'sidebar'   => __('Sidebar', 'bonus-hunt-guesser'),
-                    'shortcode' => __('Shortcode', 'bonus-hunt-guesser'),
-                ];
-                $sel = $ad ? ($ad->placement ?? 'none') : 'none';
-                foreach ( $placement_opts as $o ) {
-                    $label = $placement_labels[ $o ] ?? $o;
-                    echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
-                }
-              ?>
-            </select>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_ad_vis"><?php echo esc_html__('Visible To', 'bonus-hunt-guesser'); ?></label></th>
-          <td>
-            <select id="bhg_ad_vis" name="visible_to">
-              <?php
-                $visible_opts   = ['all', 'guests', 'logged_in', 'affiliates', 'non_affiliates'];
-                $visible_labels = [
-                    'all'            => __('All', 'bonus-hunt-guesser'),
-                    'guests'         => __('Guests', 'bonus-hunt-guesser'),
-                    'logged_in'      => __('Logged In', 'bonus-hunt-guesser'),
-                    'affiliates'     => __('Affiliates', 'bonus-hunt-guesser'),
-                    'non_affiliates' => __('Non Affiliates', 'bonus-hunt-guesser'),
-                ];
-                $sel = $ad ? ($ad->visible_to ?? 'all') : 'all';
-                foreach ( $visible_opts as $o ) {
-                    $label = $visible_labels[ $o ] ?? $o;
-                    echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
-                }
-              ?>
-            </select>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_ad_targets"><?php echo esc_html__('Target Page Slugs', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input class="regular-text" id="bhg_ad_targets" name="target_pages" value="<?php echo esc_attr($ad ? ($ad->target_pages ?? '') : ''); ?>" placeholder="page-slug-1,page-slug-2"></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_ad_active"><?php echo esc_html__('Active', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input type="checkbox" id="bhg_ad_active" name="active" value="1" <?php checked($ad ? ($ad->active ?? 1) : 1, 1); ?>></td>
-        </tr>
-      </tbody>
-    </table>
-    <?php submit_button($ad ? __('Update Ad', 'bonus-hunt-guesser') : __('Create Ad', 'bonus-hunt-guesser')); ?>
+	<table class="form-table" role="presentation">
+	  <tbody>
+		<tr>
+		  <th scope="row"><label for="bhg_ad_title"><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input class="regular-text" id="bhg_ad_title" name="title" value="<?php echo esc_attr($ad ? ($ad->title ?? '') : ''); ?>"></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_ad_content"><?php echo esc_html__('Content', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><textarea class="large-text" rows="3" id="bhg_ad_content" name="content"><?php echo esc_textarea($ad ? ($ad->content ?? '') : ''); ?></textarea></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_ad_link"><?php echo esc_html__('Link URL (optional)', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input class="regular-text" id="bhg_ad_link" name="link_url" value="<?php echo esc_attr($ad ? ($ad->link_url ?? '') : ''); ?>"></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_ad_place"><?php echo esc_html__('Placement', 'bonus-hunt-guesser'); ?></label></th>
+		  <td>
+			<select id="bhg_ad_place" name="placement">
+			  <?php
+				$placement_opts   = ['none', 'footer', 'bottom', 'sidebar', 'shortcode'];
+				$placement_labels = [
+					'none'      => __('None', 'bonus-hunt-guesser'),
+					'footer'    => __('Footer', 'bonus-hunt-guesser'),
+					'bottom'    => __('Bottom', 'bonus-hunt-guesser'),
+					'sidebar'   => __('Sidebar', 'bonus-hunt-guesser'),
+					'shortcode' => __('Shortcode', 'bonus-hunt-guesser'),
+				];
+				$sel = $ad ? ($ad->placement ?? 'none') : 'none';
+				foreach ( $placement_opts as $o ) {
+					$label = $placement_labels[ $o ] ?? $o;
+					echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
+				}
+			  ?>
+			</select>
+		  </td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_ad_vis"><?php echo esc_html__('Visible To', 'bonus-hunt-guesser'); ?></label></th>
+		  <td>
+			<select id="bhg_ad_vis" name="visible_to">
+			  <?php
+				$visible_opts   = ['all', 'guests', 'logged_in', 'affiliates', 'non_affiliates'];
+				$visible_labels = [
+					'all'            => __('All', 'bonus-hunt-guesser'),
+					'guests'         => __('Guests', 'bonus-hunt-guesser'),
+					'logged_in'      => __('Logged In', 'bonus-hunt-guesser'),
+					'affiliates'     => __('Affiliates', 'bonus-hunt-guesser'),
+					'non_affiliates' => __('Non Affiliates', 'bonus-hunt-guesser'),
+				];
+				$sel = $ad ? ($ad->visible_to ?? 'all') : 'all';
+				foreach ( $visible_opts as $o ) {
+					$label = $visible_labels[ $o ] ?? $o;
+					echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
+				}
+			  ?>
+			</select>
+		  </td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_ad_targets"><?php echo esc_html__('Target Page Slugs', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input class="regular-text" id="bhg_ad_targets" name="target_pages" value="<?php echo esc_attr($ad ? ($ad->target_pages ?? '') : ''); ?>" placeholder="page-slug-1,page-slug-2"></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_ad_active"><?php echo esc_html__('Active', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input type="checkbox" id="bhg_ad_active" name="active" value="1" <?php checked($ad ? ($ad->active ?? 1) : 1, 1); ?>></td>
+		</tr>
+	  </tbody>
+	</table>
+	<?php submit_button($ad ? __('Update Ad', 'bonus-hunt-guesser') : __('Create Ad', 'bonus-hunt-guesser')); ?>
   </form>
 </div>

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -1,7 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) {
-    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_affiliates';
@@ -18,63 +18,63 @@ $rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 
   <h2 style="margin-top:1em"><?php echo esc_html__('All Affiliate Websites', 'bonus-hunt-guesser'); ?></h2>
   <table class="widefat striped">
-    <thead>
-      <tr>
-        <th><?php esc_html_e('ID','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Name','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('URL','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Status','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Actions','bonus-hunt-guesser'); ?></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php if (empty($rows)) : ?>
-        <tr><td colspan="5"><em><?php esc_html_e('No affiliates yet.','bonus-hunt-guesser'); ?></em></td></tr>
-      <?php else : foreach ($rows as $r) : ?>
-        <tr>
-          <td><?php echo (int)$r->id; ?></td>
-          <td><?php echo esc_html($r->name); ?></td>
-          <td><?php echo esc_html($r->url); ?></td>
-          <td><?php echo esc_html($r->status); ?></td>
-          <td>
-            <a class="button" href="<?php echo esc_url(add_query_arg(['edit'=>(int)$r->id])); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
-            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline" onsubmit="return confirm('<?php echo esc_js(__('Delete this affiliate?', 'bonus-hunt-guesser')); ?>');">
-              <?php wp_nonce_field('bhg_delete_affiliate'); ?>
-              <input type="hidden" name="action" value="bhg_delete_affiliate">
-              <input type="hidden" name="id" value="<?php echo (int)$r->id; ?>">
-              <button class="button-link-delete" type="submit"><?php esc_html_e('Remove','bonus-hunt-guesser'); ?></button>
-            </form>
-          </td>
-        </tr>
-      <?php endforeach; endif; ?>
-    </tbody>
+	<thead>
+	  <tr>
+		<th><?php esc_html_e('ID','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Name','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('URL','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Status','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Actions','bonus-hunt-guesser'); ?></th>
+	  </tr>
+	</thead>
+	<tbody>
+	  <?php if (empty($rows)) : ?>
+		<tr><td colspan="5"><em><?php esc_html_e('No affiliates yet.','bonus-hunt-guesser'); ?></em></td></tr>
+	  <?php else : foreach ($rows as $r) : ?>
+		<tr>
+		  <td><?php echo (int)$r->id; ?></td>
+		  <td><?php echo esc_html($r->name); ?></td>
+		  <td><?php echo esc_html($r->url); ?></td>
+		  <td><?php echo esc_html($r->status); ?></td>
+		  <td>
+			<a class="button" href="<?php echo esc_url(add_query_arg(['edit'=>(int)$r->id])); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
+			<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline" onsubmit="return confirm('<?php echo esc_js(__('Delete this affiliate?', 'bonus-hunt-guesser')); ?>');">
+			  <?php wp_nonce_field('bhg_delete_affiliate'); ?>
+			  <input type="hidden" name="action" value="bhg_delete_affiliate">
+			  <input type="hidden" name="id" value="<?php echo (int)$r->id; ?>">
+			  <button class="button-link-delete" type="submit"><?php esc_html_e('Remove','bonus-hunt-guesser'); ?></button>
+			</form>
+		  </td>
+		</tr>
+	  <?php endforeach; endif; ?>
+	</tbody>
   </table>
 
   <h2 style="margin-top:2em"><?php echo $row ? esc_html__('Edit Affiliate','bonus-hunt-guesser') : esc_html__('Add Affiliate','bonus-hunt-guesser'); ?></h2>
   <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="max-width:800px">
-    <?php wp_nonce_field('bhg_save_affiliate'); ?>
-    <input type="hidden" name="action" value="bhg_save_affiliate">
-    <?php if ($row): ?><input type="hidden" name="id" value="<?php echo (int)$row->id; ?>"><?php endif; ?>
-    <table class="form-table">
-      <tr>
-        <th><label for="aff_name"><?php esc_html_e('Name','bonus-hunt-guesser'); ?></label></th>
-        <td><input class="regular-text" id="aff_name" name="name" value="<?php echo esc_attr($row->name ?? ''); ?>" required></td>
-      </tr>
-      <tr>
-        <th><label for="aff_url"><?php esc_html_e('URL','bonus-hunt-guesser'); ?></label></th>
-        <td><input class="regular-text" id="aff_url" name="url" value="<?php echo esc_attr($row->url ?? ''); ?>" placeholder="https://example.com"></td>
-      </tr>
-      <tr>
-        <th><label for="aff_status"><?php esc_html_e('Status','bonus-hunt-guesser'); ?></label></th>
-        <td>
-          <select id="aff_status" name="status">
-            <?php $opts=['active','inactive']; $cur = $row->status ?? 'active'; foreach ($opts as $o): ?>
-              <option value="<?php echo esc_attr($o); ?>" <?php selected($cur, $o); ?>><?php echo esc_html(ucfirst($o)); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </td>
-      </tr>
-    </table>
-    <?php submit_button($row ? __('Update Affiliate','bonus-hunt-guesser') : __('Create Affiliate','bonus-hunt-guesser')); ?>
+	<?php wp_nonce_field('bhg_save_affiliate'); ?>
+	<input type="hidden" name="action" value="bhg_save_affiliate">
+	<?php if ($row): ?><input type="hidden" name="id" value="<?php echo (int)$row->id; ?>"><?php endif; ?>
+	<table class="form-table">
+	  <tr>
+		<th><label for="aff_name"><?php esc_html_e('Name','bonus-hunt-guesser'); ?></label></th>
+		<td><input class="regular-text" id="aff_name" name="name" value="<?php echo esc_attr($row->name ?? ''); ?>" required></td>
+	  </tr>
+	  <tr>
+		<th><label for="aff_url"><?php esc_html_e('URL','bonus-hunt-guesser'); ?></label></th>
+		<td><input class="regular-text" id="aff_url" name="url" value="<?php echo esc_attr($row->url ?? ''); ?>" placeholder="https://example.com"></td>
+	  </tr>
+	  <tr>
+		<th><label for="aff_status"><?php esc_html_e('Status','bonus-hunt-guesser'); ?></label></th>
+		<td>
+		  <select id="aff_status" name="status">
+			<?php $opts=['active','inactive']; $cur = $row->status ?? 'active'; foreach ($opts as $o): ?>
+			  <option value="<?php echo esc_attr($o); ?>" <?php selected($cur, $o); ?>><?php echo esc_html(ucfirst($o)); ?></option>
+			<?php endforeach; ?>
+		  </select>
+		</td>
+	  </tr>
+	</table>
+	<?php submit_button($row ? __('Update Affiliate','bonus-hunt-guesser') : __('Create Affiliate','bonus-hunt-guesser')); ?>
   </form>
 </div>

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -8,31 +8,31 @@ $guesses = $wpdb->prefix.'bhg_guesses';
 $hunt = $wpdb->get_row($wpdb->prepare("SELECT * FROM `$hunts` WHERE id=%d",$hunt_id));
 if(!$hunt) { echo '<div class="wrap"><h1>'.esc_html__('Hunt not found','bonus-hunt-guesser').'</h1></div>'; return; }
 $rows = $wpdb->get_results(
-    $wpdb->prepare(
-        "SELECT g.*, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
-        (float) $hunt->final_balance,
-        $hunt_id
-    )
+	$wpdb->prepare(
+		"SELECT g.*, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
+		(float) $hunt->final_balance,
+		$hunt_id
+	)
 );
 ?>
 <div class="wrap">
   <h1><?php echo esc_html__('Results for ','bonus-hunt-guesser').esc_html($hunt->title); ?></h1>
   <table class="widefat striped">
-    <thead><tr>
-      <th><?php esc_html_e('Position','bonus-hunt-guesser'); ?></th>
-      <th><?php esc_html_e('User','bonus-hunt-guesser'); ?></th>
-      <th><?php esc_html_e('Guess','bonus-hunt-guesser'); ?></th>
-      <th><?php esc_html_e('Difference','bonus-hunt-guesser'); ?></th>
-    </tr></thead>
-    <tbody>
-    <?php $pos=1; foreach($rows as $r): $wcount = (int)$hunt->winners_count; if ($wcount < 1) $wcount = 3; $isWinner = $pos <= $wcount; ?>
-      <tr <?php if($isWinner) echo 'class="bhg-winner-row"'; ?>>
-        <td><?php echo (int)$pos; ?></td>
-        <td><?php echo esc_html($r->display_name); ?></td>
-        <td><?php echo esc_html(number_format_i18n((float)$r->guess,2)); ?></td>
-        <td><?php echo esc_html(number_format_i18n((float)$r->diff,2)); ?></td>
-      </tr>
-    <?php $pos++; endforeach; ?>
-    </tbody>
+	<thead><tr>
+	  <th><?php esc_html_e('Position','bonus-hunt-guesser'); ?></th>
+	  <th><?php esc_html_e('User','bonus-hunt-guesser'); ?></th>
+	  <th><?php esc_html_e('Guess','bonus-hunt-guesser'); ?></th>
+	  <th><?php esc_html_e('Difference','bonus-hunt-guesser'); ?></th>
+	</tr></thead>
+	<tbody>
+	<?php $pos=1; foreach($rows as $r): $wcount = (int)$hunt->winners_count; if ($wcount < 1) $wcount = 3; $isWinner = $pos <= $wcount; ?>
+	  <tr <?php if($isWinner) echo 'class="bhg-winner-row"'; ?>>
+		<td><?php echo (int)$pos; ?></td>
+		<td><?php echo esc_html($r->display_name); ?></td>
+		<td><?php echo esc_html(number_format_i18n((float)$r->guess,2)); ?></td>
+		<td><?php echo esc_html(number_format_i18n((float)$r->diff,2)); ?></td>
+	  </tr>
+	<?php $pos++; endforeach; ?>
+	</tbody>
   </table>
 </div>

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -6,20 +6,20 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  */
 
 if ( ! current_user_can( 'manage_options' ) ) {
-    wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 global $wpdb;
 $hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
 $guesses_table = $wpdb->prefix . 'bhg_guesses';
 $allowed_tables = [
-    $wpdb->prefix . 'bhg_bonus_hunts',
-    $wpdb->prefix . 'bhg_guesses',
-    $wpdb->prefix . 'bhg_affiliates',
-    $wpdb->users,
+	$wpdb->prefix . 'bhg_bonus_hunts',
+	$wpdb->prefix . 'bhg_guesses',
+	$wpdb->prefix . 'bhg_affiliates',
+	$wpdb->users,
 ];
 if ( ! in_array( $hunts_table, $allowed_tables, true ) || ! in_array( $guesses_table, $allowed_tables, true ) ) {
-    wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+	wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
 $hunts_table   = esc_sql( $hunts_table );
 $guesses_table = esc_sql( $guesses_table );
@@ -28,52 +28,52 @@ $view = isset( $_GET['view'] ) ? sanitize_text_field( $_GET['view'] ) : 'list';
 
 /** LIST VIEW */
 if ( 'list' === $view ) :
-    $hunts = $wpdb->get_results(
-        "SELECT * FROM {$hunts_table} ORDER BY id DESC"
-    );
+	$hunts = $wpdb->get_results(
+		"SELECT * FROM {$hunts_table} ORDER BY id DESC"
+	);
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Bonus Hunts', 'bonus-hunt-guesser'); ?></h1>
   <a href="<?php echo esc_url(add_query_arg(['view'=>'add'])); ?>" class="page-title-action"><?php echo esc_html__('Add New', 'bonus-hunt-guesser'); ?></a>
 
   <?php if ( isset( $_GET['closed'] ) && '1' === $_GET['closed'] ) : ?>
-    <div class="notice notice-success is-dismissible"><p><?php echo esc_html__( 'Hunt closed successfully.', 'bonus-hunt-guesser' ); ?></p></div>
+	<div class="notice notice-success is-dismissible"><p><?php echo esc_html__( 'Hunt closed successfully.', 'bonus-hunt-guesser' ); ?></p></div>
   <?php endif; ?>
 
   <table class="widefat striped bhg-margin-top-small">
-    <thead>
-      <tr>
-        <th><?php echo esc_html__('ID', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Start Balance', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Final Balance', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Winners', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php if ( empty( $hunts ) ) : ?>
-        <tr><td colspan="7"><?php echo esc_html__('No hunts found.', 'bonus-hunt-guesser'); ?></td></tr>
-      <?php else : foreach ( $hunts as $h ) : ?>
-        <tr>
-          <td><?php echo (int) $h->id; ?></td>
-          <td><a href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html( $h->title ); ?></a></td>
-          <td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-          <td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : '—'; ?></td>
-          <td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
-          <td><?php echo esc_html( $h->status ); ?></td>
-          <td>
-            <a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Edit', 'bonus-hunt-guesser' ); ?></a>
-            <?php if ( 'open' === $h->status ) : ?>
-              <a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'close', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
-            <?php elseif ( $h->final_balance !== null ) : ?>
-              <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
-            <?php endif; ?>
-          </td>
-        </tr>
-      <?php endforeach; endif; ?>
-    </tbody>
+	<thead>
+	  <tr>
+		<th><?php echo esc_html__('ID', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Start Balance', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Final Balance', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Winners', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
+	  </tr>
+	</thead>
+	<tbody>
+	  <?php if ( empty( $hunts ) ) : ?>
+		<tr><td colspan="7"><?php echo esc_html__('No hunts found.', 'bonus-hunt-guesser'); ?></td></tr>
+	  <?php else : foreach ( $hunts as $h ) : ?>
+		<tr>
+		  <td><?php echo (int) $h->id; ?></td>
+		  <td><a href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html( $h->title ); ?></a></td>
+		  <td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
+		  <td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : '—'; ?></td>
+		  <td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
+		  <td><?php echo esc_html( $h->status ); ?></td>
+		  <td>
+			<a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Edit', 'bonus-hunt-guesser' ); ?></a>
+			<?php if ( 'open' === $h->status ) : ?>
+			  <a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'close', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
+			<?php elseif ( $h->final_balance !== null ) : ?>
+			  <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
+			<?php endif; ?>
+		  </td>
+		</tr>
+	  <?php endforeach; endif; ?>
+	</tbody>
   </table>
 </div>
 <?php endif; ?>
@@ -81,33 +81,33 @@ if ( 'list' === $view ) :
 <?php
 /** CLOSE VIEW */
 if ( 'close' === $view ) :
-    $id   = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
-    $hunt = $wpdb->get_row(
-        $wpdb->prepare( "SELECT * FROM {$hunts_table} WHERE id = %d", $id )
-    );
-    if ( ! $hunt || 'open' !== $hunt->status ) :
-        echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) . '</p></div>';
-    else :
+	$id   = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
+	$hunt = $wpdb->get_row(
+		$wpdb->prepare( "SELECT * FROM {$hunts_table} WHERE id = %d", $id )
+	);
+	if ( ! $hunt || 'open' !== $hunt->status ) :
+		echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) . '</p></div>';
+	else :
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__( 'Close Bonus Hunt', 'bonus-hunt-guesser' ); ?> — <?php echo esc_html( $hunt->title ); ?></h1>
   <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-400 bhg-margin-top-small">
-    <?php wp_nonce_field( 'bhg_close_hunt' ); ?>
-    <input type="hidden" name="action" value="bhg_close_hunt" />
-    <input type="hidden" name="hunt_id" value="<?php echo (int) $hunt->id; ?>" />
-    <table class="form-table" role="presentation">
-      <tbody>
-        <tr>
-          <th scope="row"><label for="bhg_final_balance"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>
-          <td><input type="number" step="0.01" min="0" id="bhg_final_balance" name="final_balance" required></td>
-        </tr>
-      </tbody>
-    </table>
-    <?php submit_button( __( 'Close Hunt', 'bonus-hunt-guesser' ) ); ?>
+	<?php wp_nonce_field( 'bhg_close_hunt' ); ?>
+	<input type="hidden" name="action" value="bhg_close_hunt" />
+	<input type="hidden" name="hunt_id" value="<?php echo (int) $hunt->id; ?>" />
+	<table class="form-table" role="presentation">
+	  <tbody>
+		<tr>
+		  <th scope="row"><label for="bhg_final_balance"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>
+		  <td><input type="number" step="0.01" min="0" id="bhg_final_balance" name="final_balance" required></td>
+		</tr>
+	  </tbody>
+	</table>
+	<?php submit_button( __( 'Close Hunt', 'bonus-hunt-guesser' ) ); ?>
   </form>
 </div>
 <?php
-    endif;
+	endif;
 endif;
 ?>
 
@@ -117,69 +117,69 @@ if ($view === 'add') : ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Add New Bonus Hunt', 'bonus-hunt-guesser'); ?></h1>
   <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-    <?php wp_nonce_field('bhg_save_hunt'); ?>
-    <input type="hidden" name="action" value="bhg_save_hunt" />
+	<?php wp_nonce_field('bhg_save_hunt'); ?>
+	<input type="hidden" name="action" value="bhg_save_hunt" />
 
-    <table class="form-table" role="presentation">
-      <tbody>
-        <tr>
-          <th scope="row"><label for="bhg_title"><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input required class="regular-text" id="bhg_title" name="title" value=""></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_starting"><?php echo esc_html__('Starting Balance', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value=""></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_num"><?php echo esc_html__('Number of Bonuses', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input type="number" min="0" id="bhg_num" name="num_bonuses" value=""></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_prizes"><?php echo esc_html__('Prizes', 'bonus-hunt-guesser'); ?></label></th>
-          <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"></textarea></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
-          <td>
-            <?php
-            $aff_table = $wpdb->prefix . 'bhg_affiliates';
-            if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
-                wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
-            }
-            $aff_table = esc_sql( $aff_table );
-            $affs      = $wpdb->get_results(
-                "SELECT id, name FROM {$aff_table} ORDER BY name ASC"
-            );
-            $sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
-            ?>
-            <select id="bhg_affiliate" name="affiliate_site_id">
-              <option value="0"><?php echo esc_html__('None', 'bonus-hunt-guesser'); ?></option>
-              <?php foreach ($affs as $a): ?>
-                <option value="<?php echo (int)$a->id; ?>" <?php if ($sel === (int)$a->id) echo 'selected'; ?>><?php echo esc_html($a->name); ?></option>
-              <?php endforeach; ?>
-            </select>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_winners"><?php echo esc_html__('Number of Winners', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="3"></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_status"><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></label></th>
-          <td>
-            <select id="bhg_status" name="status">
-              <option value="open"><?php echo esc_html__('Open', 'bonus-hunt-guesser'); ?></option>
-              <option value="closed"><?php echo esc_html__('Closed', 'bonus-hunt-guesser'); ?></option>
-            </select>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_final"><?php echo esc_html__('Final Balance (optional)', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value=""></td>
-        </tr>
-      </tbody>
-    </table>
-    <?php submit_button(__('Create Bonus Hunt', 'bonus-hunt-guesser')); ?>
+	<table class="form-table" role="presentation">
+	  <tbody>
+		<tr>
+		  <th scope="row"><label for="bhg_title"><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input required class="regular-text" id="bhg_title" name="title" value=""></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_starting"><?php echo esc_html__('Starting Balance', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value=""></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_num"><?php echo esc_html__('Number of Bonuses', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input type="number" min="0" id="bhg_num" name="num_bonuses" value=""></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_prizes"><?php echo esc_html__('Prizes', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"></textarea></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
+		  <td>
+			<?php
+			$aff_table = $wpdb->prefix . 'bhg_affiliates';
+			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
+				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+			}
+			$aff_table = esc_sql( $aff_table );
+			$affs      = $wpdb->get_results(
+				"SELECT id, name FROM {$aff_table} ORDER BY name ASC"
+			);
+			$sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+			?>
+			<select id="bhg_affiliate" name="affiliate_site_id">
+			  <option value="0"><?php echo esc_html__('None', 'bonus-hunt-guesser'); ?></option>
+			  <?php foreach ($affs as $a): ?>
+				<option value="<?php echo (int)$a->id; ?>" <?php if ($sel === (int)$a->id) echo 'selected'; ?>><?php echo esc_html($a->name); ?></option>
+			  <?php endforeach; ?>
+			</select>
+		  </td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_winners"><?php echo esc_html__('Number of Winners', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="3"></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_status"><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></label></th>
+		  <td>
+			<select id="bhg_status" name="status">
+			  <option value="open"><?php echo esc_html__('Open', 'bonus-hunt-guesser'); ?></option>
+			  <option value="closed"><?php echo esc_html__('Closed', 'bonus-hunt-guesser'); ?></option>
+			</select>
+		  </td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_final"><?php echo esc_html__('Final Balance (optional)', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value=""></td>
+		</tr>
+	  </tbody>
+	</table>
+	<?php submit_button(__('Create Bonus Hunt', 'bonus-hunt-guesser')); ?>
   </form>
 </div>
 <?php endif; ?>
@@ -187,129 +187,129 @@ if ($view === 'add') : ?>
 <?php
 /** EDIT VIEW */
 if ($view === 'edit') :
-    $id    = isset($_GET['id']) ? (int) $_GET['id'] : 0;
-    $hunt  = $wpdb->get_row(
-        $wpdb->prepare( "SELECT * FROM {$hunts_table} WHERE id = %d", $id )
-    );
-    if (!$hunt) {
-        echo '<div class="notice notice-error"><p>'.esc_html__('Invalid hunt', 'bonus-hunt-guesser').'</p></div>';
-        return;
-    }
-    $users_table = $wpdb->users;
-    if ( ! in_array( $users_table, $allowed_tables, true ) ) {
-        wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
-    }
-    $users_table = esc_sql( $users_table );
-    $guesses     = $wpdb->get_results(
-        $wpdb->prepare(
-            "SELECT g.*, u.display_name FROM {$guesses_table} g LEFT JOIN {$users_table} u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC",
-            $id
-        )
-    );
+	$id    = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+	$hunt  = $wpdb->get_row(
+		$wpdb->prepare( "SELECT * FROM {$hunts_table} WHERE id = %d", $id )
+	);
+	if (!$hunt) {
+		echo '<div class="notice notice-error"><p>'.esc_html__('Invalid hunt', 'bonus-hunt-guesser').'</p></div>';
+		return;
+	}
+	$users_table = $wpdb->users;
+	if ( ! in_array( $users_table, $allowed_tables, true ) ) {
+		wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+	}
+	$users_table = esc_sql( $users_table );
+	$guesses     = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT g.*, u.display_name FROM {$guesses_table} g LEFT JOIN {$users_table} u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC",
+			$id
+		)
+	);
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Edit Bonus Hunt', 'bonus-hunt-guesser'); ?> — <?php echo esc_html($hunt->title); ?></h1>
 
   <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-    <?php wp_nonce_field('bhg_save_hunt'); ?>
-    <input type="hidden" name="action" value="bhg_save_hunt" />
-    <input type="hidden" name="id" value="<?php echo (int)$hunt->id; ?>" />
+	<?php wp_nonce_field('bhg_save_hunt'); ?>
+	<input type="hidden" name="action" value="bhg_save_hunt" />
+	<input type="hidden" name="id" value="<?php echo (int)$hunt->id; ?>" />
 
-    <table class="form-table" role="presentation">
-      <tbody>
-        <tr>
-          <th scope="row"><label for="bhg_title"><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input required class="regular-text" id="bhg_title" name="title" value="<?php echo esc_attr($hunt->title); ?>"></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_starting"><?php echo esc_html__('Starting Balance', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value="<?php echo esc_attr($hunt->starting_balance); ?>"></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_num"><?php echo esc_html__('Number of Bonuses', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input type="number" min="0" id="bhg_num" name="num_bonuses" value="<?php echo esc_attr($hunt->num_bonuses); ?>"></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_prizes"><?php echo esc_html__('Prizes', 'bonus-hunt-guesser'); ?></label></th>
-          <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"><?php echo esc_textarea($hunt->prizes); ?></textarea></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
-          <td>
-            <?php
-            $aff_table = $wpdb->prefix . 'bhg_affiliates';
-            if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
-                wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
-            }
-            $aff_table = esc_sql( $aff_table );
-            $affs      = $wpdb->get_results(
-                "SELECT id, name FROM {$aff_table} ORDER BY name ASC"
-            );
-            $sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
-            ?>
-            <select id="bhg_affiliate" name="affiliate_site_id">
-              <option value="0"><?php echo esc_html__('None', 'bonus-hunt-guesser'); ?></option>
-              <?php foreach ($affs as $a): ?>
-                <option value="<?php echo (int)$a->id; ?>" <?php if ($sel === (int)$a->id) echo 'selected'; ?>><?php echo esc_html($a->name); ?></option>
-              <?php endforeach; ?>
-            </select>
-          </td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_winners"><?php echo esc_html__('Number of Winners', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr($hunt->winners_count ?: 3); ?>"></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_final"><?php echo esc_html__('Final Balance', 'bonus-hunt-guesser'); ?></label></th>
-          <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr($hunt->final_balance); ?>" placeholder="—"></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="bhg_status"><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></label></th>
-          <td>
-            <select id="bhg_status" name="status">
-              <option value="open" <?php selected($hunt->status, 'open'); ?>><?php echo esc_html__('Open', 'bonus-hunt-guesser'); ?></option>
-              <option value="closed" <?php selected($hunt->status, 'closed'); ?>><?php echo esc_html__('Closed', 'bonus-hunt-guesser'); ?></option>
-            </select>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <?php submit_button(__('Save Hunt', 'bonus-hunt-guesser')); ?>
+	<table class="form-table" role="presentation">
+	  <tbody>
+		<tr>
+		  <th scope="row"><label for="bhg_title"><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input required class="regular-text" id="bhg_title" name="title" value="<?php echo esc_attr($hunt->title); ?>"></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_starting"><?php echo esc_html__('Starting Balance', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value="<?php echo esc_attr($hunt->starting_balance); ?>"></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_num"><?php echo esc_html__('Number of Bonuses', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input type="number" min="0" id="bhg_num" name="num_bonuses" value="<?php echo esc_attr($hunt->num_bonuses); ?>"></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_prizes"><?php echo esc_html__('Prizes', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"><?php echo esc_textarea($hunt->prizes); ?></textarea></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
+		  <td>
+			<?php
+			$aff_table = $wpdb->prefix . 'bhg_affiliates';
+			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
+				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+			}
+			$aff_table = esc_sql( $aff_table );
+			$affs      = $wpdb->get_results(
+				"SELECT id, name FROM {$aff_table} ORDER BY name ASC"
+			);
+			$sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+			?>
+			<select id="bhg_affiliate" name="affiliate_site_id">
+			  <option value="0"><?php echo esc_html__('None', 'bonus-hunt-guesser'); ?></option>
+			  <?php foreach ($affs as $a): ?>
+				<option value="<?php echo (int)$a->id; ?>" <?php if ($sel === (int)$a->id) echo 'selected'; ?>><?php echo esc_html($a->name); ?></option>
+			  <?php endforeach; ?>
+			</select>
+		  </td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_winners"><?php echo esc_html__('Number of Winners', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr($hunt->winners_count ?: 3); ?>"></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_final"><?php echo esc_html__('Final Balance', 'bonus-hunt-guesser'); ?></label></th>
+		  <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr($hunt->final_balance); ?>" placeholder="—"></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="bhg_status"><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></label></th>
+		  <td>
+			<select id="bhg_status" name="status">
+			  <option value="open" <?php selected($hunt->status, 'open'); ?>><?php echo esc_html__('Open', 'bonus-hunt-guesser'); ?></option>
+			  <option value="closed" <?php selected($hunt->status, 'closed'); ?>><?php echo esc_html__('Closed', 'bonus-hunt-guesser'); ?></option>
+			</select>
+		  </td>
+		</tr>
+	  </tbody>
+	</table>
+	<?php submit_button(__('Save Hunt', 'bonus-hunt-guesser')); ?>
   </form>
 
   <h2 class="bhg-margin-top-large"><?php echo esc_html__('Participants', 'bonus-hunt-guesser'); ?></h2>
   <table class="widefat striped">
-    <thead>
-      <tr>
-        <th><?php echo esc_html__('User', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Guess', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php if (empty($guesses)) : ?>
-        <tr><td colspan="3"><?php echo esc_html__('No participants yet.', 'bonus-hunt-guesser'); ?></td></tr>
-      <?php else : foreach ($guesses as $g) : ?>
-        <tr>
-          <td>
-            <?php
-              $name = $g->display_name ? $g->display_name : ('user#' . (int)$g->user_id);
-              $url  = admin_url('user-edit.php?user_id=' . (int)$g->user_id);
-              echo '<a href="' . esc_url($url) . '">' . esc_html($name) . '</a>';
-            ?>
-          </td>
-          <td><?php echo esc_html(number_format_i18n((float)($g->guess ?? 0), 2)); ?></td>
-          <td>
-            <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" onsubmit="return confirm('<?php echo esc_js(__('Delete this guess?', 'bonus-hunt-guesser')); ?>');" class="bhg-inline-form">
-              <?php wp_nonce_field('bhg_delete_guess'); ?>
-              <input type="hidden" name="action" value="bhg_delete_guess">
-              <input type="hidden" name="guess_id" value="<?php echo (int)$g->id; ?>">
-              <button type="submit" class="button-link-delete"><?php echo esc_html__('Remove', 'bonus-hunt-guesser'); ?></button>
-            </form>
-          </td>
-        </tr>
-      <?php endforeach; endif; ?>
-    </tbody>
+	<thead>
+	  <tr>
+		<th><?php echo esc_html__('User', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Guess', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
+	  </tr>
+	</thead>
+	<tbody>
+	  <?php if (empty($guesses)) : ?>
+		<tr><td colspan="3"><?php echo esc_html__('No participants yet.', 'bonus-hunt-guesser'); ?></td></tr>
+	  <?php else : foreach ($guesses as $g) : ?>
+		<tr>
+		  <td>
+			<?php
+			  $name = $g->display_name ? $g->display_name : ('user#' . (int)$g->user_id);
+			  $url  = admin_url('user-edit.php?user_id=' . (int)$g->user_id);
+			  echo '<a href="' . esc_url($url) . '">' . esc_html($name) . '</a>';
+			?>
+		  </td>
+		  <td><?php echo esc_html(number_format_i18n((float)($g->guess ?? 0), 2)); ?></td>
+		  <td>
+			<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" onsubmit="return confirm('<?php echo esc_js(__('Delete this guess?', 'bonus-hunt-guesser')); ?>');" class="bhg-inline-form">
+			  <?php wp_nonce_field('bhg_delete_guess'); ?>
+			  <input type="hidden" name="action" value="bhg_delete_guess">
+			  <input type="hidden" name="guess_id" value="<?php echo (int)$g->id; ?>">
+			  <button type="submit" class="button-link-delete"><?php echo esc_html__('Remove', 'bonus-hunt-guesser'); ?></button>
+			</form>
+		  </td>
+		</tr>
+	  <?php endforeach; endif; ?>
+	</tbody>
   </table>
 </div>
 <?php endif; ?>

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -1,21 +1,21 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 if ( ! current_user_can( 'manage_options' ) ) {
-    wp_die(
-        __( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' )
-    );
+	wp_die(
+		__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' )
+	);
 }
 
 if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {
-    wp_die(
-        __(
-            'Helper function bhg_get_latest_closed_hunts() missing. Please include class-bhg-bonus-hunts.php helpers.',
-            'bonus-hunt-guesser'
-        )
-    );
+	wp_die(
+		__(
+			'Helper function bhg_get_latest_closed_hunts() missing. Please include class-bhg-bonus-hunts.php helpers.',
+			'bonus-hunt-guesser'
+		)
+	);
 }
 
 $hunts = bhg_get_latest_closed_hunts( 3 );
@@ -23,54 +23,54 @@ $hunts = bhg_get_latest_closed_hunts( 3 );
 <div class="wrap">
   <h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
   <table class="widefat striped">
-    <thead>
-      <tr>
-        <th><?php esc_html_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?></th>
-        <th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
-        <th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
-        <th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
-        <th><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php if ( $hunts ) : ?>
-        <?php foreach ( $hunts as $h ) : ?>
-          <?php
-          $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
-              ? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
-              : array();
-          ?>
-          <tr>
-            <td><?php echo esc_html( $h->title ); ?></td>
-            <td>
-              <?php
-              if ( $winners ) {
-                  $out = array();
-                  foreach ( $winners as $w ) {
-                      $u  = get_userdata( (int) $w->user_id );
-                      $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-                      $out[] = sprintf(
-                          '%s — %s (%s %s)',
-                          esc_html( $nm ),
-                          esc_html( number_format_i18n( (float) $w->guess, 2 ) ),
-                          esc_html__( 'diff', 'bonus-hunt-guesser' ),
-                          esc_html( number_format_i18n( (float) $w->diff, 2 ) )
-                      );
-                  }
-                  echo esc_html( implode( ' • ', $out ) );
-              } else {
-                  esc_html_e( 'No winners yet', 'bonus-hunt-guesser' );
-              }
-              ?>
-            </td>
-            <td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-            <td><?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : '—'; ?></td>
-            <td><?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : '—'; ?></td>
-          </tr>
-        <?php endforeach; ?>
-      <?php else : ?>
-        <tr><td colspan="5"><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></td></tr>
-      <?php endif; ?>
-    </tbody>
+	<thead>
+	  <tr>
+		<th><?php esc_html_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
+		<th><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?></th>
+	  </tr>
+	</thead>
+	<tbody>
+	  <?php if ( $hunts ) : ?>
+		<?php foreach ( $hunts as $h ) : ?>
+		  <?php
+		  $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
+			  ? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
+			  : array();
+		  ?>
+		  <tr>
+			<td><?php echo esc_html( $h->title ); ?></td>
+			<td>
+			  <?php
+			  if ( $winners ) {
+				  $out = array();
+				  foreach ( $winners as $w ) {
+					  $u  = get_userdata( (int) $w->user_id );
+					  $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
+					  $out[] = sprintf(
+						  '%s — %s (%s %s)',
+						  esc_html( $nm ),
+						  esc_html( number_format_i18n( (float) $w->guess, 2 ) ),
+						  esc_html__( 'diff', 'bonus-hunt-guesser' ),
+						  esc_html( number_format_i18n( (float) $w->diff, 2 ) )
+					  );
+				  }
+				  echo esc_html( implode( ' • ', $out ) );
+			  } else {
+				  esc_html_e( 'No winners yet', 'bonus-hunt-guesser' );
+			  }
+			  ?>
+			</td>
+			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
+			<td><?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : '—'; ?></td>
+			<td><?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : '—'; ?></td>
+		  </tr>
+		<?php endforeach; ?>
+	  <?php else : ?>
+		<tr><td colspan="5"><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></td></tr>
+	  <?php endif; ?>
+	</tbody>
   </table>
 </div>

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -2,169 +2,169 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if (!current_user_can('manage_options')) {
-    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }
 
 // Handle form submissions
 if (isset($_POST['bhg_action'])) {
-    if ($_POST['bhg_action'] === 'db_cleanup' && isset($_POST['bhg_db_cleanup'])) {
-        if (!wp_verify_nonce($_POST['bhg_nonce'], 'bhg_db_cleanup_action')) {
-            wp_die(esc_html__('Security check failed', 'bonus-hunt-guesser'));
-        }
-        
-        // Perform database cleanup
-        bhg_database_cleanup();
-        $cleanup_completed = true;
-    } 
-    elseif ($_POST['bhg_action'] === 'db_optimize' && isset($_POST['bhg_db_optimize'])) {
-        if (!wp_verify_nonce($_POST['bhg_nonce'], 'bhg_db_optimize_action')) {
-            wp_die(esc_html__('Security check failed', 'bonus-hunt-guesser'));
-        }
-        
-        // Perform database optimization
-        bhg_database_optimize();
-        $optimize_completed = true;
-    }
+	if ($_POST['bhg_action'] === 'db_cleanup' && isset($_POST['bhg_db_cleanup'])) {
+		if (!wp_verify_nonce($_POST['bhg_nonce'], 'bhg_db_cleanup_action')) {
+			wp_die(esc_html__('Security check failed', 'bonus-hunt-guesser'));
+		}
+		
+		// Perform database cleanup
+		bhg_database_cleanup();
+		$cleanup_completed = true;
+	} 
+	elseif ($_POST['bhg_action'] === 'db_optimize' && isset($_POST['bhg_db_optimize'])) {
+		if (!wp_verify_nonce($_POST['bhg_nonce'], 'bhg_db_optimize_action')) {
+			wp_die(esc_html__('Security check failed', 'bonus-hunt-guesser'));
+		}
+		
+		// Perform database optimization
+		bhg_database_optimize();
+		$optimize_completed = true;
+	}
 }
 
 // Database cleanup function
 function bhg_database_cleanup() {
-    global $wpdb;
-    
-    $tables = array(
-        $wpdb->prefix . 'bhg_bonus_hunts',
-        $wpdb->prefix . 'bhg_guesses',
-        $wpdb->prefix . 'bhg_tournaments',
-        $wpdb->prefix . 'bhg_tournament_results',
-        $wpdb->prefix . 'bhg_translations',
-        $wpdb->prefix . 'bhg_affiliate_websites',
-        $wpdb->prefix . 'bhg_hunt_winners',
-        $wpdb->prefix . 'bhg_ads'
-    );
-    
-    foreach ( $tables as $table ) {
-        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
-            $wpdb->query( "TRUNCATE TABLE {$table}" );
-        }
-    }
-    
-    // Reinsert default data if needed
-    bhg_insert_demo_data();
+	global $wpdb;
+	
+	$tables = array(
+		$wpdb->prefix . 'bhg_bonus_hunts',
+		$wpdb->prefix . 'bhg_guesses',
+		$wpdb->prefix . 'bhg_tournaments',
+		$wpdb->prefix . 'bhg_tournament_results',
+		$wpdb->prefix . 'bhg_translations',
+		$wpdb->prefix . 'bhg_affiliate_websites',
+		$wpdb->prefix . 'bhg_hunt_winners',
+		$wpdb->prefix . 'bhg_ads'
+	);
+	
+	foreach ( $tables as $table ) {
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
+			$wpdb->query( "TRUNCATE TABLE {$table}" );
+		}
+	}
+	
+	// Reinsert default data if needed
+	bhg_insert_demo_data();
 }
 
 // Database optimization function
 function bhg_database_optimize() {
-    global $wpdb;
-    
-    $tables = array(
-        $wpdb->prefix . 'bhg_bonus_hunts',
-        $wpdb->prefix . 'bhg_guesses',
-        $wpdb->prefix . 'bhg_tournaments',
-        $wpdb->prefix . 'bhg_tournament_results',
-        $wpdb->prefix . 'bhg_translations',
-        $wpdb->prefix . 'bhg_affiliate_websites',
-        $wpdb->prefix . 'bhg_hunt_winners',
-        $wpdb->prefix . 'bhg_ads'
-    );
-    
-    foreach ( $tables as $table ) {
-        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
-            $wpdb->query( "OPTIMIZE TABLE {$table}" );
-        }
-    }
+	global $wpdb;
+	
+	$tables = array(
+		$wpdb->prefix . 'bhg_bonus_hunts',
+		$wpdb->prefix . 'bhg_guesses',
+		$wpdb->prefix . 'bhg_tournaments',
+		$wpdb->prefix . 'bhg_tournament_results',
+		$wpdb->prefix . 'bhg_translations',
+		$wpdb->prefix . 'bhg_affiliate_websites',
+		$wpdb->prefix . 'bhg_hunt_winners',
+		$wpdb->prefix . 'bhg_ads'
+	);
+	
+	foreach ( $tables as $table ) {
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
+			$wpdb->query( "OPTIMIZE TABLE {$table}" );
+		}
+	}
 }
 
 // Demo data insertion function (simplified version)
 function bhg_insert_demo_data() {
-    // This would typically be in a separate file like includes/demo.php
-    global $wpdb;
-    
-    // Insert default bonus hunt
-    $wpdb->insert(
-        $wpdb->prefix . 'bhg_bonus_hunts',
-        array(
-            'title' => 'Demo Bonus Hunt',
-            'starting_balance' => 2000,
-            'number_of_bonuses' => 10,
-            'status' => 'active',
-            'created_at' => current_time('mysql')
-        ),
-        array('%s', '%d', '%d', '%s', '%s')
-    );
+	// This would typically be in a separate file like includes/demo.php
+	global $wpdb;
+	
+	// Insert default bonus hunt
+	$wpdb->insert(
+		$wpdb->prefix . 'bhg_bonus_hunts',
+		array(
+			'title' => 'Demo Bonus Hunt',
+			'starting_balance' => 2000,
+			'number_of_bonuses' => 10,
+			'status' => 'active',
+			'created_at' => current_time('mysql')
+		),
+		array('%s', '%d', '%d', '%s', '%s')
+	);
 }
 ?>
 <div class="wrap bhg-wrap">
-    <h1><?php esc_html_e('Database Tools', 'bonus-hunt-guesser'); ?></h1>
-    <p><?php esc_html_e('Tables are automatically created on activation. If you need to reinstall them, deactivate and activate the plugin again.', 'bonus-hunt-guesser'); ?></p>
-    
-    <?php if (isset($cleanup_completed) && $cleanup_completed) : ?>
-        <div class="notice notice-success">
-            <p><?php esc_html_e('Database cleanup completed successfully.', 'bonus-hunt-guesser'); ?></p>
-        </div>
-    <?php endif; ?>
-    
-    <?php if (isset($optimize_completed) && $optimize_completed) : ?>
-        <div class="notice notice-success">
-            <p><?php esc_html_e('Database optimization completed successfully.', 'bonus-hunt-guesser'); ?></p>
-        </div>
-    <?php endif; ?>
-    
-    <form method="post" action="">
-        <?php wp_nonce_field('bhg_db_cleanup_action', 'bhg_nonce'); ?>
-        <input type="hidden" name="bhg_action" value="db_cleanup">
-        <p>
-            <input type="submit" name="bhg_db_cleanup" class="button button-secondary" value="<?php esc_attr_e('Run Database Cleanup', 'bonus-hunt-guesser'); ?>"
-                   onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to run database cleanup? This action cannot be undone.', 'bonus-hunt-guesser' ) ); ?>')">
-        </p>
-        <p class="description">
-            <?php esc_html_e('Note: This will remove any demo data and reset tables to their initial state.', 'bonus-hunt-guesser'); ?>
-        </p>
-    </form>
-    
-    <h2><?php esc_html_e('Current Database Status', 'bonus-hunt-guesser'); ?></h2>
-    <table class="wp-list-table widefat fixed striped">
-        <thead>
-            <tr>
-                <th><?php esc_html_e('Table Name', 'bonus-hunt-guesser'); ?></th>
-                <th><?php esc_html_e('Status', 'bonus-hunt-guesser'); ?></th>
-                <th><?php esc_html_e('Rows', 'bonus-hunt-guesser'); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php
-            global $wpdb;
-            $tables = array(
-                'bhg_bonus_hunts',
-                'bhg_guesses',
-                'bhg_tournaments',
-                'bhg_tournament_results',
-                'bhg_translations',
-                'bhg_affiliate_websites',
-                'bhg_hunt_winners',
-                'bhg_ads'
-            );
-            
-            foreach ( $tables as $table ) {
-                $table_name = $wpdb->prefix . $table;
-                $exists     = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name;
-                $row_count  = $exists ? (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$table_name}`" ) : 0;
-                
-                echo '<tr>';
-                echo '<td>' . esc_html($table_name) . '</td>';
-                echo '<td><span class="' . ($exists ? 'dashicons dashicons-yes-alt" style="color: #46b450"' : 'dashicons dashicons-no" style="color: #dc3232"') . '"></span> ' . ($exists ? esc_html__('Exists', 'bonus-hunt-guesser') : esc_html__('Missing', 'bonus-hunt-guesser')) . '</td>';
-                echo '<td>' . esc_html(number_format_i18n($row_count)) . '</td>';
-                echo '</tr>';
-            }
-            ?>
-        </tbody>
-    </table>
-    
-    <h2><?php esc_html_e('Database Maintenance', 'bonus-hunt-guesser'); ?></h2>
-    <form method="post" action="">
-        <?php wp_nonce_field('bhg_db_optimize_action', 'bhg_nonce'); ?>
-        <input type="hidden" name="bhg_action" value="db_optimize">
-        <p>
-            <input type="submit" name="bhg_db_optimize" class="button button-primary" value="<?php esc_attr_e('Optimize Database Tables', 'bonus-hunt-guesser'); ?>">
-        </p>
-    </form>
+	<h1><?php esc_html_e('Database Tools', 'bonus-hunt-guesser'); ?></h1>
+	<p><?php esc_html_e('Tables are automatically created on activation. If you need to reinstall them, deactivate and activate the plugin again.', 'bonus-hunt-guesser'); ?></p>
+	
+	<?php if (isset($cleanup_completed) && $cleanup_completed) : ?>
+		<div class="notice notice-success">
+			<p><?php esc_html_e('Database cleanup completed successfully.', 'bonus-hunt-guesser'); ?></p>
+		</div>
+	<?php endif; ?>
+	
+	<?php if (isset($optimize_completed) && $optimize_completed) : ?>
+		<div class="notice notice-success">
+			<p><?php esc_html_e('Database optimization completed successfully.', 'bonus-hunt-guesser'); ?></p>
+		</div>
+	<?php endif; ?>
+	
+	<form method="post" action="">
+		<?php wp_nonce_field('bhg_db_cleanup_action', 'bhg_nonce'); ?>
+		<input type="hidden" name="bhg_action" value="db_cleanup">
+		<p>
+			<input type="submit" name="bhg_db_cleanup" class="button button-secondary" value="<?php esc_attr_e('Run Database Cleanup', 'bonus-hunt-guesser'); ?>"
+				   onclick="return confirm('<?php echo esc_js( __( 'Are you sure you want to run database cleanup? This action cannot be undone.', 'bonus-hunt-guesser' ) ); ?>')">
+		</p>
+		<p class="description">
+			<?php esc_html_e('Note: This will remove any demo data and reset tables to their initial state.', 'bonus-hunt-guesser'); ?>
+		</p>
+	</form>
+	
+	<h2><?php esc_html_e('Current Database Status', 'bonus-hunt-guesser'); ?></h2>
+	<table class="wp-list-table widefat fixed striped">
+		<thead>
+			<tr>
+				<th><?php esc_html_e('Table Name', 'bonus-hunt-guesser'); ?></th>
+				<th><?php esc_html_e('Status', 'bonus-hunt-guesser'); ?></th>
+				<th><?php esc_html_e('Rows', 'bonus-hunt-guesser'); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php
+			global $wpdb;
+			$tables = array(
+				'bhg_bonus_hunts',
+				'bhg_guesses',
+				'bhg_tournaments',
+				'bhg_tournament_results',
+				'bhg_translations',
+				'bhg_affiliate_websites',
+				'bhg_hunt_winners',
+				'bhg_ads'
+			);
+			
+			foreach ( $tables as $table ) {
+				$table_name = $wpdb->prefix . $table;
+				$exists     = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) === $table_name;
+				$row_count  = $exists ? (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$table_name}`" ) : 0;
+				
+				echo '<tr>';
+				echo '<td>' . esc_html($table_name) . '</td>';
+				echo '<td><span class="' . ($exists ? 'dashicons dashicons-yes-alt" style="color: #46b450"' : 'dashicons dashicons-no" style="color: #dc3232"') . '"></span> ' . ($exists ? esc_html__('Exists', 'bonus-hunt-guesser') : esc_html__('Missing', 'bonus-hunt-guesser')) . '</td>';
+				echo '<td>' . esc_html(number_format_i18n($row_count)) . '</td>';
+				echo '</tr>';
+			}
+			?>
+		</tbody>
+	</table>
+	
+	<h2><?php esc_html_e('Database Maintenance', 'bonus-hunt-guesser'); ?></h2>
+	<form method="post" action="">
+		<?php wp_nonce_field('bhg_db_optimize_action', 'bhg_nonce'); ?>
+		<input type="hidden" name="bhg_action" value="db_optimize">
+		<p>
+			<input type="submit" name="bhg_db_optimize" class="button button-primary" value="<?php esc_attr_e('Optimize Database Tables', 'bonus-hunt-guesser'); ?>">
+		</p>
+	</form>
 </div>

--- a/admin/views/demo-tools.php
+++ b/admin/views/demo-tools.php
@@ -1,14 +1,14 @@
 <?php
 if (!defined('ABSPATH')) {
-    exit;
+	exit;
 }
 ?>
 <div class="wrap">
-    <h1><?php esc_html_e('Demo Tools', 'bonus-hunt-guesser'); ?></h1>
-    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
-        <input type="hidden" name="action" value="bhg_demo_reseed">
-        <?php wp_nonce_field('bhg_demo_reseed_action', 'bhg_demo_reseed_nonce'); ?>
-        <p><?php esc_html_e('This will delete all demo data and pages, then recreate fresh demo content.', 'bonus-hunt-guesser'); ?></p>
-        <p><input type="submit" class="button button-primary" value="<?php esc_attr_e('Reset & Reseed Demo Data', 'bonus-hunt-guesser'); ?>"></p>
-    </form>
+	<h1><?php esc_html_e('Demo Tools', 'bonus-hunt-guesser'); ?></h1>
+	<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+		<input type="hidden" name="action" value="bhg_demo_reseed">
+		<?php wp_nonce_field('bhg_demo_reseed_action', 'bhg_demo_reseed_nonce'); ?>
+		<p><?php esc_html_e('This will delete all demo data and pages, then recreate fresh demo content.', 'bonus-hunt-guesser'); ?></p>
+		<p><input type="submit" class="button button-primary" value="<?php esc_attr_e('Reset & Reseed Demo Data', 'bonus-hunt-guesser'); ?>"></p>
+	</form>
 </div>

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -9,15 +9,15 @@ check_admin_referer('bhg_edit_hunt_' . $hunt_id, 'bhg_nonce');
 
 // Handle delete guess action
 if (isset($_POST['bhg_remove_guess']) && isset($_POST['bhg_remove_guess_nonce']) && wp_verify_nonce($_POST['bhg_remove_guess_nonce'], 'bhg_remove_guess_action')) {
-    $guess_id = (int) ($_POST['guess_id'] ?? 0);
-    if ($guess_id > 0 && function_exists('bhg_remove_guess')) {
-        bhg_remove_guess($guess_id);
-        echo '<div class="notice notice-success is-dismissible"><p>'.esc_html__('Guess removed.','bonus-hunt-guesser').'</p></div>';
-    }
+	$guess_id = (int) ($_POST['guess_id'] ?? 0);
+	if ($guess_id > 0 && function_exists('bhg_remove_guess')) {
+		bhg_remove_guess($guess_id);
+		echo '<div class="notice notice-success is-dismissible"><p>'.esc_html__('Guess removed.','bonus-hunt-guesser').'</p></div>';
+	}
 }
 
 if (!function_exists('bhg_get_hunt') || !function_exists('bhg_get_hunt_participants')) {
-    wp_die(esc_html__('Missing helper functions. Please include class-bhg-bonus-hunts-helpers.php.', 'bonus-hunt-guesser'));
+	wp_die(esc_html__('Missing helper functions. Please include class-bhg-bonus-hunts-helpers.php.', 'bonus-hunt-guesser'));
 }
 
 $hunt = bhg_get_hunt($hunt_id);
@@ -39,51 +39,51 @@ $pages = max(1, (int) ceil($total / $per_page));
   <p><?php echo esc_html(sprintf(_n('%s participant', '%s participants', $total, 'bonus-hunt-guesser'), number_format_i18n($total))); ?></p>
 
   <table class="widefat striped">
-    <thead>
-      <tr>
-        <th><?php esc_html_e('User','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Guess','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Date','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Actions','bonus-hunt-guesser'); ?></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php if ($rows): foreach ($rows as $r): 
-        $u = get_userdata((int)$r->user_id);
-        $name = $u ? $u->user_login : ('#'.$r->user_id);
-      ?>
-        <tr>
-          <td><a href="<?php echo esc_url( admin_url('user-edit.php?user_id='.(int)$r->user_id) ); ?>"><?php echo esc_html($name); ?></a></td>
-          <td><?php echo esc_html(number_format_i18n((float)$r->guess, 2)); ?></td>
-          <td><?php echo $r->created_at ? esc_html(date_i18n(get_option('date_format').' '.get_option('time_format'), strtotime($r->created_at))) : '—'; ?></td>
-          <td>
-            <form method="post" style="display:inline">
-              <?php wp_nonce_field('bhg_remove_guess_action','bhg_remove_guess_nonce'); ?>
-              <input type="hidden" name="guess_id" value="<?php echo (int)$r->id; ?>">
-              <button type="submit" name="bhg_remove_guess" class="button button-link-delete" onclick="return confirm('<?php echo esc_js(__('Remove this guess?','bonus-hunt-guesser')); ?>');">
-                <?php esc_html_e('Remove','bonus-hunt-guesser'); ?>
-              </button>
-            </form>
-          </td>
-        </tr>
-      <?php endforeach; else: ?>
-        <tr><td colspan="4"><?php esc_html_e('No participants yet.','bonus-hunt-guesser'); ?></td></tr>
-      <?php endif; ?>
-    </tbody>
+	<thead>
+	  <tr>
+		<th><?php esc_html_e('User','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Guess','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Date','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Actions','bonus-hunt-guesser'); ?></th>
+	  </tr>
+	</thead>
+	<tbody>
+	  <?php if ($rows): foreach ($rows as $r): 
+		$u = get_userdata((int)$r->user_id);
+		$name = $u ? $u->user_login : ('#'.$r->user_id);
+	  ?>
+		<tr>
+		  <td><a href="<?php echo esc_url( admin_url('user-edit.php?user_id='.(int)$r->user_id) ); ?>"><?php echo esc_html($name); ?></a></td>
+		  <td><?php echo esc_html(number_format_i18n((float)$r->guess, 2)); ?></td>
+		  <td><?php echo $r->created_at ? esc_html(date_i18n(get_option('date_format').' '.get_option('time_format'), strtotime($r->created_at))) : '—'; ?></td>
+		  <td>
+			<form method="post" style="display:inline">
+			  <?php wp_nonce_field('bhg_remove_guess_action','bhg_remove_guess_nonce'); ?>
+			  <input type="hidden" name="guess_id" value="<?php echo (int)$r->id; ?>">
+			  <button type="submit" name="bhg_remove_guess" class="button button-link-delete" onclick="return confirm('<?php echo esc_js(__('Remove this guess?','bonus-hunt-guesser')); ?>');">
+				<?php esc_html_e('Remove','bonus-hunt-guesser'); ?>
+			  </button>
+			</form>
+		  </td>
+		</tr>
+	  <?php endforeach; else: ?>
+		<tr><td colspan="4"><?php esc_html_e('No participants yet.','bonus-hunt-guesser'); ?></td></tr>
+	  <?php endif; ?>
+	</tbody>
   </table>
 
   <?php if ($pages > 1): ?>
-    <div class="tablenav">
-      <div class="tablenav-pages">
-        <?php
-          $base = remove_query_arg('ppaged');
-          for ($i=1; $i<=$pages; $i++) {
-            $url = esc_url( add_query_arg('ppaged', $i, $base) );
-            $class = $i === $paged ? ' class="page-numbers current"' : ' class="page-numbers"';
-            echo '<a'.$class.' href="'.$url.'">'.$i.'</a> ';
-          }
-        ?>
-      </div>
-    </div>
+	<div class="tablenav">
+	  <div class="tablenav-pages">
+		<?php
+		  $base = remove_query_arg('ppaged');
+		  for ($i=1; $i<=$pages; $i++) {
+			$url = esc_url( add_query_arg('ppaged', $i, $base) );
+			$class = $i === $paged ? ' class="page-numbers current"' : ' class="page-numbers"';
+			echo '<a'.$class.' href="'.$url.'">'.$i.'</a> ';
+		  }
+		?>
+	  </div>
+	</div>
   <?php endif; ?>
 </div>

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -11,12 +11,12 @@ $offset = ($paged - 1) * $per_page;
 
 $rows = $wpdb->get_results(
   $wpdb->prepare(
-    "SELECT id, title, start_balance, final_balance, status, winners_limit, closed_at
-     FROM $t
-     ORDER BY id DESC
-     LIMIT %d OFFSET %d",
-    $per_page,
-    $offset
+	"SELECT id, title, start_balance, final_balance, status, winners_limit, closed_at
+	 FROM $t
+	 ORDER BY id DESC
+	 LIMIT %d OFFSET %d",
+	$per_page,
+	$offset
   )
 );
 $total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $t" );
@@ -26,55 +26,55 @@ $pages = max(1, (int) ceil($total / $per_page));
 <div class="wrap">
   <h1><?php esc_html_e('Bonus Hunts','bonus-hunt-guesser'); ?></h1>
   <table class="widefat striped">
-    <thead>
-      <tr>
-        <th><?php esc_html_e('ID','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Title','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Start Balance','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Final Balance','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Status','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Winners','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Closed At','bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Actions','bonus-hunt-guesser'); ?></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php if ($rows): foreach ($rows as $r): ?>
-        <tr>
-          <td><?php echo (int)$r->id; ?></td>
-          <td><strong><a href="<?php echo esc_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id) ); ?>"><?php echo esc_html($r->title); ?></a></strong></td>
-          <td><?php echo esc_html(number_format_i18n((float)$r->start_balance, 2)); ?></td>
-          <td><?php echo ($r->final_balance !== null) ? esc_html(number_format_i18n((float)$r->final_balance, 2)) : '—'; ?></td>
-          <td><?php echo esc_html($r->status); ?></td>
-          <td><?php echo (int)$r->winners_limit; ?></td>
-          <td><?php echo $r->closed_at ? esc_html(date_i18n(get_option('date_format').' '.get_option('time_format'), strtotime($r->closed_at))) : '—'; ?></td>
-          <td>
-            <?php
-              $results_url = wp_nonce_url( admin_url('admin.php?page=bhg-hunt-results&id='.(int)$r->id), 'bhg_view_results_'.(int)$r->id, 'bhg_nonce' );
-              $edit_url    = wp_nonce_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id), 'bhg_edit_hunt_'.(int)$r->id, 'bhg_nonce' );
-            ?>
-            <a class="button" href="<?php echo esc_url($results_url); ?>"><?php esc_html_e('Results','bonus-hunt-guesser'); ?></a>
-            <a class="button" href="<?php echo esc_url($edit_url); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
-          </td>
-        </tr>
-      <?php endforeach; else: ?>
-        <tr><td colspan="8"><?php esc_html_e('No hunts found.','bonus-hunt-guesser'); ?></td></tr>
-      <?php endif; ?>
-    </tbody>
+	<thead>
+	  <tr>
+		<th><?php esc_html_e('ID','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Title','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Start Balance','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Final Balance','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Status','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Winners','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Closed At','bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Actions','bonus-hunt-guesser'); ?></th>
+	  </tr>
+	</thead>
+	<tbody>
+	  <?php if ($rows): foreach ($rows as $r): ?>
+		<tr>
+		  <td><?php echo (int)$r->id; ?></td>
+		  <td><strong><a href="<?php echo esc_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id) ); ?>"><?php echo esc_html($r->title); ?></a></strong></td>
+		  <td><?php echo esc_html(number_format_i18n((float)$r->start_balance, 2)); ?></td>
+		  <td><?php echo ($r->final_balance !== null) ? esc_html(number_format_i18n((float)$r->final_balance, 2)) : '—'; ?></td>
+		  <td><?php echo esc_html($r->status); ?></td>
+		  <td><?php echo (int)$r->winners_limit; ?></td>
+		  <td><?php echo $r->closed_at ? esc_html(date_i18n(get_option('date_format').' '.get_option('time_format'), strtotime($r->closed_at))) : '—'; ?></td>
+		  <td>
+			<?php
+			  $results_url = wp_nonce_url( admin_url('admin.php?page=bhg-hunt-results&id='.(int)$r->id), 'bhg_view_results_'.(int)$r->id, 'bhg_nonce' );
+			  $edit_url    = wp_nonce_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id), 'bhg_edit_hunt_'.(int)$r->id, 'bhg_nonce' );
+			?>
+			<a class="button" href="<?php echo esc_url($results_url); ?>"><?php esc_html_e('Results','bonus-hunt-guesser'); ?></a>
+			<a class="button" href="<?php echo esc_url($edit_url); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
+		  </td>
+		</tr>
+	  <?php endforeach; else: ?>
+		<tr><td colspan="8"><?php esc_html_e('No hunts found.','bonus-hunt-guesser'); ?></td></tr>
+	  <?php endif; ?>
+	</tbody>
   </table>
 
   <?php if ($pages > 1): ?>
-    <div class="tablenav">
-      <div class="tablenav-pages">
-        <?php
-          $base = remove_query_arg('paged');
-          for ($i=1; $i<=$pages; $i++) {
-            $url = esc_url( add_query_arg('paged', $i, $base) );
-            $class = $i === $paged ? ' class="page-numbers current"' : ' class="page-numbers"';
-            echo '<a'.$class.' href="'.$url.'">'.$i.'</a> ';
-          }
-        ?>
-      </div>
-    </div>
+	<div class="tablenav">
+	  <div class="tablenav-pages">
+		<?php
+		  $base = remove_query_arg('paged');
+		  for ($i=1; $i<=$pages; $i++) {
+			$url = esc_url( add_query_arg('paged', $i, $base) );
+			$class = $i === $paged ? ' class="page-numbers current"' : ' class="page-numbers"';
+			echo '<a'.$class.' href="'.$url.'">'.$i.'</a> ';
+		  }
+		?>
+	  </div>
+	</div>
   <?php endif; ?>
 </div>

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -1,146 +1,146 @@
 <?php
 if (!defined('ABSPATH')) {
-    exit;
+	exit;
 }
 
 // Check user capabilities
 if (!current_user_can('manage_options')) {
-    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }
 
 // Get current settings
 $current_settings = get_option('bhg_plugin_settings', array(
-    'default_tournament_period' => 'monthly',
-    'max_guess_amount' => 100000,
-    'min_guess_amount' => 0,
-    'allow_guess_changes' => 'yes'
+	'default_tournament_period' => 'monthly',
+	'max_guess_amount' => 100000,
+	'min_guess_amount' => 0,
+	'allow_guess_changes' => 'yes'
 ));
 
 // Handle settings save via admin-post.php
 $message = isset($_GET['message']) ? sanitize_text_field(wp_unslash($_GET['message'])) : '';
 if ('saved' === $message) {
-    echo '<div class="notice notice-success is-dismissible"><p>' .
-         esc_html__('Settings saved successfully.', 'bonus-hunt-guesser') .
-         '</p></div>';
+	echo '<div class="notice notice-success is-dismissible"><p>' .
+		 esc_html__('Settings saved successfully.', 'bonus-hunt-guesser') .
+		 '</p></div>';
 }
 
 // Handle error messages
 $error = isset($_GET['error']) ? sanitize_text_field(wp_unslash($_GET['error'])) : '';
 if (!empty($error)) {
-    $error_message = '';
-    switch ($error) {
-        case 'nonce_failed':
-            $error_message = __('Security check failed. Please try again.', 'bonus-hunt-guesser');
-            break;
-        case 'invalid_data':
-            $error_message = __('Invalid data submitted. Please check your inputs.', 'bonus-hunt-guesser');
-            break;
-        default:
-            $error_message = __('An error occurred while saving settings.', 'bonus-hunt-guesser');
-    }
+	$error_message = '';
+	switch ($error) {
+		case 'nonce_failed':
+			$error_message = __('Security check failed. Please try again.', 'bonus-hunt-guesser');
+			break;
+		case 'invalid_data':
+			$error_message = __('Invalid data submitted. Please check your inputs.', 'bonus-hunt-guesser');
+			break;
+		default:
+			$error_message = __('An error occurred while saving settings.', 'bonus-hunt-guesser');
+	}
 
-    if (!empty($error_message)) {
-        echo '<div class="notice notice-error is-dismissible"><p>' . esc_html($error_message) . '</p></div>';
-    }
+	if (!empty($error_message)) {
+		echo '<div class="notice notice-error is-dismissible"><p>' . esc_html($error_message) . '</p></div>';
+	}
 }
 ?>
 
 <div class="wrap">
-    <h1><?php _e('Bonus Hunt Guesser Settings', 'bonus-hunt-guesser'); ?></h1>
-    
-    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
-        <input type="hidden" name="action" value="bhg_save_settings">
-        <?php wp_nonce_field('bhg_save_settings_nonce', 'bhg_settings_nonce'); ?>
-        
-        <?php wp_nonce_field('bhg_save_settings'); ?>
+	<h1><?php _e('Bonus Hunt Guesser Settings', 'bonus-hunt-guesser'); ?></h1>
+	
+	<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+		<input type="hidden" name="action" value="bhg_save_settings">
+		<?php wp_nonce_field('bhg_save_settings_nonce', 'bhg_settings_nonce'); ?>
+		
+		<?php wp_nonce_field('bhg_save_settings'); ?>
 <table class="form-table">
-            <tr>
-                <th scope="row">
-                    <label for="bhg_default_tournament_period">
-                        <?php _e('Default Tournament Period', 'bonus-hunt-guesser'); ?>
-                    </label>
-                </th>
-                <td>
-                    <select name="bhg_default_tournament_period" id="bhg_default_tournament_period" class="regular-text">
-                        <option value="weekly" <?php selected($current_settings['default_tournament_period'], 'weekly'); ?>>
-                            <?php _e('Weekly', 'bonus-hunt-guesser'); ?>
-                        </option>
-                        <option value="monthly" <?php selected($current_settings['default_tournament_period'], 'monthly'); ?>>
-                            <?php _e('Monthly', 'bonus-hunt-guesser'); ?>
-                        </option>
-                        <option value="quarterly" <?php selected($current_settings['default_tournament_period'], 'quarterly'); ?>>
-                            <?php _e('Quarterly', 'bonus-hunt-guesser'); ?>
-                        </option>
-                        <option value="yearly" <?php selected($current_settings['default_tournament_period'], 'yearly'); ?>>
-                            <?php _e('Yearly', 'bonus-hunt-guesser'); ?>
-                        </option>
-                        <option value="alltime" <?php selected($current_settings['default_tournament_period'], 'alltime'); ?>>
-                            <?php _e('All-Time', 'bonus-hunt-guesser'); ?>
-                        </option>
-                    </select>
-                    <p class="description">
-                        <?php _e('Default period for tournament calculations.', 'bonus-hunt-guesser'); ?>
-                    </p>
-                </td>
-            </tr>
-            
-            <tr>
-                <th scope="row">
-                    <label for="bhg_min_guess_amount">
-                        <?php _e('Minimum Guess Amount', 'bonus-hunt-guesser'); ?>
-                    </label>
-                </th>
-                <td>
-                    <input type="number" name="bhg_min_guess_amount" id="bhg_min_guess_amount" 
-                           value="<?php echo esc_attr($current_settings['min_guess_amount']); ?>" 
-                           class="regular-text" step="0.01" min="0" required>
-                    <p class="description">
-                        <?php _e('Minimum amount users can guess for a bonus hunt.', 'bonus-hunt-guesser'); ?>
-                    </p>
-                </td>
-            </tr>
-            
-            <tr>
-                <th scope="row">
-                    <label for="bhg_max_guess_amount">
-                        <?php _e('Maximum Guess Amount', 'bonus-hunt-guesser'); ?>
-                    </label>
-                </th>
-                <td>
-                    <input type="number" name="bhg_max_guess_amount" id="bhg_max_guess_amount" 
-                           value="<?php echo esc_attr($current_settings['max_guess_amount']); ?>" 
-                           class="regular-text" step="0.01" min="0" required>
-                    <p class="description">
-                        <?php _e('Maximum amount users can guess for a bonus hunt.', 'bonus-hunt-guesser'); ?>
-                    </p>
-                </td>
-            </tr>
-            
-            <tr>
-                <th scope="row">
-                    <label for="bhg_allow_guess_changes">
-                        <?php _e('Allow Guess Changes', 'bonus-hunt-guesser'); ?>
-                    </label>
-                </th>
-                <td>
-                    <select name="bhg_allow_guess_changes" id="bhg_allow_guess_changes" class="regular-text">
-                        <option value="yes" <?php selected($current_settings['allow_guess_changes'], 'yes'); ?>>
-                            <?php _e('Yes', 'bonus-hunt-guesser'); ?>
-                        </option>
-                        <option value="no" <?php selected($current_settings['allow_guess_changes'], 'no'); ?>>
-                            <?php _e('No', 'bonus-hunt-guesser'); ?>
-                        </option>
-                    </select>
-                    <p class="description">
-                        <?php _e('Allow users to change their guesses before a bonus hunt closes.', 'bonus-hunt-guesser'); ?>
-                    </p>
-                </td>
-            </tr>
-        </table>
-        
-        <p class="submit">
-            <input type="submit" name="bhg_settings_submit" id="submit" 
-                   class="button button-primary" value="<?php _e('Save Changes', 'bonus-hunt-guesser'); ?>">
-        </p>
-    </form>
+			<tr>
+				<th scope="row">
+					<label for="bhg_default_tournament_period">
+						<?php _e('Default Tournament Period', 'bonus-hunt-guesser'); ?>
+					</label>
+				</th>
+				<td>
+					<select name="bhg_default_tournament_period" id="bhg_default_tournament_period" class="regular-text">
+						<option value="weekly" <?php selected($current_settings['default_tournament_period'], 'weekly'); ?>>
+							<?php _e('Weekly', 'bonus-hunt-guesser'); ?>
+						</option>
+						<option value="monthly" <?php selected($current_settings['default_tournament_period'], 'monthly'); ?>>
+							<?php _e('Monthly', 'bonus-hunt-guesser'); ?>
+						</option>
+						<option value="quarterly" <?php selected($current_settings['default_tournament_period'], 'quarterly'); ?>>
+							<?php _e('Quarterly', 'bonus-hunt-guesser'); ?>
+						</option>
+						<option value="yearly" <?php selected($current_settings['default_tournament_period'], 'yearly'); ?>>
+							<?php _e('Yearly', 'bonus-hunt-guesser'); ?>
+						</option>
+						<option value="alltime" <?php selected($current_settings['default_tournament_period'], 'alltime'); ?>>
+							<?php _e('All-Time', 'bonus-hunt-guesser'); ?>
+						</option>
+					</select>
+					<p class="description">
+						<?php _e('Default period for tournament calculations.', 'bonus-hunt-guesser'); ?>
+					</p>
+				</td>
+			</tr>
+			
+			<tr>
+				<th scope="row">
+					<label for="bhg_min_guess_amount">
+						<?php _e('Minimum Guess Amount', 'bonus-hunt-guesser'); ?>
+					</label>
+				</th>
+				<td>
+					<input type="number" name="bhg_min_guess_amount" id="bhg_min_guess_amount" 
+						   value="<?php echo esc_attr($current_settings['min_guess_amount']); ?>" 
+						   class="regular-text" step="0.01" min="0" required>
+					<p class="description">
+						<?php _e('Minimum amount users can guess for a bonus hunt.', 'bonus-hunt-guesser'); ?>
+					</p>
+				</td>
+			</tr>
+			
+			<tr>
+				<th scope="row">
+					<label for="bhg_max_guess_amount">
+						<?php _e('Maximum Guess Amount', 'bonus-hunt-guesser'); ?>
+					</label>
+				</th>
+				<td>
+					<input type="number" name="bhg_max_guess_amount" id="bhg_max_guess_amount" 
+						   value="<?php echo esc_attr($current_settings['max_guess_amount']); ?>" 
+						   class="regular-text" step="0.01" min="0" required>
+					<p class="description">
+						<?php _e('Maximum amount users can guess for a bonus hunt.', 'bonus-hunt-guesser'); ?>
+					</p>
+				</td>
+			</tr>
+			
+			<tr>
+				<th scope="row">
+					<label for="bhg_allow_guess_changes">
+						<?php _e('Allow Guess Changes', 'bonus-hunt-guesser'); ?>
+					</label>
+				</th>
+				<td>
+					<select name="bhg_allow_guess_changes" id="bhg_allow_guess_changes" class="regular-text">
+						<option value="yes" <?php selected($current_settings['allow_guess_changes'], 'yes'); ?>>
+							<?php _e('Yes', 'bonus-hunt-guesser'); ?>
+						</option>
+						<option value="no" <?php selected($current_settings['allow_guess_changes'], 'no'); ?>>
+							<?php _e('No', 'bonus-hunt-guesser'); ?>
+						</option>
+					</select>
+					<p class="description">
+						<?php _e('Allow users to change their guesses before a bonus hunt closes.', 'bonus-hunt-guesser'); ?>
+					</p>
+				</td>
+			</tr>
+		</table>
+		
+		<p class="submit">
+			<input type="submit" name="bhg_settings_submit" id="submit" 
+				   class="button button-primary" value="<?php _e('Save Changes', 'bonus-hunt-guesser'); ?>">
+		</p>
+	</form>
 </div>

--- a/admin/views/tools.php
+++ b/admin/views/tools.php
@@ -14,17 +14,17 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
   ?>
 
   <div class="card" style="max-width:900px;padding:16px;margin-top:12px;">
-    <h2><?php echo esc_html__('Diagnostics', 'bonus-hunt-guesser'); ?></h2>
-    <?php if (($hunts + $guesses + $users + $ads + $tournaments) > 0): ?>
-      <ul>
-        <li><?php echo esc_html__('Hunts:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($hunts); ?></li>
-        <li><?php echo esc_html__('Guesses:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($guesses); ?></li>
-        <li><?php echo esc_html__('Users:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($users); ?></li>
-        <li><?php echo esc_html__('Ads:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($ads); ?></li>
-        <li><?php echo esc_html__('Tournaments:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($tournaments); ?></li>
-      </ul>
-    <?php else: ?>
-      <p><?php echo esc_html__('Nothing to show yet. Start by creating a hunt or a test user.', 'bonus-hunt-guesser'); ?></p>
-    <?php endif; ?>
+	<h2><?php echo esc_html__('Diagnostics', 'bonus-hunt-guesser'); ?></h2>
+	<?php if (($hunts + $guesses + $users + $ads + $tournaments) > 0): ?>
+	  <ul>
+		<li><?php echo esc_html__('Hunts:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($hunts); ?></li>
+		<li><?php echo esc_html__('Guesses:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($guesses); ?></li>
+		<li><?php echo esc_html__('Users:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($users); ?></li>
+		<li><?php echo esc_html__('Ads:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($ads); ?></li>
+		<li><?php echo esc_html__('Tournaments:', 'bonus-hunt-guesser'); ?> <?php echo number_format_i18n($tournaments); ?></li>
+	  </ul>
+	<?php else: ?>
+	  <p><?php echo esc_html__('Nothing to show yet. Start by creating a hunt or a test user.', 'bonus-hunt-guesser'); ?></p>
+	<?php endif; ?>
   </div>
 </div>

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -1,29 +1,29 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) {
-    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_tournaments';
 $allowed_tables = [ $wpdb->prefix . 'bhg_tournaments' ];
 if ( ! in_array( $table, $allowed_tables, true ) ) {
-    wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+	wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
 $table   = esc_sql( $table );
 
 $edit_id = isset( $_GET['edit'] ) ? (int) $_GET['edit'] : 0;
 $row     = $edit_id
-    ? $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id ) )
-    : null;
+	? $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id ) )
+	: null;
 
 $rows = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY id DESC" );
 
 $labels = [
-    'weekly'    => __( 'Weekly', 'bonus-hunt-guesser' ),
-    'monthly'   => __( 'Monthly', 'bonus-hunt-guesser' ),
-    'quarterly' => __( 'Quarterly', 'bonus-hunt-guesser' ),
-    'yearly'    => __( 'Yearly', 'bonus-hunt-guesser' ),
-    'alltime'   => __( 'Alltime', 'bonus-hunt-guesser' ),
+	'weekly'    => __( 'Weekly', 'bonus-hunt-guesser' ),
+	'monthly'   => __( 'Monthly', 'bonus-hunt-guesser' ),
+	'quarterly' => __( 'Quarterly', 'bonus-hunt-guesser' ),
+	'yearly'    => __( 'Yearly', 'bonus-hunt-guesser' ),
+	'alltime'   => __( 'Alltime', 'bonus-hunt-guesser' ),
 ];
 ?>
 <div class="wrap">
@@ -31,84 +31,84 @@ $labels = [
 
   <h2 class="bhg-margin-top-small"><?php esc_html_e('All Tournaments', 'bonus-hunt-guesser'); ?></h2>
   <table class="widefat striped">
-    <thead>
-      <tr>
-        <th><?php esc_html_e('ID', 'bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Title', 'bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Type', 'bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Start', 'bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('End', 'bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Status', 'bonus-hunt-guesser'); ?></th>
-        <th><?php esc_html_e('Actions', 'bonus-hunt-guesser'); ?></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php if (empty($rows)) : ?>
-        <tr><td colspan="7"><em><?php esc_html_e('No tournaments yet.', 'bonus-hunt-guesser'); ?></em></td></tr>
-      <?php else : foreach ($rows as $r) : ?>
-        <tr>
-          <td><?php echo (int)$r->id; ?></td>
-          <td><?php echo esc_html($r->title); ?></td>
-          <td><?php echo esc_html( $labels[ $r->type ] ?? $r->type ); ?></td>
-          <td><?php echo esc_html($r->start_date); ?></td>
-          <td><?php echo esc_html($r->end_date); ?></td>
-          <td><?php echo esc_html($r->status); ?></td>
-          <td>
-            <a class="button" href="<?php echo esc_url(add_query_arg(['edit' => (int)$r->id])); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
-          </td>
-        </tr>
-      <?php endforeach; endif; ?>
-    </tbody>
+	<thead>
+	  <tr>
+		<th><?php esc_html_e('ID', 'bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Title', 'bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Type', 'bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Start', 'bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('End', 'bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Status', 'bonus-hunt-guesser'); ?></th>
+		<th><?php esc_html_e('Actions', 'bonus-hunt-guesser'); ?></th>
+	  </tr>
+	</thead>
+	<tbody>
+	  <?php if (empty($rows)) : ?>
+		<tr><td colspan="7"><em><?php esc_html_e('No tournaments yet.', 'bonus-hunt-guesser'); ?></em></td></tr>
+	  <?php else : foreach ($rows as $r) : ?>
+		<tr>
+		  <td><?php echo (int)$r->id; ?></td>
+		  <td><?php echo esc_html($r->title); ?></td>
+		  <td><?php echo esc_html( $labels[ $r->type ] ?? $r->type ); ?></td>
+		  <td><?php echo esc_html($r->start_date); ?></td>
+		  <td><?php echo esc_html($r->end_date); ?></td>
+		  <td><?php echo esc_html($r->status); ?></td>
+		  <td>
+			<a class="button" href="<?php echo esc_url(add_query_arg(['edit' => (int)$r->id])); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
+		  </td>
+		</tr>
+	  <?php endforeach; endif; ?>
+	</tbody>
   </table>
 
   <h2 class="bhg-margin-top-large"><?php echo $row ? esc_html__('Edit Tournament', 'bonus-hunt-guesser') : esc_html__('Add Tournament', 'bonus-hunt-guesser'); ?></h2>
   <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900">
-    <?php wp_nonce_field('bhg_tournament_save_action'); ?>
-    <input type="hidden" name="action" value="bhg_tournament_save" />
-    <?php if ($row): ?><input type="hidden" name="id" value="<?php echo (int)$row->id; ?>" /><?php endif; ?>
-    <table class="form-table">
-      <tr>
-        <th><label for="bhg_t_title"><?php esc_html_e('Title','bonus-hunt-guesser'); ?></label></th>
-        <td><input id="bhg_t_title" class="regular-text" name="title" value="<?php echo esc_attr($row->title ?? ''); ?>" required /></td>
-      </tr>
-      <tr>
-        <th><label for="bhg_t_desc"><?php esc_html_e('Description','bonus-hunt-guesser'); ?></label></th>
-        <td><textarea id="bhg_t_desc" class="large-text" rows="4" name="description"><?php echo esc_textarea($row->description ?? ''); ?></textarea></td>
-      </tr>
-      <tr>
-        <th><label for="bhg_t_type"><?php esc_html_e('Type','bonus-hunt-guesser'); ?></label></th>
-        <td>
-          <?php
-          $types = [ 'weekly', 'monthly', 'quarterly', 'yearly', 'alltime' ];
-          $cur   = $row->type ?? 'weekly';
-          ?>
-          <select id="bhg_t_type" name="type">
-            <?php foreach ( $types as $t ) : ?>
-              <option value="<?php echo esc_attr( $t ); ?>" <?php selected( $cur, $t ); ?>><?php echo esc_html( $labels[ $t ] ); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </td>
-      </tr>
-      <tr>
-        <th><label for="bhg_t_start"><?php esc_html_e('Start Date','bonus-hunt-guesser'); ?></label></th>
-        <td><input id="bhg_t_start" type="date" name="start_date" value="<?php echo esc_attr($row->start_date ?? ''); ?>" /></td>
-      </tr>
-      <tr>
-        <th><label for="bhg_t_end"><?php esc_html_e('End Date','bonus-hunt-guesser'); ?></label></th>
-        <td><input id="bhg_t_end" type="date" name="end_date" value="<?php echo esc_attr($row->end_date ?? ''); ?>" /></td>
-      </tr>
-      <tr>
-        <th><label for="bhg_t_status"><?php esc_html_e('Status','bonus-hunt-guesser'); ?></label></th>
-        <td>
-          <?php $st = ['active','archived']; $cur = $row->status ?? 'active'; ?>
-          <select id="bhg_t_status" name="status">
-            <?php foreach ($st as $v): ?>
-              <option value="<?php echo esc_attr($v); ?>" <?php selected($cur, $v); ?>><?php echo esc_html(ucfirst($v)); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </td>
-      </tr>
-    </table>
-    <?php submit_button($row ? __('Update Tournament','bonus-hunt-guesser') : __('Create Tournament','bonus-hunt-guesser')); ?>
+	<?php wp_nonce_field('bhg_tournament_save_action'); ?>
+	<input type="hidden" name="action" value="bhg_tournament_save" />
+	<?php if ($row): ?><input type="hidden" name="id" value="<?php echo (int)$row->id; ?>" /><?php endif; ?>
+	<table class="form-table">
+	  <tr>
+		<th><label for="bhg_t_title"><?php esc_html_e('Title','bonus-hunt-guesser'); ?></label></th>
+		<td><input id="bhg_t_title" class="regular-text" name="title" value="<?php echo esc_attr($row->title ?? ''); ?>" required /></td>
+	  </tr>
+	  <tr>
+		<th><label for="bhg_t_desc"><?php esc_html_e('Description','bonus-hunt-guesser'); ?></label></th>
+		<td><textarea id="bhg_t_desc" class="large-text" rows="4" name="description"><?php echo esc_textarea($row->description ?? ''); ?></textarea></td>
+	  </tr>
+	  <tr>
+		<th><label for="bhg_t_type"><?php esc_html_e('Type','bonus-hunt-guesser'); ?></label></th>
+		<td>
+		  <?php
+		  $types = [ 'weekly', 'monthly', 'quarterly', 'yearly', 'alltime' ];
+		  $cur   = $row->type ?? 'weekly';
+		  ?>
+		  <select id="bhg_t_type" name="type">
+			<?php foreach ( $types as $t ) : ?>
+			  <option value="<?php echo esc_attr( $t ); ?>" <?php selected( $cur, $t ); ?>><?php echo esc_html( $labels[ $t ] ); ?></option>
+			<?php endforeach; ?>
+		  </select>
+		</td>
+	  </tr>
+	  <tr>
+		<th><label for="bhg_t_start"><?php esc_html_e('Start Date','bonus-hunt-guesser'); ?></label></th>
+		<td><input id="bhg_t_start" type="date" name="start_date" value="<?php echo esc_attr($row->start_date ?? ''); ?>" /></td>
+	  </tr>
+	  <tr>
+		<th><label for="bhg_t_end"><?php esc_html_e('End Date','bonus-hunt-guesser'); ?></label></th>
+		<td><input id="bhg_t_end" type="date" name="end_date" value="<?php echo esc_attr($row->end_date ?? ''); ?>" /></td>
+	  </tr>
+	  <tr>
+		<th><label for="bhg_t_status"><?php esc_html_e('Status','bonus-hunt-guesser'); ?></label></th>
+		<td>
+		  <?php $st = ['active','archived']; $cur = $row->status ?? 'active'; ?>
+		  <select id="bhg_t_status" name="status">
+			<?php foreach ($st as $v): ?>
+			  <option value="<?php echo esc_attr($v); ?>" <?php selected($cur, $v); ?>><?php echo esc_html(ucfirst($v)); ?></option>
+			<?php endforeach; ?>
+		  </select>
+		</td>
+	  </tr>
+	</table>
+	<?php submit_button($row ? __('Update Tournament','bonus-hunt-guesser') : __('Create Tournament','bonus-hunt-guesser')); ?>
   </form>
 </div>

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -2,14 +2,14 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 if (!current_user_can('manage_options')) {
-    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }
 
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_translations';
 
 if ( function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
-    bhg_seed_default_translations_if_empty();
+	bhg_seed_default_translations_if_empty();
 }
 
 $default_translations = function_exists( 'bhg_get_default_translations' ) ? bhg_get_default_translations() : array();
@@ -17,26 +17,26 @@ $default_keys        = array_keys( $default_translations );
 
 // Handle form submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bhg_save_translation'])) {
-    // Verify nonce
-    if (!isset($_POST['bhg_nonce']) || !wp_verify_nonce($_POST['bhg_nonce'], 'bhg_save_translation_action')) {
-        wp_die(esc_html__('Security check failed.', 'bonus-hunt-guesser'));
-    }
+	// Verify nonce
+	if (!isset($_POST['bhg_nonce']) || !wp_verify_nonce($_POST['bhg_nonce'], 'bhg_save_translation_action')) {
+		wp_die(esc_html__('Security check failed.', 'bonus-hunt-guesser'));
+	}
 
-    // Sanitize input
-    $tkey   = isset($_POST['tkey']) ? sanitize_text_field(wp_unslash($_POST['tkey'])) : '';
-    $tvalue = isset($_POST['tvalue']) ? sanitize_textarea_field(wp_unslash($_POST['tvalue'])) : '';
+	// Sanitize input
+	$tkey   = isset($_POST['tkey']) ? sanitize_text_field(wp_unslash($_POST['tkey'])) : '';
+	$tvalue = isset($_POST['tvalue']) ? sanitize_textarea_field(wp_unslash($_POST['tvalue'])) : '';
 
-    // Validate input
-    if ($tkey === '') {
-        $error = __('Key field is required.', 'bonus-hunt-guesser');
-    } else {
-        $wpdb->replace(
-            $table,
-            array('tkey' => $tkey, 'tvalue' => $tvalue),
-            array('%s', '%s')
-        );
-        $notice = __('Translation saved.', 'bonus-hunt-guesser');
-    }
+	// Validate input
+	if ($tkey === '') {
+		$error = __('Key field is required.', 'bonus-hunt-guesser');
+	} else {
+		$wpdb->replace(
+			$table,
+			array('tkey' => $tkey, 'tvalue' => $tvalue),
+			array('%s', '%s')
+		);
+		$notice = __('Translation saved.', 'bonus-hunt-guesser');
+	}
 }
 
 // Fetch rows
@@ -46,45 +46,45 @@ $rows = $wpdb->get_results( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC
   <h1><?php esc_html_e('Translations', 'bonus-hunt-guesser'); ?></h1>
 
   <style>
-    .bhg-default-row td { background-color: #fffbcc; }
+	.bhg-default-row td { background-color: #fffbcc; }
   </style>
 
   <?php if (!empty($notice)): ?>
-    <div class="notice notice-success"><p><?php echo esc_html($notice); ?></p></div>
+	<div class="notice notice-success"><p><?php echo esc_html($notice); ?></p></div>
   <?php endif; ?>
   <?php if (!empty($error)): ?>
-    <div class="notice notice-error"><p><?php echo esc_html($error); ?></p></div>
+	<div class="notice notice-error"><p><?php echo esc_html($error); ?></p></div>
   <?php endif; ?>
 
   <form method="post">
-    <?php wp_nonce_field('bhg_save_translation_action', 'bhg_nonce'); ?>
-    <table class="form-table" role="presentation">
-      <tbody>
-        <tr>
-          <th scope="row"><label for="tkey"><?php esc_html_e('Key','bonus-hunt-guesser'); ?></label></th>
-          <td><input name="tkey" id="tkey" type="text" class="regular-text" required></td>
-        </tr>
-        <tr>
-          <th scope="row"><label for="tvalue"><?php esc_html_e('Value','bonus-hunt-guesser'); ?></label></th>
-          <td><textarea name="tvalue" id="tvalue" class="large-text" rows="4"></textarea></td>
-        </tr>
-      </tbody>
-    </table>
-          <p class="submit"><button type="submit" name="bhg_save_translation" class="button button-primary"><?php esc_html_e('Save', 'bonus-hunt-guesser'); ?></button></p>
+	<?php wp_nonce_field('bhg_save_translation_action', 'bhg_nonce'); ?>
+	<table class="form-table" role="presentation">
+	  <tbody>
+		<tr>
+		  <th scope="row"><label for="tkey"><?php esc_html_e('Key','bonus-hunt-guesser'); ?></label></th>
+		  <td><input name="tkey" id="tkey" type="text" class="regular-text" required></td>
+		</tr>
+		<tr>
+		  <th scope="row"><label for="tvalue"><?php esc_html_e('Value','bonus-hunt-guesser'); ?></label></th>
+		  <td><textarea name="tvalue" id="tvalue" class="large-text" rows="4"></textarea></td>
+		</tr>
+	  </tbody>
+	</table>
+		  <p class="submit"><button type="submit" name="bhg_save_translation" class="button button-primary"><?php esc_html_e('Save', 'bonus-hunt-guesser'); ?></button></p>
   </form>
 
   <h2><?php esc_html_e('Existing keys', 'bonus-hunt-guesser'); ?></h2>
   <table class="widefat striped">
-    <thead><tr><th><?php esc_html_e('Key', 'bonus-hunt-guesser'); ?></th><th><?php esc_html_e('Value', 'bonus-hunt-guesser'); ?></th></tr></thead>
-    <tbody>
-      <?php if ($rows): foreach ($rows as $r): ?>
-        <tr<?php echo in_array( $r->tkey, $default_keys, true ) ? ' class="bhg-default-row"' : ''; ?>>
-          <td><code><?php echo esc_html($r->tkey); ?></code></td>
-          <td><?php echo esc_html($r->tvalue); ?></td>
-        </tr>
-      <?php endforeach; else: ?>
-        <tr><td colspan="2"><?php esc_html_e('No translations yet.','bonus-hunt-guesser'); ?></td></tr>
-      <?php endif; ?>
-    </tbody>
+	<thead><tr><th><?php esc_html_e('Key', 'bonus-hunt-guesser'); ?></th><th><?php esc_html_e('Value', 'bonus-hunt-guesser'); ?></th></tr></thead>
+	<tbody>
+	  <?php if ($rows): foreach ($rows as $r): ?>
+		<tr<?php echo in_array( $r->tkey, $default_keys, true ) ? ' class="bhg-default-row"' : ''; ?>>
+		  <td><code><?php echo esc_html($r->tkey); ?></code></td>
+		  <td><?php echo esc_html($r->tvalue); ?></td>
+		</tr>
+	  <?php endforeach; else: ?>
+		<tr><td colspan="2"><?php esc_html_e('No translations yet.','bonus-hunt-guesser'); ?></td></tr>
+	  <?php endif; ?>
+	</tbody>
   </table>
 </div>

--- a/admin/views/users.php
+++ b/admin/views/users.php
@@ -1,7 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 if (!current_user_can('manage_options')) {
-    wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
 }
 
 $paged    = max(1, isset($_GET['paged']) ? (int) $_GET['paged'] : 1);
@@ -10,17 +10,17 @@ $search   = isset($_GET['s']) ? sanitize_text_field($_GET['s']) : '';
 $allowed_orderby = ['user_login', 'display_name', 'user_email'];
 $orderby         = isset($_GET['orderby']) ? sanitize_key($_GET['orderby']) : 'user_login';
 if ( ! in_array( $orderby, $allowed_orderby, true ) ) {
-    $orderby = 'user_login';
+	$orderby = 'user_login';
 }
 $order = ( isset( $_GET['order'] ) && strtolower( $_GET['order'] ) === 'desc' ) ? 'DESC' : 'ASC';
 
 $args = [
-    'number'   => $per_page,
-    'offset'   => ($paged - 1) * $per_page,
-    'orderby'  => $orderby,
-    'order'    => $order,
-    'search'   => $search ? '*' . $search . '*' : '',
-    'search_columns' => ['user_login','user_email','display_name'],
+	'number'   => $per_page,
+	'offset'   => ($paged - 1) * $per_page,
+	'orderby'  => $orderby,
+	'order'    => $order,
+	'search'   => $search ? '*' . $search . '*' : '',
+	'search_columns' => ['user_login','user_email','display_name'],
 ];
 
 $user_query = new WP_User_Query($args);
@@ -33,66 +33,66 @@ $base_url = remove_query_arg(['paged']);
   <h1 class="wp-heading-inline"><?php echo esc_html__('Users', 'bonus-hunt-guesser'); ?></h1>
 
   <form method="get" class="bhg-margin-top-small">
-    <input type="hidden" name="page" value="bhg-users" />
-    <p class="search-box">
-      <label class="screen-reader-text" for="user-search-input"><?php echo esc_html__('Search Users', 'bonus-hunt-guesser'); ?></label>
-      <input type="search" id="user-search-input" name="s" value="<?php echo esc_attr($search); ?>" />
-      <input type="submit" id="search-submit" class="button" value="<?php echo esc_attr__('Search', 'bonus-hunt-guesser'); ?>" />
-    </p>
+	<input type="hidden" name="page" value="bhg-users" />
+	<p class="search-box">
+	  <label class="screen-reader-text" for="user-search-input"><?php echo esc_html__('Search Users', 'bonus-hunt-guesser'); ?></label>
+	  <input type="search" id="user-search-input" name="s" value="<?php echo esc_attr($search); ?>" />
+	  <input type="submit" id="search-submit" class="button" value="<?php echo esc_attr__('Search', 'bonus-hunt-guesser'); ?>" />
+	</p>
   </form>
 
   <table class="widefat striped">
-    <thead>
-      <tr>
-        <th><a href="<?php echo esc_url(add_query_arg(['orderby'=>'user_login','order'=> $order==='ASC'?'desc':'asc'], $base_url)); ?>"><?php echo esc_html__('Username', 'bonus-hunt-guesser'); ?></a></th>
-        <th><a href="<?php echo esc_url(add_query_arg(['orderby'=>'display_name','order'=> $order==='ASC'?'desc':'asc'], $base_url)); ?>"><?php echo esc_html__('Name', 'bonus-hunt-guesser'); ?></a></th>
-        <th><?php echo esc_html__('Real Name', 'bonus-hunt-guesser'); ?></th>
-        <th><a href="<?php echo esc_url(add_query_arg(['orderby'=>'user_email','order'=> $order==='ASC'?'desc':'asc'], $base_url)); ?>"><?php echo esc_html__('Email', 'bonus-hunt-guesser'); ?></a></th>
-        <th><?php echo esc_html__('Affiliate', 'bonus-hunt-guesser'); ?></th>
-        <th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php if (empty($users)) : ?>
-        <tr><td colspan="6"><?php echo esc_html__('No users found.', 'bonus-hunt-guesser'); ?></td></tr>
-      <?php else : foreach ($users as $u) :
-          $form_id    = 'bhg-user-' . (int) $u->ID;
-          $real_name  = get_user_meta($u->ID, 'bhg_real_name', true);
-          $is_aff     = get_user_meta($u->ID, 'bhg_is_affiliate', true);
-      ?>
-        <tr>
-          <td><?php echo esc_html($u->user_login); ?></td>
-          <td><?php echo esc_html($u->display_name); ?></td>
-          <td><input type="text" name="bhg_real_name" form="<?php echo esc_attr($form_id); ?>" value="<?php echo esc_attr($real_name); ?>" /></td>
-          <td><?php echo esc_html($u->user_email); ?></td>
-          <td class="bhg-text-center"><input type="checkbox" name="bhg_is_affiliate" value="1" form="<?php echo esc_attr($form_id); ?>" <?php checked( $is_aff, 1 ); ?> /></td>
-          <td>
-            <form id="<?php echo esc_attr($form_id); ?>" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
-              <input type="hidden" name="action" value="bhg_save_user_meta" />
-              <input type="hidden" name="user_id" value="<?php echo (int) $u->ID; ?>" />
-              <?php wp_nonce_field('bhg_save_user_meta'); ?>
-              <button type="submit" class="button button-primary"><?php echo esc_html__('Save', 'bonus-hunt-guesser'); ?></button>
-            </form>
-            <a class="button" href="<?php echo esc_url(admin_url('user-edit.php?user_id='.(int)$u->ID)); ?>"><?php echo esc_html__('View / Edit', 'bonus-hunt-guesser'); ?></a>
-          </td>
-        </tr>
-      <?php endforeach; endif; ?>
-    </tbody>
+	<thead>
+	  <tr>
+		<th><a href="<?php echo esc_url(add_query_arg(['orderby'=>'user_login','order'=> $order==='ASC'?'desc':'asc'], $base_url)); ?>"><?php echo esc_html__('Username', 'bonus-hunt-guesser'); ?></a></th>
+		<th><a href="<?php echo esc_url(add_query_arg(['orderby'=>'display_name','order'=> $order==='ASC'?'desc':'asc'], $base_url)); ?>"><?php echo esc_html__('Name', 'bonus-hunt-guesser'); ?></a></th>
+		<th><?php echo esc_html__('Real Name', 'bonus-hunt-guesser'); ?></th>
+		<th><a href="<?php echo esc_url(add_query_arg(['orderby'=>'user_email','order'=> $order==='ASC'?'desc':'asc'], $base_url)); ?>"><?php echo esc_html__('Email', 'bonus-hunt-guesser'); ?></a></th>
+		<th><?php echo esc_html__('Affiliate', 'bonus-hunt-guesser'); ?></th>
+		<th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
+	  </tr>
+	</thead>
+	<tbody>
+	  <?php if (empty($users)) : ?>
+		<tr><td colspan="6"><?php echo esc_html__('No users found.', 'bonus-hunt-guesser'); ?></td></tr>
+	  <?php else : foreach ($users as $u) :
+		  $form_id    = 'bhg-user-' . (int) $u->ID;
+		  $real_name  = get_user_meta($u->ID, 'bhg_real_name', true);
+		  $is_aff     = get_user_meta($u->ID, 'bhg_is_affiliate', true);
+	  ?>
+		<tr>
+		  <td><?php echo esc_html($u->user_login); ?></td>
+		  <td><?php echo esc_html($u->display_name); ?></td>
+		  <td><input type="text" name="bhg_real_name" form="<?php echo esc_attr($form_id); ?>" value="<?php echo esc_attr($real_name); ?>" /></td>
+		  <td><?php echo esc_html($u->user_email); ?></td>
+		  <td class="bhg-text-center"><input type="checkbox" name="bhg_is_affiliate" value="1" form="<?php echo esc_attr($form_id); ?>" <?php checked( $is_aff, 1 ); ?> /></td>
+		  <td>
+			<form id="<?php echo esc_attr($form_id); ?>" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+			  <input type="hidden" name="action" value="bhg_save_user_meta" />
+			  <input type="hidden" name="user_id" value="<?php echo (int) $u->ID; ?>" />
+			  <?php wp_nonce_field('bhg_save_user_meta'); ?>
+			  <button type="submit" class="button button-primary"><?php echo esc_html__('Save', 'bonus-hunt-guesser'); ?></button>
+			</form>
+			<a class="button" href="<?php echo esc_url(admin_url('user-edit.php?user_id='.(int)$u->ID)); ?>"><?php echo esc_html__('View / Edit', 'bonus-hunt-guesser'); ?></a>
+		  </td>
+		</tr>
+	  <?php endforeach; endif; ?>
+	</tbody>
   </table>
 
   <?php
-    $total_pages = ceil($total / $per_page);
-    if ($total_pages > 1) {
-        echo '<div class="tablenav"><div class="tablenav-pages">';
-        echo paginate_links([
-            'base'      => add_query_arg('paged', '%#%', $base_url),
-            'format'    => '',
-            'prev_text' => '&laquo;',
-            'next_text' => '&raquo;',
-            'total'     => $total_pages,
-            'current'   => $paged,
-        ]);
-        echo '</div></div>';
-    }
+	$total_pages = ceil($total / $per_page);
+	if ($total_pages > 1) {
+		echo '<div class="tablenav"><div class="tablenav-pages">';
+		echo paginate_links([
+			'base'      => add_query_arg('paged', '%#%', $base_url),
+			'format'    => '',
+			'prev_text' => '&laquo;',
+			'next_text' => '&raquo;',
+			'total'     => $total_pages,
+			'current'   => $paged,
+		]);
+		echo '</div></div>';
+	}
   ?>
 </div>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -14,91 +14,91 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 // Helper: parse human-entered money-like strings into float
 if ( ! function_exists( 'bhg_parse_amount' ) ) {
-    /**
-     * Parse a human-entered money-like string into a float.
-     *
-     * @param string $s Raw amount string.
-     * @return float|null Parsed float value or null on failure.
-     */
-    function bhg_parse_amount( $s ) {
-        if ( ! is_string( $s ) ) {
-            return null;
-        }
-        // Normalize unicode spaces (NBSP / NNBSP) and trim
-        $s = str_replace( array( "\xc2\xa0", "\xe2\x80\xaf" ), ' ', $s );
-        $s = trim( wp_unslash( $s ) );
-        if ( $s === '' ) {
-            return null;
-        }
+	/**
+	 * Parse a human-entered money-like string into a float.
+	 *
+	 * @param string $s Raw amount string.
+	 * @return float|null Parsed float value or null on failure.
+	 */
+	function bhg_parse_amount( $s ) {
+		if ( ! is_string( $s ) ) {
+			return null;
+		}
+		// Normalize unicode spaces (NBSP / NNBSP) and trim
+		$s = str_replace( array( "\xc2\xa0", "\xe2\x80\xaf" ), ' ', $s );
+		$s = trim( wp_unslash( $s ) );
+		if ( $s === '' ) {
+			return null;
+		}
 
-        // Remove currency symbols/letters while keeping digits, separators, minus
-        $s = preg_replace( '/[^\d,\.\-\s]/u', '', $s );
-        $s = str_replace( ' ', '', $s );
+		// Remove currency symbols/letters while keeping digits, separators, minus
+		$s = preg_replace( '/[^\d,\.\-\s]/u', '', $s );
+		$s = str_replace( ' ', '', $s );
 
-        $has_comma = strpos( $s, ',' ) !== false;
-        $has_dot   = strpos( $s, '.' ) !== false;
+		$has_comma = strpos( $s, ',' ) !== false;
+		$has_dot   = strpos( $s, '.' ) !== false;
 
-        if ( $has_comma && $has_dot ) {
-            // Use the last occurring symbol as decimal separator
-            $last_comma = strrpos( $s, ',' );
-            $last_dot   = strrpos( $s, '.' );
-            if ( $last_comma !== false && ( $last_dot === false || $last_comma > $last_dot ) ) {
-                // Comma as decimal
-                $s = str_replace( '.', '', $s );  // thousands
-                $s = str_replace( ',', '.', $s ); // decimal
-            } else {
-                // Dot as decimal
-                $s = str_replace( ',', '', $s );
-            }
-        } elseif ( $has_comma ) {
-            // Only comma present
-            $last = strrpos( $s, ',' );
-            $frac = substr( $s, $last + 1 );
-            if ( ctype_digit( $frac ) && strlen( $frac ) >= 1 && strlen( $frac ) <= 2 ) {
-                // Treat as decimal
-                $s = str_replace( ',', '.', $s );
-            } else {
-                // Treat as thousands (incl. Indian grouping)
-                $s = str_replace( ',', '', $s );
-            }
-        } elseif ( $has_dot ) {
-            // Only dot present
-            $last = strrpos( $s, '.' );
-            $frac = substr( $s, $last + 1 );
-            if ( ctype_digit( $frac ) && strlen( $frac ) > 3 ) {
-                // Likely thousands separators → remove all dots
-                $s = str_replace( '.', '', $s );
-            }
-        }
+		if ( $has_comma && $has_dot ) {
+			// Use the last occurring symbol as decimal separator
+			$last_comma = strrpos( $s, ',' );
+			$last_dot   = strrpos( $s, '.' );
+			if ( $last_comma !== false && ( $last_dot === false || $last_comma > $last_dot ) ) {
+				// Comma as decimal
+				$s = str_replace( '.', '', $s );  // thousands
+				$s = str_replace( ',', '.', $s ); // decimal
+			} else {
+				// Dot as decimal
+				$s = str_replace( ',', '', $s );
+			}
+		} elseif ( $has_comma ) {
+			// Only comma present
+			$last = strrpos( $s, ',' );
+			$frac = substr( $s, $last + 1 );
+			if ( ctype_digit( $frac ) && strlen( $frac ) >= 1 && strlen( $frac ) <= 2 ) {
+				// Treat as decimal
+				$s = str_replace( ',', '.', $s );
+			} else {
+				// Treat as thousands (incl. Indian grouping)
+				$s = str_replace( ',', '', $s );
+			}
+		} elseif ( $has_dot ) {
+			// Only dot present
+			$last = strrpos( $s, '.' );
+			$frac = substr( $s, $last + 1 );
+			if ( ctype_digit( $frac ) && strlen( $frac ) > 3 ) {
+				// Likely thousands separators → remove all dots
+				$s = str_replace( '.', '', $s );
+			}
+		}
 
-        // Keep only digits, one leading minus, and dots
-        $s = preg_replace( '/[^0-9\.\-]/', '', $s );
-        if ( $s === '' || $s === '-' || $s === '.' || $s === '-.' || $s === '.-' ) {
-            return null;
-        }
+		// Keep only digits, one leading minus, and dots
+		$s = preg_replace( '/[^0-9\.\-]/', '', $s );
+		if ( $s === '' || $s === '-' || $s === '.' || $s === '-.' || $s === '.-' ) {
+			return null;
+		}
 
-        // Collapse multiple dots to a single decimal point (keep first as decimal)
-        $parts = explode( '.', $s );
-        if ( count( $parts ) > 2 ) {
-            $s = $parts[0] . '.' . implode( '', array_slice( $parts, 1 ) );
-        }
+		// Collapse multiple dots to a single decimal point (keep first as decimal)
+		$parts = explode( '.', $s );
+		if ( count( $parts ) > 2 ) {
+			$s = $parts[0] . '.' . implode( '', array_slice( $parts, 1 ) );
+		}
 
-        if ( is_numeric( $s ) ) {
-            return (float) $s;
-        }
+		if ( is_numeric( $s ) ) {
+			return (float) $s;
+		}
 
-        // Permissive fallback: first number pattern
-        if ( preg_match( '/\d+(?:\.\d+)?/', $s, $m2 ) ) {
-            return (float) $m2[0];
-        }
+		// Permissive fallback: first number pattern
+		if ( preg_match( '/\d+(?:\.\d+)?/', $s, $m2 ) ) {
+			return (float) $m2[0];
+		}
 
-        return null;
-    }
+		return null;
+	}
 }
 
 // Ensure canonical DB class is loaded
@@ -120,11 +120,11 @@ define( 'BHG_TABLE_PREFIX', 'bhg_' );
  * @return void
  */
 function bhg_create_tables() {
-        if ( class_exists( 'BHG_DB' ) ) {
-            ( new BHG_DB() )->create_tables();
-            BHG_DB::migrate();
-            return;
-        }
+		if ( class_exists( 'BHG_DB' ) ) {
+			( new BHG_DB() )->create_tables();
+			BHG_DB::migrate();
+			return;
+		}
 }
 
 // Check and create tables if needed
@@ -134,35 +134,35 @@ function bhg_create_tables() {
  * @return void
  */
 function bhg_check_tables() {
-    if ( ! get_option( 'bhg_tables_created' ) ) {
-        bhg_create_tables();
-        update_option( 'bhg_tables_created', true );
-    }
+	if ( ! get_option( 'bhg_tables_created' ) ) {
+		bhg_create_tables();
+		update_option( 'bhg_tables_created', true );
+	}
 }
 
 // Autoloader for plugin classes
 spl_autoload_register( function ( $class ) {
-    if ( strpos( $class, 'BHG_' ) !== 0 ) {
-        return;
-    }
-    
-    $class_map = [
-        'BHG_Admin' => 'admin/class-bhg-admin.php',
-        'BHG_Shortcodes' => 'includes/class-bhg-shortcodes.php',
-        'BHG_Logger' => 'includes/class-bhg-logger.php',
-        'BHG_Settings' => 'includes/class-bhg-settings.php',
-        'BHG_Utils' => 'includes/class-bhg-utils.php',
-        'BHG_Models' => 'includes/class-bhg-models.php',
-        'BHG_Front_Menus' => 'includes/class-bhg-front-menus.php',
-        'BHG_Demo' => 'admin/class-bhg-demo.php',
-    ];
-    
-    if ( isset( $class_map[ $class ] ) ) {
-        $file_path = BHG_PLUGIN_DIR . $class_map[ $class ];
-        if ( file_exists( $file_path ) ) {
-            require_once $file_path;
-        }
-    }
+	if ( strpos( $class, 'BHG_' ) !== 0 ) {
+		return;
+	}
+	
+	$class_map = [
+		'BHG_Admin' => 'admin/class-bhg-admin.php',
+		'BHG_Shortcodes' => 'includes/class-bhg-shortcodes.php',
+		'BHG_Logger' => 'includes/class-bhg-logger.php',
+		'BHG_Settings' => 'includes/class-bhg-settings.php',
+		'BHG_Utils' => 'includes/class-bhg-utils.php',
+		'BHG_Models' => 'includes/class-bhg-models.php',
+		'BHG_Front_Menus' => 'includes/class-bhg-front-menus.php',
+		'BHG_Demo' => 'admin/class-bhg-demo.php',
+	];
+	
+	if ( isset( $class_map[ $class ] ) ) {
+		$file_path = BHG_PLUGIN_DIR . $class_map[ $class ];
+		if ( file_exists( $file_path ) ) {
+			require_once $file_path;
+		}
+	}
 } );
 
 // Include helper functions
@@ -177,45 +177,45 @@ require_once BHG_PLUGIN_DIR . 'includes/class-bhg-bonus-hunts-helpers.php';
  * @return void
  */
 function bhg_activate_plugin( $network_wide ) {
-    if ( ! current_user_can( 'activate_plugins' ) ) {
-        return;
-    }
+	if ( ! current_user_can( 'activate_plugins' ) ) {
+		return;
+	}
 
-    bhg_create_tables();
+	bhg_create_tables();
 
-    if ( function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
-        bhg_seed_default_translations_if_empty();
-    }
+	if ( function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
+		bhg_seed_default_translations_if_empty();
+	}
 
-    // Set default options
-    add_option( 'bhg_version', BHG_VERSION );
-    add_option( 'bhg_plugin_settings', [
-        'allow_guess_changes' => 'yes',
-        'default_tournament_period' => 'monthly',
-        'min_guess_amount' => 0,
-        'max_guess_amount' => 100000,
-        'max_guesses' => 1,
-        'ads_enabled' => 1,
-        'email_from' => get_bloginfo( 'admin_email' ),
-    ]);
-    
-    // Seed demo data if empty
-    if ( function_exists( 'bhg_seed_demo_if_empty' ) ) {
-        bhg_seed_demo_if_empty();
-    }
-    update_option( 'bhg_demo_notice', 1 );
-    
-    // Set tables created flag
-    update_option( 'bhg_tables_created', true );
-    
-    // Flush rewrite rules after database changes
-    flush_rewrite_rules();
+	// Set default options
+	add_option( 'bhg_version', BHG_VERSION );
+	add_option( 'bhg_plugin_settings', [
+		'allow_guess_changes' => 'yes',
+		'default_tournament_period' => 'monthly',
+		'min_guess_amount' => 0,
+		'max_guess_amount' => 100000,
+		'max_guesses' => 1,
+		'ads_enabled' => 1,
+		'email_from' => get_bloginfo( 'admin_email' ),
+	]);
+	
+	// Seed demo data if empty
+	if ( function_exists( 'bhg_seed_demo_if_empty' ) ) {
+		bhg_seed_demo_if_empty();
+	}
+	update_option( 'bhg_demo_notice', 1 );
+	
+	// Set tables created flag
+	update_option( 'bhg_tables_created', true );
+	
+	// Flush rewrite rules after database changes
+	flush_rewrite_rules();
 }
 register_activation_hook( __FILE__, 'bhg_activate_plugin' );
 
 // Deactivation hook ( no destructive actions )
 register_deactivation_hook( __FILE__, function () {
-    // Keep data intact by default
+	// Keep data intact by default
 } );
 
 // Frontend asset loader
@@ -227,42 +227,42 @@ add_action( 'wp_enqueue_scripts', 'bhg_enqueue_public_assets' );
  * @return void
  */
 function bhg_enqueue_public_assets() {
-    wp_register_style(
-        'bhg-public',
-        BHG_PLUGIN_URL . 'assets/css/public.css',
-        array(),
-        defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-    );
+	wp_register_style(
+		'bhg-public',
+		BHG_PLUGIN_URL . 'assets/css/public.css',
+		array(),
+		defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+	);
 
-    wp_register_script(
-        'bhg-public',
-        BHG_PLUGIN_URL . 'assets/js/public.js',
-        array( 'jquery' ),
-        defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
-        true
-    );
+	wp_register_script(
+		'bhg-public',
+		BHG_PLUGIN_URL . 'assets/js/public.js',
+		array( 'jquery' ),
+		defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
+		true
+	);
 
-    wp_localize_script(
-        'bhg-public',
-        'bhg_public_ajax',
-        array(
-            'ajax_url'     => admin_url( 'admin-ajax.php' ),
-            'nonce'        => wp_create_nonce( 'bhg_public_nonce' ),
-            'is_logged_in' => is_user_logged_in(),
-            'i18n'         => array(
-                'guess_required'     => __( 'Please enter a guess.', 'bonus-hunt-guesser' ),
-                'guess_numeric'      => __( 'Please enter a valid number.', 'bonus-hunt-guesser' ),
-                'guess_range'        => __( 'Guess must be between €0 and €100,000.', 'bonus-hunt-guesser' ),
-                'guess_submitted'    => __( 'Your guess has been submitted!', 'bonus-hunt-guesser' ),
-                'ajax_error'         => __( 'An error occurred. Please try again.', 'bonus-hunt-guesser' ),
-                'affiliate_user'     => __( 'Affiliate', 'bonus-hunt-guesser' ),
-                'non_affiliate_user' => __( 'Non-affiliate', 'bonus-hunt-guesser' ),
-            ),
-        )
-    );
+	wp_localize_script(
+		'bhg-public',
+		'bhg_public_ajax',
+		array(
+			'ajax_url'     => admin_url( 'admin-ajax.php' ),
+			'nonce'        => wp_create_nonce( 'bhg_public_nonce' ),
+			'is_logged_in' => is_user_logged_in(),
+			'i18n'         => array(
+				'guess_required'     => __( 'Please enter a guess.', 'bonus-hunt-guesser' ),
+				'guess_numeric'      => __( 'Please enter a valid number.', 'bonus-hunt-guesser' ),
+				'guess_range'        => __( 'Guess must be between €0 and €100,000.', 'bonus-hunt-guesser' ),
+				'guess_submitted'    => __( 'Your guess has been submitted!', 'bonus-hunt-guesser' ),
+				'ajax_error'         => __( 'An error occurred. Please try again.', 'bonus-hunt-guesser' ),
+				'affiliate_user'     => __( 'Affiliate', 'bonus-hunt-guesser' ),
+				'non_affiliate_user' => __( 'Non-affiliate', 'bonus-hunt-guesser' ),
+			),
+		)
+	);
 
-    wp_enqueue_style( 'bhg-public' );
-    wp_enqueue_script( 'bhg-public' );
+	wp_enqueue_style( 'bhg-public' );
+	wp_enqueue_script( 'bhg-public' );
 }
 
 // Initialize plugin
@@ -273,44 +273,44 @@ add_action( 'plugins_loaded', 'bhg_init_plugin' );
  * @return void
  */
 function bhg_init_plugin() {
-    // Load text domain
-    load_plugin_textdomain( 'bonus-hunt-guesser', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+	// Load text domain
+	load_plugin_textdomain( 'bonus-hunt-guesser', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
-    // Initialize components
-    if ( is_admin() ) {
-        if ( class_exists( 'BHG_Admin' ) ) {
-            new BHG_Admin();
-        }
-        if ( class_exists( 'BHG_Demo' ) ) {
-            new BHG_Demo();
-        }
-    }
+	// Initialize components
+	if ( is_admin() ) {
+		if ( class_exists( 'BHG_Admin' ) ) {
+			new BHG_Admin();
+		}
+		if ( class_exists( 'BHG_Demo' ) ) {
+			new BHG_Demo();
+		}
+	}
 
-    if ( class_exists( 'BHG_Shortcodes' ) ) {
-        new BHG_Shortcodes();
-    }
-    if ( class_exists( 'BHG_Front_Menus' ) ) {
-        new BHG_Front_Menus();
-    }
+	if ( class_exists( 'BHG_Shortcodes' ) ) {
+		new BHG_Shortcodes();
+	}
+	if ( class_exists( 'BHG_Front_Menus' ) ) {
+		new BHG_Front_Menus();
+	}
 
-    if ( class_exists( 'BHG_DB' ) ) {
-        BHG_DB::migrate();
-    }
+	if ( class_exists( 'BHG_DB' ) ) {
+		BHG_DB::migrate();
+	}
 
-    if ( class_exists( 'BHG_Utils' ) ) {
-        BHG_Utils::init_hooks();
-    }
+	if ( class_exists( 'BHG_Utils' ) ) {
+		BHG_Utils::init_hooks();
+	}
 
-    // Register form handlers
-    add_action( 'admin_post_bhg_submit_guess', 'bhg_handle_submit_guess' );
-    add_action( 'admin_post_nopriv_bhg_submit_guess', function () {
-        $ref = wp_get_referer();
-        wp_safe_redirect( wp_login_url( $ref ? $ref : home_url() ) );
-        exit;
-    } );
-    add_action( 'wp_ajax_submit_bhg_guess', 'bhg_handle_submit_guess' );
-    add_action( 'wp_ajax_nopriv_submit_bhg_guess', 'bhg_handle_submit_guess' );
-    add_action( 'admin_post_bhg_save_settings', 'bhg_handle_settings_save' );
+	// Register form handlers
+	add_action( 'admin_post_bhg_submit_guess', 'bhg_handle_submit_guess' );
+	add_action( 'admin_post_nopriv_bhg_submit_guess', function () {
+		$ref = wp_get_referer();
+		wp_safe_redirect( wp_login_url( $ref ? $ref : home_url() ) );
+		exit;
+	} );
+	add_action( 'wp_ajax_submit_bhg_guess', 'bhg_handle_submit_guess' );
+	add_action( 'wp_ajax_nopriv_submit_bhg_guess', 'bhg_handle_submit_guess' );
+	add_action( 'admin_post_bhg_save_settings', 'bhg_handle_settings_save' );
 }
 
 // Early table check on init
@@ -323,74 +323,74 @@ add_action( 'init', 'bhg_check_tables', 0 );
  * @return void
  */
 function bhg_handle_settings_save() {
-    // Check user capabilities
-    if ( ! current_user_can( 'manage_options' ) ) {
-        wp_die( esc_html__( 'You do not have sufficient permissions to perform this action.', 'bonus-hunt-guesser' ) );
-    }
+	// Check user capabilities
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to perform this action.', 'bonus-hunt-guesser' ) );
+	}
 
-    // Verify nonce
-    if ( ! isset( $_POST['bhg_settings_nonce'] ) || ! wp_verify_nonce( $_POST['bhg_settings_nonce'], 'bhg_save_settings_nonce' ) ) {
-        wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_settings&error=nonce_failed' ) ) );
-        exit;
-    }
+	// Verify nonce
+	if ( ! isset( $_POST['bhg_settings_nonce'] ) || ! wp_verify_nonce( $_POST['bhg_settings_nonce'], 'bhg_save_settings_nonce' ) ) {
+		wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_settings&error=nonce_failed' ) ) );
+		exit;
+	}
 
-    // Sanitize and validate data
-    $settings = array();
+	// Sanitize and validate data
+	$settings = array();
 
-    if ( isset( $_POST['bhg_default_tournament_period'] ) ) {
-        $period = sanitize_text_field( $_POST['bhg_default_tournament_period'] );
-        if ( in_array( $period, array( 'weekly', 'monthly', 'quarterly', 'yearly', 'alltime' ) ) ) {
-            $settings['default_tournament_period'] = $period;
-        }
-    }
+	if ( isset( $_POST['bhg_default_tournament_period'] ) ) {
+		$period = sanitize_text_field( $_POST['bhg_default_tournament_period'] );
+		if ( in_array( $period, array( 'weekly', 'monthly', 'quarterly', 'yearly', 'alltime' ) ) ) {
+			$settings['default_tournament_period'] = $period;
+		}
+	}
 
-    if ( isset( $_POST['bhg_max_guess_amount'] ) ) {
-        $max = floatval( $_POST['bhg_max_guess_amount'] );
-        if ( $max >= 0 ) {
-            $settings['max_guess_amount'] = $max;
-        }
-    }
+	if ( isset( $_POST['bhg_max_guess_amount'] ) ) {
+		$max = floatval( $_POST['bhg_max_guess_amount'] );
+		if ( $max >= 0 ) {
+			$settings['max_guess_amount'] = $max;
+		}
+	}
 
-    if ( isset( $_POST['bhg_min_guess_amount'] ) ) {
-        $min = floatval( $_POST['bhg_min_guess_amount'] );
-        if ( $min >= 0 ) {
-            $settings['min_guess_amount'] = $min;
-        }
-    }
+	if ( isset( $_POST['bhg_min_guess_amount'] ) ) {
+		$min = floatval( $_POST['bhg_min_guess_amount'] );
+		if ( $min >= 0 ) {
+			$settings['min_guess_amount'] = $min;
+		}
+	}
 
-    // Validate that min is not greater than max
-    if ( isset( $settings['min_guess_amount'] ) && isset( $settings['max_guess_amount'] ) &&
-        $settings['min_guess_amount'] > $settings['max_guess_amount'] ) {
-        wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_settings&error=invalid_data' ) ) );
-        exit;
-    }
+	// Validate that min is not greater than max
+	if ( isset( $settings['min_guess_amount'] ) && isset( $settings['max_guess_amount'] ) &&
+		$settings['min_guess_amount'] > $settings['max_guess_amount'] ) {
+		wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_settings&error=invalid_data' ) ) );
+		exit;
+	}
 
-    if ( isset( $_POST['bhg_allow_guess_changes'] ) ) {
-        $allow = sanitize_text_field( $_POST['bhg_allow_guess_changes'] );
-        if ( in_array( $allow, array( 'yes', 'no' ) ) ) {
-            $settings['allow_guess_changes'] = $allow;
-        }
-    }
+	if ( isset( $_POST['bhg_allow_guess_changes'] ) ) {
+		$allow = sanitize_text_field( $_POST['bhg_allow_guess_changes'] );
+		if ( in_array( $allow, array( 'yes', 'no' ) ) ) {
+			$settings['allow_guess_changes'] = $allow;
+		}
+	}
 
-    if ( isset( $_POST['bhg_ads_enabled'] ) ) {
-        $ads_enabled           = sanitize_text_field( $_POST['bhg_ads_enabled'] );
-        $settings['ads_enabled'] = $ads_enabled === '1' ? 1 : 0;
-    }
+	if ( isset( $_POST['bhg_ads_enabled'] ) ) {
+		$ads_enabled           = sanitize_text_field( $_POST['bhg_ads_enabled'] );
+		$settings['ads_enabled'] = $ads_enabled === '1' ? 1 : 0;
+	}
 
-    if ( isset( $_POST['bhg_email_from'] ) ) {
-        $email_from = sanitize_email( $_POST['bhg_email_from'] );
-        if ( $email_from ) {
-            $settings['email_from'] = $email_from;
-        }
-    }
+	if ( isset( $_POST['bhg_email_from'] ) ) {
+		$email_from = sanitize_email( $_POST['bhg_email_from'] );
+		if ( $email_from ) {
+			$settings['email_from'] = $email_from;
+		}
+	}
 
-    // Save settings
-    $existing = get_option( 'bhg_plugin_settings', [] );
-    update_option( 'bhg_plugin_settings', array_merge( $existing, $settings ) );
+	// Save settings
+	$existing = get_option( 'bhg_plugin_settings', [] );
+	update_option( 'bhg_plugin_settings', array_merge( $existing, $settings ) );
 
-    // Redirect back to settings page
-    wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_settings&message=saved' ) ) );
-    exit;
+	// Redirect back to settings page
+	wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_settings&message=saved' ) ) );
+	exit;
 }
 
 // Canonical guess submit handler
@@ -400,117 +400,117 @@ function bhg_handle_settings_save() {
  * @return void
  */
 function bhg_handle_submit_guess() {
-    if ( wp_doing_ajax() ) {
-        check_ajax_referer( 'bhg_public_nonce', 'nonce' );
-    } else {
-        if ( ! isset( $_POST['bhg_nonce'] ) ) {
-            wp_die( esc_html__( 'Security check failed.', 'bonus-hunt-guesser' ) );
-        }
-        check_admin_referer( 'bhg_submit_guess', 'bhg_nonce' );
-    }
+	if ( wp_doing_ajax() ) {
+		check_ajax_referer( 'bhg_public_nonce', 'nonce' );
+	} else {
+		if ( ! isset( $_POST['bhg_nonce'] ) ) {
+			wp_die( esc_html__( 'Security check failed.', 'bonus-hunt-guesser' ) );
+		}
+		check_admin_referer( 'bhg_submit_guess', 'bhg_nonce' );
+	}
 
-    $user_id = get_current_user_id();
-    if ( ! $user_id ) {
-        if ( wp_doing_ajax() ) {
-            wp_send_json_error( __( 'You must be logged in to submit a guess.', 'bonus-hunt-guesser' ) );
-        }
-        wp_die( esc_html__( 'You must be logged in to submit a guess.', 'bonus-hunt-guesser' ) );
-    }
+	$user_id = get_current_user_id();
+	if ( ! $user_id ) {
+		if ( wp_doing_ajax() ) {
+			wp_send_json_error( __( 'You must be logged in to submit a guess.', 'bonus-hunt-guesser' ) );
+		}
+		wp_die( esc_html__( 'You must be logged in to submit a guess.', 'bonus-hunt-guesser' ) );
+	}
 
-    $hunt_id = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
-    if ( $hunt_id <= 0 ) {
-        if ( wp_doing_ajax() ) {
-            wp_send_json_error( __( 'Invalid hunt.', 'bonus-hunt-guesser' ) );
-        }
-        wp_die( esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) );
-    }
+	$hunt_id = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
+	if ( $hunt_id <= 0 ) {
+		if ( wp_doing_ajax() ) {
+			wp_send_json_error( __( 'Invalid hunt.', 'bonus-hunt-guesser' ) );
+		}
+		wp_die( esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) );
+	}
 
-    // Parse guess robustly
-    if ( wp_doing_ajax() ) {
-        $raw_guess = isset( $_POST['guess_amount'] ) ? wp_unslash( $_POST['guess_amount'] ) : '';
-    } else {
-        $raw_guess = isset( $_POST['guess'] ) ? wp_unslash( $_POST['guess'] ) : ( isset( $_POST['balance_guess'] ) ? wp_unslash( $_POST['balance_guess'] ) : '' );
-    }
-    $guess = -1.0;
-    if ( function_exists( 'bhg_parse_amount' ) ) {
-        $parsed = bhg_parse_amount( $raw_guess );
-        $guess  = ( null === $parsed ) ? -1.0 : (float) $parsed;
-    } else {
-        $guess = is_numeric( $raw_guess ) ? (float) $raw_guess : -1.0;
-    }
-    $settings   = get_option( 'bhg_plugin_settings', [] );
-    $min_guess  = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
-    $max_guess  = isset( $settings['max_guess_amount'] ) ? (float) $settings['max_guess_amount'] : 100000;
-    $max        = isset( $settings['max_guesses'] ) ? (int) $settings['max_guesses'] : 1;
-    $allow_edit = isset( $settings['allow_guess_changes'] ) && $settings['allow_guess_changes'] === 'yes';
+	// Parse guess robustly
+	if ( wp_doing_ajax() ) {
+		$raw_guess = isset( $_POST['guess_amount'] ) ? wp_unslash( $_POST['guess_amount'] ) : '';
+	} else {
+		$raw_guess = isset( $_POST['guess'] ) ? wp_unslash( $_POST['guess'] ) : ( isset( $_POST['balance_guess'] ) ? wp_unslash( $_POST['balance_guess'] ) : '' );
+	}
+	$guess = -1.0;
+	if ( function_exists( 'bhg_parse_amount' ) ) {
+		$parsed = bhg_parse_amount( $raw_guess );
+		$guess  = ( null === $parsed ) ? -1.0 : (float) $parsed;
+	} else {
+		$guess = is_numeric( $raw_guess ) ? (float) $raw_guess : -1.0;
+	}
+	$settings   = get_option( 'bhg_plugin_settings', [] );
+	$min_guess  = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
+	$max_guess  = isset( $settings['max_guess_amount'] ) ? (float) $settings['max_guess_amount'] : 100000;
+	$max        = isset( $settings['max_guesses'] ) ? (int) $settings['max_guesses'] : 1;
+	$allow_edit = isset( $settings['allow_guess_changes'] ) && $settings['allow_guess_changes'] === 'yes';
 
-    if ( $guess < $min_guess || $guess > $max_guess ) {
-        if ( function_exists( 'error_log' ) ) {
-            error_log( '[BHG] invalid guess after parse: raw=' . print_r( $raw_guess, true ) . ' parsed=' . print_r( $guess, true ) );
-        }
-        if ( wp_doing_ajax() ) {
-            wp_send_json_error( __( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
-        }
-        wp_die( esc_html__( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
-    }
+	if ( $guess < $min_guess || $guess > $max_guess ) {
+		if ( function_exists( 'error_log' ) ) {
+			error_log( '[BHG] invalid guess after parse: raw=' . print_r( $raw_guess, true ) . ' parsed=' . print_r( $guess, true ) );
+		}
+		if ( wp_doing_ajax() ) {
+			wp_send_json_error( __( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
+		}
+		wp_die( esc_html__( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
+	}
 
-    global $wpdb;
-    $hunts = $wpdb->prefix . 'bhg_bonus_hunts';
-    $g_tbl = $wpdb->prefix . 'bhg_guesses';
+	global $wpdb;
+	$hunts = $wpdb->prefix . 'bhg_bonus_hunts';
+	$g_tbl = $wpdb->prefix . 'bhg_guesses';
 
-    $hunt = $wpdb->get_row( $wpdb->prepare( "SELECT id, status FROM `$hunts` WHERE id=%d", $hunt_id ) );
-    if ( ! $hunt ) {
-        if ( wp_doing_ajax() ) {
-            wp_send_json_error( __( 'Hunt not found.', 'bonus-hunt-guesser' ) );
-        }
-        wp_die( esc_html__( 'Hunt not found.', 'bonus-hunt-guesser' ) );
-    }
-    if ( $hunt->status !== 'open' ) {
-        if ( wp_doing_ajax() ) {
-            wp_send_json_error( __( 'This hunt is closed. You cannot submit or change a guess.', 'bonus-hunt-guesser' ) );
-        }
-        wp_die( esc_html__( 'This hunt is closed. You cannot submit or change a guess.', 'bonus-hunt-guesser' ) );
-    }
+	$hunt = $wpdb->get_row( $wpdb->prepare( "SELECT id, status FROM `$hunts` WHERE id=%d", $hunt_id ) );
+	if ( ! $hunt ) {
+		if ( wp_doing_ajax() ) {
+			wp_send_json_error( __( 'Hunt not found.', 'bonus-hunt-guesser' ) );
+		}
+		wp_die( esc_html__( 'Hunt not found.', 'bonus-hunt-guesser' ) );
+	}
+	if ( $hunt->status !== 'open' ) {
+		if ( wp_doing_ajax() ) {
+			wp_send_json_error( __( 'This hunt is closed. You cannot submit or change a guess.', 'bonus-hunt-guesser' ) );
+		}
+		wp_die( esc_html__( 'This hunt is closed. You cannot submit or change a guess.', 'bonus-hunt-guesser' ) );
+	}
 
-    // Insert or update last guess per settings
+	// Insert or update last guess per settings
 
-    $count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM `$g_tbl` WHERE hunt_id=%d AND user_id=%d", $hunt_id, $user_id ) );
-    if ( $count >= $max ) {
-        if ( $allow_edit && $count > 0 ) {
-            $gid = (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM `$g_tbl` WHERE hunt_id=%d AND user_id=%d ORDER BY id DESC LIMIT 1", $hunt_id, $user_id ) );
-            if ( $gid ) {
-                $wpdb->update( $g_tbl, [ 'guess' => $guess, 'updated_at' => current_time( 'mysql' ) ], [ 'id' => $gid ] );
-                if ( wp_doing_ajax() ) {
-                    wp_send_json_success();
-                }
-                wp_safe_redirect( wp_get_referer() ?: home_url() );
-                exit;
-            }
-        }
-        if ( wp_doing_ajax() ) {
-            wp_send_json_error( __( 'You have reached the maximum number of guesses.', 'bonus-hunt-guesser' ) );
-        }
-        wp_die( esc_html__( 'You have reached the maximum number of guesses.', 'bonus-hunt-guesser' ) );
-    }
+	$count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM `$g_tbl` WHERE hunt_id=%d AND user_id=%d", $hunt_id, $user_id ) );
+	if ( $count >= $max ) {
+		if ( $allow_edit && $count > 0 ) {
+			$gid = (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM `$g_tbl` WHERE hunt_id=%d AND user_id=%d ORDER BY id DESC LIMIT 1", $hunt_id, $user_id ) );
+			if ( $gid ) {
+				$wpdb->update( $g_tbl, [ 'guess' => $guess, 'updated_at' => current_time( 'mysql' ) ], [ 'id' => $gid ] );
+				if ( wp_doing_ajax() ) {
+					wp_send_json_success();
+				}
+				wp_safe_redirect( wp_get_referer() ?: home_url() );
+				exit;
+			}
+		}
+		if ( wp_doing_ajax() ) {
+			wp_send_json_error( __( 'You have reached the maximum number of guesses.', 'bonus-hunt-guesser' ) );
+		}
+		wp_die( esc_html__( 'You have reached the maximum number of guesses.', 'bonus-hunt-guesser' ) );
+	}
 
-    // Insert
-    $wpdb->insert(
-        $g_tbl,
-        [
-            'hunt_id'    => $hunt_id,
-            'user_id'    => $user_id,
-            'guess'      => $guess,
-            'created_at' => current_time( 'mysql' ),
-        ],
-        [ '%d', '%d', '%f', '%s' ]
-    );
+	// Insert
+	$wpdb->insert(
+		$g_tbl,
+		[
+			'hunt_id'    => $hunt_id,
+			'user_id'    => $user_id,
+			'guess'      => $guess,
+			'created_at' => current_time( 'mysql' ),
+		],
+		[ '%d', '%d', '%f', '%s' ]
+	);
 
-    if ( wp_doing_ajax() ) {
-        wp_send_json_success();
-    }
+	if ( wp_doing_ajax() ) {
+		wp_send_json_success();
+	}
 
-    wp_safe_redirect( wp_get_referer() ?: home_url() );
-    exit;
+	wp_safe_redirect( wp_get_referer() ?: home_url() );
+	exit;
 }
 
 // Frontend ads rendering
@@ -521,22 +521,22 @@ function bhg_handle_submit_guess() {
  * @return bool True if ad should be shown, false otherwise.
  */
 function bhg_should_show_ad( $visibility ) {
-    if ($visibility === 'all') {
-        return true;
-    }
-    if ($visibility === 'logged_in') {
-        return (function_exists('is_user_logged_in') && is_user_logged_in());
-    }
-    if ($visibility === 'guests') {
-        return !(function_exists('is_user_logged_in') && is_user_logged_in());
-    }
-    if ($visibility === 'affiliates') {
-        return (function_exists('is_user_logged_in') && is_user_logged_in()) && bhg_is_affiliate();
-    }
-    if ($visibility === 'non_affiliates') {
-        return !(function_exists('is_user_logged_in') && is_user_logged_in()) || !bhg_is_affiliate();
-    }
-    return true;
+	if ($visibility === 'all') {
+		return true;
+	}
+	if ($visibility === 'logged_in') {
+		return (function_exists('is_user_logged_in') && is_user_logged_in());
+	}
+	if ($visibility === 'guests') {
+		return !(function_exists('is_user_logged_in') && is_user_logged_in());
+	}
+	if ($visibility === 'affiliates') {
+		return (function_exists('is_user_logged_in') && is_user_logged_in()) && bhg_is_affiliate();
+	}
+	if ($visibility === 'non_affiliates') {
+		return !(function_exists('is_user_logged_in') && is_user_logged_in()) || !bhg_is_affiliate();
+	}
+	return true;
 }
 
 /**
@@ -547,47 +547,47 @@ function bhg_should_show_ad( $visibility ) {
  * @return array List of ad rows.
  */
 function bhg_build_ads_query( $table, $placement = 'footer' ) {
-    global $wpdb;
+	global $wpdb;
 
-    // Validate table variable (only allow alphanumeric and underscore)
-    if (!is_string($table) || !preg_match('/^[A-Za-z0-9_]+$/', $table)) {
-        return array();
-    }
+	// Validate table variable (only allow alphanumeric and underscore)
+	if (!is_string($table) || !preg_match('/^[A-Za-z0-9_]+$/', $table)) {
+		return array();
+	}
 
-    // Build safe table name with prefix if required
-    $safe_table = esc_sql($table);
-    if (strpos($safe_table, $wpdb->prefix) !== 0) {
-        if (strpos($safe_table, BHG_TABLE_PREFIX) === 0 || strpos($safe_table, 'bhg_') === 0) {
-            $safe_table = $safe_table;
-        } else {
-            $safe_table = $wpdb->prefix . $safe_table;
-        }
-    }
+	// Build safe table name with prefix if required
+	$safe_table = esc_sql($table);
+	if (strpos($safe_table, $wpdb->prefix) !== 0) {
+		if (strpos($safe_table, BHG_TABLE_PREFIX) === 0 || strpos($safe_table, 'bhg_') === 0) {
+			$safe_table = $safe_table;
+		} else {
+			$safe_table = $wpdb->prefix . $safe_table;
+		}
+	}
 
-    // Ensure final safe table name still matches allowed characters
-    if (!preg_match('/^[A-Za-z0-9_]+$/', str_replace($wpdb->prefix, '', $safe_table))) {
-        return array();
-    }
+	// Ensure final safe table name still matches allowed characters
+	if (!preg_match('/^[A-Za-z0-9_]+$/', str_replace($wpdb->prefix, '', $safe_table))) {
+		return array();
+	}
 
-    // Use prepare for the placement value
-    $query = $wpdb->prepare(
-        "SELECT * FROM `{$safe_table}` WHERE placement = %s AND active = %d",
-        $placement,
-        1
-    );
+	// Use prepare for the placement value
+	$query = $wpdb->prepare(
+		"SELECT * FROM `{$safe_table}` WHERE placement = %s AND active = %d",
+		$placement,
+		1
+	);
 
-    $rows = $wpdb->get_results($query);
-    if ( did_action('wp') && function_exists('get_queried_object_id') ) {
-        $pid = (int)get_queried_object_id();
-        if ($pid && is_array($rows)) {
-            $rows = array_filter($rows, function($r) use ($pid) {
-                if (empty($r->target_pages)) return true;
-                $ids = array_filter(array_map('intval', array_map('trim', explode(',', $r->target_pages))));
-                return in_array($pid, $ids, true);
-            });
-        }
-    }
-    return $rows;
+	$rows = $wpdb->get_results($query);
+	if ( did_action('wp') && function_exists('get_queried_object_id') ) {
+		$pid = (int)get_queried_object_id();
+		if ($pid && is_array($rows)) {
+			$rows = array_filter($rows, function($r) use ($pid) {
+				if (empty($r->target_pages)) return true;
+				$ids = array_filter(array_map('intval', array_map('trim', explode(',', $r->target_pages))));
+				return in_array($pid, $ids, true);
+			});
+		}
+	}
+	return $rows;
 }
 
 // AJAX handler for loading leaderboard data
@@ -600,22 +600,22 @@ add_action('wp_ajax_nopriv_bhg_load_leaderboard', 'bhg_load_leaderboard_ajax');
  * @return void
  */
 function bhg_load_leaderboard_ajax() {
-    check_ajax_referer('bhg_public_nonce', 'nonce');
-    
-    if ( ! isset( $_POST['timeframe'] ) ) {
-        wp_send_json_error( __( 'Invalid timeframe', 'bonus-hunt-guesser' ) );
-    }
+	check_ajax_referer('bhg_public_nonce', 'nonce');
+	
+	if ( ! isset( $_POST['timeframe'] ) ) {
+		wp_send_json_error( __( 'Invalid timeframe', 'bonus-hunt-guesser' ) );
+	}
 
-    $timeframe = sanitize_text_field( wp_unslash( $_POST['timeframe'] ) );
-    $allowed_timeframes = array( 'overall', 'monthly', 'yearly', 'alltime' );
-    if ( ! in_array( $timeframe, $allowed_timeframes, true ) ) {
-        wp_send_json_error( __( 'Invalid timeframe', 'bonus-hunt-guesser' ) );
-    }
-    
-    // Generate leaderboard HTML based on timeframe
-    $html = bhg_generate_leaderboard_html($timeframe);
-    
-    wp_send_json_success($html);
+	$timeframe = sanitize_text_field( wp_unslash( $_POST['timeframe'] ) );
+	$allowed_timeframes = array( 'overall', 'monthly', 'yearly', 'alltime' );
+	if ( ! in_array( $timeframe, $allowed_timeframes, true ) ) {
+		wp_send_json_error( __( 'Invalid timeframe', 'bonus-hunt-guesser' ) );
+	}
+	
+	// Generate leaderboard HTML based on timeframe
+	$html = bhg_generate_leaderboard_html($timeframe);
+	
+	wp_send_json_success($html);
 }
 
 // Helper function to generate leaderboard HTML
@@ -626,114 +626,114 @@ function bhg_load_leaderboard_ajax() {
  * @return string Generated HTML.
  */
 function bhg_generate_leaderboard_html( $timeframe ) {
-    global $wpdb;
+	global $wpdb;
 
-    $per_page = 20;
-    $paged    = isset( $_POST['paged'] ) ? max( 1, (int) $_POST['paged'] ) : 1;
-    $offset   = ( $paged - 1 ) * $per_page;
+	$per_page = 20;
+	$paged    = isset( $_POST['paged'] ) ? max( 1, (int) $_POST['paged'] ) : 1;
+	$offset   = ( $paged - 1 ) * $per_page;
 
-    $start_date = '';
-    $now        = current_time( 'timestamp' );
-    switch ( strtolower( $timeframe ) ) {
-        case 'monthly':
-            $start_date = gmdate( 'Y-m-01 00:00:00', $now );
-            break;
-        case 'yearly':
-            $start_date = gmdate( 'Y-01-01 00:00:00', $now );
-            break;
-        case 'overall':
-            $start_date = gmdate( 'Y-m-d H:i:s', $now - 30 * DAY_IN_SECONDS );
-            break;
-        case 'all-time':
-        case 'all_time':
-        default:
-            $start_date = '';
-            break;
-    }
+	$start_date = '';
+	$now        = current_time( 'timestamp' );
+	switch ( strtolower( $timeframe ) ) {
+		case 'monthly':
+			$start_date = gmdate( 'Y-m-01 00:00:00', $now );
+			break;
+		case 'yearly':
+			$start_date = gmdate( 'Y-01-01 00:00:00', $now );
+			break;
+		case 'overall':
+			$start_date = gmdate( 'Y-m-d H:i:s', $now - 30 * DAY_IN_SECONDS );
+			break;
+		case 'all-time':
+		case 'all_time':
+		default:
+			$start_date = '';
+			break;
+	}
 
-    $g = $wpdb->prefix . 'bhg_guesses';
-    $h = $wpdb->prefix . 'bhg_bonus_hunts';
-    $u = $wpdb->users;
+	$g = $wpdb->prefix . 'bhg_guesses';
+	$h = $wpdb->prefix . 'bhg_bonus_hunts';
+	$u = $wpdb->users;
 
-    $where = "h.status='closed' AND h.final_balance IS NOT NULL";
-    $args  = array();
-    if ( $start_date ) {
-        $where .= " AND h.updated_at >= %s";
-        $args[] = $start_date;
-    }
+	$where = "h.status='closed' AND h.final_balance IS NOT NULL";
+	$args  = array();
+	if ( $start_date ) {
+		$where .= " AND h.updated_at >= %s";
+		$args[] = $start_date;
+	}
 
-    $sql_total = "
-        SELECT COUNT(*) FROM (
-            SELECT g.user_id
-            FROM {$g} g
-            INNER JOIN {$h} h ON h.id = g.hunt_id
-            WHERE {$where} AND NOT EXISTS (
-                SELECT 1 FROM {$g} g2
-                WHERE g2.hunt_id = g.hunt_id
-                  AND ABS(g2.guess - h.final_balance) < ABS(g.guess - h.final_balance)
-            )
-            GROUP BY g.user_id
-        ) t";
+	$sql_total = "
+		SELECT COUNT(*) FROM (
+			SELECT g.user_id
+			FROM {$g} g
+			INNER JOIN {$h} h ON h.id = g.hunt_id
+			WHERE {$where} AND NOT EXISTS (
+				SELECT 1 FROM {$g} g2
+				WHERE g2.hunt_id = g.hunt_id
+				  AND ABS(g2.guess - h.final_balance) < ABS(g.guess - h.final_balance)
+			)
+			GROUP BY g.user_id
+		) t";
 
-    if ( $args ) {
-        $total = (int) $wpdb->get_var( $wpdb->prepare( $sql_total, $args ) );
-    } else {
-        $total = (int) $wpdb->get_var( $sql_total );
-    }
+	if ( $args ) {
+		$total = (int) $wpdb->get_var( $wpdb->prepare( $sql_total, $args ) );
+	} else {
+		$total = (int) $wpdb->get_var( $sql_total );
+	}
 
-    $sql = "
-        SELECT g.user_id, u.user_login, COUNT(*) AS wins
-        FROM {$g} g
-        INNER JOIN {$h} h ON h.id = g.hunt_id
-        INNER JOIN {$u} u ON u.ID = g.user_id
-        WHERE {$where} AND NOT EXISTS (
-            SELECT 1 FROM {$g} g2
-            WHERE g2.hunt_id = g.hunt_id
-              AND ABS(g2.guess - h.final_balance) < ABS(g.guess - h.final_balance)
-        )
-        GROUP BY g.user_id, u.user_login
-        ORDER BY wins DESC, u.user_login ASC
-        LIMIT %d OFFSET %d";
+	$sql = "
+		SELECT g.user_id, u.user_login, COUNT(*) AS wins
+		FROM {$g} g
+		INNER JOIN {$h} h ON h.id = g.hunt_id
+		INNER JOIN {$u} u ON u.ID = g.user_id
+		WHERE {$where} AND NOT EXISTS (
+			SELECT 1 FROM {$g} g2
+			WHERE g2.hunt_id = g.hunt_id
+			  AND ABS(g2.guess - h.final_balance) < ABS(g.guess - h.final_balance)
+		)
+		GROUP BY g.user_id, u.user_login
+		ORDER BY wins DESC, u.user_login ASC
+		LIMIT %d OFFSET %d";
 
-    $args_query   = $args;
-    $args_query[] = $per_page;
-    $args_query[] = $offset;
-    $rows         = $wpdb->get_results( $wpdb->prepare( $sql, $args_query ) );
+	$args_query   = $args;
+	$args_query[] = $per_page;
+	$args_query[] = $offset;
+	$rows         = $wpdb->get_results( $wpdb->prepare( $sql, $args_query ) );
 
-    if ( ! $rows ) {
-        return '<p>' . esc_html__( 'No data available.', 'bonus-hunt-guesser' ) . '</p>';
-    }
+	if ( ! $rows ) {
+		return '<p>' . esc_html__( 'No data available.', 'bonus-hunt-guesser' ) . '</p>';
+	}
 
-    ob_start();
-    echo '<table class="bhg-leaderboard bhg-table" data-timeframe="' . esc_attr( $timeframe ) . '">';
-    echo '<thead><tr>';
-    echo '<th class="sortable" data-sort="position">' . esc_html__( 'Position', 'bonus-hunt-guesser' ) . '</th>';
-    echo '<th class="sortable" data-sort="username">' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th>';
-    echo '<th class="sortable" data-sort="wins">' . esc_html__( 'Wins', 'bonus-hunt-guesser' ) . '</th>';
-    echo '</tr></thead><tbody>';
+	ob_start();
+	echo '<table class="bhg-leaderboard bhg-table" data-timeframe="' . esc_attr( $timeframe ) . '">';
+	echo '<thead><tr>';
+	echo '<th class="sortable" data-sort="position">' . esc_html__( 'Position', 'bonus-hunt-guesser' ) . '</th>';
+	echo '<th class="sortable" data-sort="username">' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th>';
+	echo '<th class="sortable" data-sort="wins">' . esc_html__( 'Wins', 'bonus-hunt-guesser' ) . '</th>';
+	echo '</tr></thead><tbody>';
 
-    $pos = $offset + 1;
-    foreach ( $rows as $row ) {
-        $user_label = $row->user_login ? $row->user_login : 'user#' . (int) $row->user_id;
-        echo '<tr>';
-        echo '<td>' . (int) $pos++ . '</td>';
-        echo '<td>' . esc_html( $user_label ) . '</td>';
-        echo '<td>' . (int) $row->wins . '</td>';
-        echo '</tr>';
-    }
-    echo '</tbody></table>';
+	$pos = $offset + 1;
+	foreach ( $rows as $row ) {
+		$user_label = $row->user_login ? $row->user_login : 'user#' . (int) $row->user_id;
+		echo '<tr>';
+		echo '<td>' . (int) $pos++ . '</td>';
+		echo '<td>' . esc_html( $user_label ) . '</td>';
+		echo '<td>' . (int) $row->wins . '</td>';
+		echo '</tr>';
+	}
+	echo '</tbody></table>';
 
-    $pages = (int) ceil( $total / $per_page );
-    if ( $pages > 1 ) {
-        echo '<div class="bhg-pagination">';
-        for ( $p = 1; $p <= $pages; $p++ ) {
-            $current = $p === $paged ? ' class="current"' : '';
-            echo '<a href="#" data-page="' . (int) $p . '"' . $current . '>' . (int) $p . '</a> ';
-        }
-        echo '</div>';
-    }
+	$pages = (int) ceil( $total / $per_page );
+	if ( $pages > 1 ) {
+		echo '<div class="bhg-pagination">';
+		for ( $p = 1; $p <= $pages; $p++ ) {
+			$current = $p === $paged ? ' class="current"' : '';
+			echo '<a href="#" data-page="' . (int) $p . '"' . $current . '>' . (int) $p . '</a> ';
+		}
+		echo '</div>';
+	}
 
-    return ob_get_clean();
+	return ob_get_clean();
 }
 
 // Helper function to check if user is affiliate
@@ -744,15 +744,15 @@ function bhg_generate_leaderboard_html( $timeframe ) {
  * @return bool True if user is an affiliate.
  */
 function bhg_is_affiliate( $user_id = null ) {
-    if (!$user_id) {
-        $user_id = get_current_user_id();
-    }
+	if (!$user_id) {
+		$user_id = get_current_user_id();
+	}
 
-    if (!$user_id) {
-        return false;
-    }
+	if (!$user_id) {
+		return false;
+	}
 
-    return (bool) get_user_meta($user_id, 'bhg_is_affiliate', true);
+	return (bool) get_user_meta($user_id, 'bhg_is_affiliate', true);
 }
 
 // Add user profile fields for affiliate status
@@ -766,23 +766,23 @@ add_action('edit_user_profile', 'bhg_extra_user_profile_fields');
  * @return void
  */
 function bhg_extra_user_profile_fields( $user ) {
-    if (!current_user_can('manage_options')) {
-        return;
-    }
-    
-    $affiliate_status = get_user_meta($user->ID, 'bhg_is_affiliate', true);
-    ?>
-    <h3><?php esc_html_e('Bonus Hunt Guesser Information', 'bonus-hunt-guesser'); ?></h3>
-    <table class="form-table">
-        <tr>
-            <th><label for="bhg_is_affiliate"><?php esc_html_e('Affiliate Status', 'bonus-hunt-guesser'); ?></label></th>
-            <td>
-                <input type="checkbox" name="bhg_is_affiliate" id="bhg_is_affiliate" value="1" <?php checked($affiliate_status, 1); ?> />
-                <span class="description"><?php esc_html_e('Check if this user is an affiliate.', 'bonus-hunt-guesser'); ?></span>
-            </td>
-        </tr>
-    </table>
-    <?php
+	if (!current_user_can('manage_options')) {
+		return;
+	}
+	
+	$affiliate_status = get_user_meta($user->ID, 'bhg_is_affiliate', true);
+	?>
+	<h3><?php esc_html_e('Bonus Hunt Guesser Information', 'bonus-hunt-guesser'); ?></h3>
+	<table class="form-table">
+		<tr>
+			<th><label for="bhg_is_affiliate"><?php esc_html_e('Affiliate Status', 'bonus-hunt-guesser'); ?></label></th>
+			<td>
+				<input type="checkbox" name="bhg_is_affiliate" id="bhg_is_affiliate" value="1" <?php checked($affiliate_status, 1); ?> />
+				<span class="description"><?php esc_html_e('Check if this user is an affiliate.', 'bonus-hunt-guesser'); ?></span>
+			</td>
+		</tr>
+	</table>
+	<?php
 }
 
 add_action('personal_options_update', 'bhg_save_extra_user_profile_fields');
@@ -795,31 +795,31 @@ add_action('edit_user_profile_update', 'bhg_save_extra_user_profile_fields');
  * @return void|false Returns false if the user cannot be edited.
  */
 function bhg_save_extra_user_profile_fields( $user_id ) {
-    if (!current_user_can('edit_user', $user_id)) {
-        return false;
-    }
+	if (!current_user_can('edit_user', $user_id)) {
+		return false;
+	}
 
-    $affiliate_status = isset($_POST['bhg_is_affiliate']) ? 1 : 0;
-    update_user_meta($user_id, 'bhg_is_affiliate', $affiliate_status);
+	$affiliate_status = isset($_POST['bhg_is_affiliate']) ? 1 : 0;
+	update_user_meta($user_id, 'bhg_is_affiliate', $affiliate_status);
 }
 
 if (!function_exists('bhg_self_heal_db')) {
-    /**
-     * Attempt to repair missing database tables.
-     *
-     * @return void
-     */
-    function bhg_self_heal_db() {
-        if (!class_exists('BHG_DB')) require_once __DIR__ . '/includes/class-bhg-db.php';
-        try {
-            $db = new BHG_DB();
-            $db->create_tables();
-        } catch (Throwable $e) {
-            if (function_exists('error_log')) error_log('[BHG] DB self-heal failed: ' . $e->getMessage());
-        }
-    }
-    add_action('admin_init', 'bhg_self_heal_db');
-    register_activation_hook(__FILE__, 'bhg_self_heal_db');
+	/**
+	 * Attempt to repair missing database tables.
+	 *
+	 * @return void
+	 */
+	function bhg_self_heal_db() {
+		if (!class_exists('BHG_DB')) require_once __DIR__ . '/includes/class-bhg-db.php';
+		try {
+			$db = new BHG_DB();
+			$db->create_tables();
+		} catch (Throwable $e) {
+			if (function_exists('error_log')) error_log('[BHG] DB self-heal failed: ' . $e->getMessage());
+		}
+	}
+	add_action('admin_init', 'bhg_self_heal_db');
+	register_activation_hook(__FILE__, 'bhg_self_heal_db');
 }
 
 

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -3,125 +3,125 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_Ads {
 
-    /** Initialize front-end hooks for ads */
-    public static function init() {
-        add_action('wp_footer', ['BHG_Ads', 'render_footer']);
-        add_shortcode('bhg_ad', ['BHG_Ads', 'shortcode']);
-    }
+	/** Initialize front-end hooks for ads */
+	public static function init() {
+		add_action('wp_footer', ['BHG_Ads', 'render_footer']);
+		add_shortcode('bhg_ad', ['BHG_Ads', 'shortcode']);
+	}
 
 
-    /** Checks if front-end ads are enabled in plugin settings. */
-    protected static function ads_enabled() {
-        $settings = get_option('bhg_plugin_settings', []);
-        $enabled = isset($settings['ads_enabled']) ? (int)$settings['ads_enabled'] : 0;
-        return $enabled === 1;
-    }
+	/** Checks if front-end ads are enabled in plugin settings. */
+	protected static function ads_enabled() {
+		$settings = get_option('bhg_plugin_settings', []);
+		$enabled = isset($settings['ads_enabled']) ? (int)$settings['ads_enabled'] : 0;
+		return $enabled === 1;
+	}
 
-    /** Determine current user's affiliate status (global toggle). */
-    protected static function user_is_affiliate() {
-        if (!is_user_logged_in()) return false;
-        $uid = get_current_user_id();
-        return (bool) get_user_meta($uid, 'bhg_is_affiliate', true);
-    }
+	/** Determine current user's affiliate status (global toggle). */
+	protected static function user_is_affiliate() {
+		if (!is_user_logged_in()) return false;
+		$uid = get_current_user_id();
+		return (bool) get_user_meta($uid, 'bhg_is_affiliate', true);
+	}
 
-    /** Whether current visitor matches the ad's visibility setting. */
-    protected static function visibility_ok($visibility) {
-        $visibility = is_string($visibility) ? strtolower($visibility) : 'all';
-        switch ($visibility) {
-            case 'logged_in':
-                return is_user_logged_in();
-            case 'guests':
-                return !is_user_logged_in();
-            case 'affiliates':
-                return self::user_is_affiliate();
-            case 'non_affiliates':
-                return is_user_logged_in() ? ! self::user_is_affiliate() : false;
-            case 'all':
-            default:
-                return true;
-        }
-    }
+	/** Whether current visitor matches the ad's visibility setting. */
+	protected static function visibility_ok($visibility) {
+		$visibility = is_string($visibility) ? strtolower($visibility) : 'all';
+		switch ($visibility) {
+			case 'logged_in':
+				return is_user_logged_in();
+			case 'guests':
+				return !is_user_logged_in();
+			case 'affiliates':
+				return self::user_is_affiliate();
+			case 'non_affiliates':
+				return is_user_logged_in() ? ! self::user_is_affiliate() : false;
+			case 'all':
+			default:
+				return true;
+		}
+	}
 
-    /** Whether the current page is one of the targeted pages (by slug), if any are set. */
-    protected static function page_target_ok($target_pages) {
-        $target_pages = is_string($target_pages) ? trim($target_pages) : '';
-        if ($target_pages === '') return true; // no restriction
+	/** Whether the current page is one of the targeted pages (by slug), if any are set. */
+	protected static function page_target_ok($target_pages) {
+		$target_pages = is_string($target_pages) ? trim($target_pages) : '';
+		if ($target_pages === '') return true; // no restriction
 
-        // Normalize list of slugs
-        $slugs = array_filter(array_map(function($s){
-            return sanitize_title(wp_unslash(trim($s)));
-        }, explode(',', $target_pages)));
+		// Normalize list of slugs
+		$slugs = array_filter(array_map(function($s){
+			return sanitize_title(wp_unslash(trim($s)));
+		}, explode(',', $target_pages)));
 
-        if (empty($slugs)) return true;
+		if (empty($slugs)) return true;
 
-        // On singular pages, check post_name; otherwise, do not show
-        if (is_singular()) {
-            $post = get_post();
-            if (!$post) return false;
-            $slug = $post->post_name;
-            return in_array($slug, $slugs, true);
-        }
-        return false;
-    }
+		// On singular pages, check post_name; otherwise, do not show
+		if (is_singular()) {
+			$post = get_post();
+			if (!$post) return false;
+			$slug = $post->post_name;
+			return in_array($slug, $slugs, true);
+		}
+		return false;
+	}
 
-    /** Render a single ad row to HTML */
-    protected static function render_ad_row($row) {
-        $msg = isset($row->content) ? $row->content : '';
-        $msg = wp_kses_post($msg);
-        $link = isset($row->link_url) ? esc_url($row->link_url) : '';
+	/** Render a single ad row to HTML */
+	protected static function render_ad_row($row) {
+		$msg = isset($row->content) ? $row->content : '';
+		$msg = wp_kses_post($msg);
+		$link = isset($row->link_url) ? esc_url($row->link_url) : '';
 
-        if ($link) {
-            $msg = '<a href="' . $link . '">' . $msg . '</a>';
-        }
-        return '<div class="bhg-ad bhg-ad-' . esc_attr($row->placement) . '">' . $msg . '</div>';
-    }
+		if ($link) {
+			$msg = '<a href="' . $link . '">' . $msg . '</a>';
+		}
+		return '<div class="bhg-ad bhg-ad-' . esc_attr($row->placement) . '">' . $msg . '</div>';
+	}
 
-    /** Fetch active ads for a placement */
-    protected static function get_ads_for_placement($placement = 'footer') {
-        global $wpdb;
-        $table = $wpdb->prefix . 'bhg_ads';
-        $placement = sanitize_text_field($placement);
-        // Active ads ordered newest first
-        $sql = "SELECT id, content, link_url, placement, visible_to, target_pages FROM {$table} WHERE active=1 AND placement=%s ORDER BY id DESC";
-        return $wpdb->get_results($wpdb->prepare($sql, $placement));
-    }
+	/** Fetch active ads for a placement */
+	protected static function get_ads_for_placement($placement = 'footer') {
+		global $wpdb;
+		$table = $wpdb->prefix . 'bhg_ads';
+		$placement = sanitize_text_field($placement);
+		// Active ads ordered newest first
+		$sql = "SELECT id, content, link_url, placement, visible_to, target_pages FROM {$table} WHERE active=1 AND placement=%s ORDER BY id DESC";
+		return $wpdb->get_results($wpdb->prepare($sql, $placement));
+	}
 
-    /** Render footer-placed ads */
-    public static function render_footer() {
-        if (is_admin()) return;
-        if (!self::ads_enabled()) return;
+	/** Render footer-placed ads */
+	public static function render_footer() {
+		if (is_admin()) return;
+		if (!self::ads_enabled()) return;
 
-        $ads = self::get_ads_for_placement('footer');
-        if (empty($ads)) return;
+		$ads = self::get_ads_for_placement('footer');
+		if (empty($ads)) return;
 
-        $out = [];
-        foreach ($ads as $row) {
-            if (!self::visibility_ok($row->visible_to)) continue;
-            if (!self::page_target_ok($row->target_pages)) continue;
-            $out[] = self::render_ad_row($row);
-        }
+		$out = [];
+		foreach ($ads as $row) {
+			if (!self::visibility_ok($row->visible_to)) continue;
+			if (!self::page_target_ok($row->target_pages)) continue;
+			$out[] = self::render_ad_row($row);
+		}
 
-        if (!empty($out)) {
-            echo '<div class="bhg-ads bhg-ads-footer" style="margin:16px 0;text-align:center;">';
-            echo implode("\n", $out);
-            echo '</div>';
-        }
-    }
+		if (!empty($out)) {
+			echo '<div class="bhg-ads bhg-ads-footer" style="margin:16px 0;text-align:center;">';
+			echo implode("\n", $out);
+			echo '</div>';
+		}
+	}
 
-    /** Shortcode: [bhg_ad id="123"] renders a single ad row regardless of placement. */
-    public static function shortcode($atts = []) {
-        $a = shortcode_atts(['id' => 0], $atts, 'bhg_ad');
-        $id = isset($a['id']) ? (int)$a['id'] : 0;
-        if ($id <= 0) return '';
-        global $wpdb;
-        $table = $wpdb->prefix . 'bhg_ads';
-        $row = $wpdb->get_row($wpdb->prepare("SELECT id, content, placement, visible_to, target_pages, active, link_url FROM `$table` WHERE id=%d", $id));
-        if (!$row) return '';
-        if ((int)$row->active !== 1) return ''; // respect active flag
-        if (!self::visibility_ok($row->visible_to)) return '';
-        if (!self::page_target_ok($row->target_pages)) return '';
-        return self::render_ad_row($row);
-    }
+	/** Shortcode: [bhg_ad id="123"] renders a single ad row regardless of placement. */
+	public static function shortcode($atts = []) {
+		$a = shortcode_atts(['id' => 0], $atts, 'bhg_ad');
+		$id = isset($a['id']) ? (int)$a['id'] : 0;
+		if ($id <= 0) return '';
+		global $wpdb;
+		$table = $wpdb->prefix . 'bhg_ads';
+		$row = $wpdb->get_row($wpdb->prepare("SELECT id, content, placement, visible_to, target_pages, active, link_url FROM `$table` WHERE id=%d", $id));
+		if (!$row) return '';
+		if ((int)$row->active !== 1) return ''; // respect active flag
+		if (!self::visibility_ok($row->visible_to)) return '';
+		if (!self::page_target_ok($row->target_pages)) return '';
+		return self::render_ad_row($row);
+	}
 
 }
 

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -9,90 +9,90 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  */
 
 if (!function_exists('bhg_get_hunt')) {
-    function bhg_get_hunt($hunt_id){
-        global $wpdb;
-        $t = $wpdb->prefix . 'bhg_bonus_hunts';
-        return $wpdb->get_row($wpdb->prepare("SELECT * FROM $t WHERE id=%d", (int)$hunt_id));
-    }
+	function bhg_get_hunt($hunt_id){
+		global $wpdb;
+		$t = $wpdb->prefix . 'bhg_bonus_hunts';
+		return $wpdb->get_row($wpdb->prepare("SELECT * FROM $t WHERE id=%d", (int)$hunt_id));
+	}
 }
 
 if (!function_exists('bhg_get_latest_closed_hunts')) {
-    function bhg_get_latest_closed_hunts($limit = 3){
-        global $wpdb;
-        $t = $wpdb->prefix . 'bhg_bonus_hunts';
-        $sql = $wpdb->prepare("SELECT id, title, starting_balance, final_balance, winners_count, closed_at
-                               FROM $t
-                               WHERE status = %s
-                               ORDER BY closed_at DESC
-                               LIMIT %d", 'closed', (int)$limit);
-        return $wpdb->get_results($sql);
-    }
+	function bhg_get_latest_closed_hunts($limit = 3){
+		global $wpdb;
+		$t = $wpdb->prefix . 'bhg_bonus_hunts';
+		$sql = $wpdb->prepare("SELECT id, title, starting_balance, final_balance, winners_count, closed_at
+							   FROM $t
+							   WHERE status = %s
+							   ORDER BY closed_at DESC
+							   LIMIT %d", 'closed', (int)$limit);
+		return $wpdb->get_results($sql);
+	}
 }
 
 if (!function_exists('bhg_get_top_winners_for_hunt')) {
-    function bhg_get_top_winners_for_hunt($hunt_id, $winners_limit = 3){
-        global $wpdb;
-        $t_g = $wpdb->prefix . 'bhg_guesses';
-        $t_h = $wpdb->prefix . 'bhg_bonus_hunts';
+	function bhg_get_top_winners_for_hunt($hunt_id, $winners_limit = 3){
+		global $wpdb;
+		$t_g = $wpdb->prefix . 'bhg_guesses';
+		$t_h = $wpdb->prefix . 'bhg_bonus_hunts';
 
-        $hunt = $wpdb->get_row($wpdb->prepare("SELECT final_balance, winners_count FROM $t_h WHERE id=%d", (int)$hunt_id));
-        if (!$hunt || $hunt->final_balance === null) return array();
-        $limit = $winners_limit ?: (int) $hunt->winners_count ?: 3;
+		$hunt = $wpdb->get_row($wpdb->prepare("SELECT final_balance, winners_count FROM $t_h WHERE id=%d", (int)$hunt_id));
+		if (!$hunt || $hunt->final_balance === null) return array();
+		$limit = $winners_limit ?: (int) $hunt->winners_count ?: 3;
 
-        $sql = $wpdb->prepare(
-            "SELECT g.user_id, g.guess, ABS(g.guess - %f) AS diff
-             FROM $t_g g
-             WHERE g.hunt_id = %d
-             ORDER BY diff ASC
-             LIMIT %d",
-            (float)$hunt->final_balance, (int)$hunt_id, (int)$limit
-        );
-        return $wpdb->get_results($sql);
-    }
+		$sql = $wpdb->prepare(
+			"SELECT g.user_id, g.guess, ABS(g.guess - %f) AS diff
+			 FROM $t_g g
+			 WHERE g.hunt_id = %d
+			 ORDER BY diff ASC
+			 LIMIT %d",
+			(float)$hunt->final_balance, (int)$hunt_id, (int)$limit
+		);
+		return $wpdb->get_results($sql);
+	}
 }
 
 if (!function_exists('bhg_get_all_ranked_guesses')) {
-    function bhg_get_all_ranked_guesses($hunt_id){
-        global $wpdb;
-        $t_g = $wpdb->prefix . 'bhg_guesses';
-        $t_h = $wpdb->prefix . 'bhg_bonus_hunts';
-        $hunt = $wpdb->get_row($wpdb->prepare("SELECT final_balance FROM $t_h WHERE id=%d", (int)$hunt_id));
-        if (!$hunt || $hunt->final_balance === null) return array();
+	function bhg_get_all_ranked_guesses($hunt_id){
+		global $wpdb;
+		$t_g = $wpdb->prefix . 'bhg_guesses';
+		$t_h = $wpdb->prefix . 'bhg_bonus_hunts';
+		$hunt = $wpdb->get_row($wpdb->prepare("SELECT final_balance FROM $t_h WHERE id=%d", (int)$hunt_id));
+		if (!$hunt || $hunt->final_balance === null) return array();
 
-        $sql = $wpdb->prepare(
-            "SELECT g.id, g.user_id, g.guess, ABS(g.guess - %f) AS diff
-             FROM $t_g g
-             WHERE g.hunt_id = %d
-             ORDER BY diff ASC",
-            (float)$hunt->final_balance, (int)$hunt_id
-        );
-        return $wpdb->get_results($sql);
-    }
+		$sql = $wpdb->prepare(
+			"SELECT g.id, g.user_id, g.guess, ABS(g.guess - %f) AS diff
+			 FROM $t_g g
+			 WHERE g.hunt_id = %d
+			 ORDER BY diff ASC",
+			(float)$hunt->final_balance, (int)$hunt_id
+		);
+		return $wpdb->get_results($sql);
+	}
 }
 
 if (!function_exists('bhg_get_hunt_participants')) {
-    function bhg_get_hunt_participants($hunt_id, $paged = 1, $per_page = 30){
-        global $wpdb;
-        $t_g = $wpdb->prefix . 'bhg_guesses';
-        $offset = max(0, ((int)$paged - 1) * (int)$per_page);
+	function bhg_get_hunt_participants($hunt_id, $paged = 1, $per_page = 30){
+		global $wpdb;
+		$t_g = $wpdb->prefix . 'bhg_guesses';
+		$offset = max(0, ((int)$paged - 1) * (int)$per_page);
 
-        $rows = $wpdb->get_results($wpdb->prepare(
-            "SELECT SQL_CALC_FOUND_ROWS id, user_id, guess, created_at
-             FROM $t_g
-             WHERE hunt_id = %d
-             ORDER BY created_at DESC
-             LIMIT %d OFFSET %d",
-            (int)$hunt_id, (int)$per_page, (int)$offset
-        ));
-        $total = (int) $wpdb->get_var( "SELECT FOUND_ROWS()" );
-        return array('rows' => $rows, 'total' => $total);
-    }
+		$rows = $wpdb->get_results($wpdb->prepare(
+			"SELECT SQL_CALC_FOUND_ROWS id, user_id, guess, created_at
+			 FROM $t_g
+			 WHERE hunt_id = %d
+			 ORDER BY created_at DESC
+			 LIMIT %d OFFSET %d",
+			(int)$hunt_id, (int)$per_page, (int)$offset
+		));
+		$total = (int) $wpdb->get_var( "SELECT FOUND_ROWS()" );
+		return array('rows' => $rows, 'total' => $total);
+	}
 }
 
 if (!function_exists('bhg_remove_guess')) {
-    function bhg_remove_guess($guess_id){
-        global $wpdb;
-        $t_g = $wpdb->prefix . 'bhg_guesses';
-        return $wpdb->delete($t_g, array('id' => (int)$guess_id), array('%d'));
-    }
+	function bhg_remove_guess($guess_id){
+		global $wpdb;
+		$t_g = $wpdb->prefix . 'bhg_guesses';
+		return $wpdb->delete($t_g, array('id' => (int)$guess_id), array('%d'));
+	}
 }

--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -6,108 +6,108 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  */
 class BHG_Bonus_Hunts {
 
-    /**
-     * Retrieve latest hunts with winners.
-     *
-     * @param int $limit Number of hunts to fetch. Default 3.
-     * @return array List of hunts and winners.
-     */
-    public static function get_latest_hunts_with_winners( $limit = 3 ) {
-        global $wpdb;
-        $hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
-        $guesses_table = $wpdb->prefix . 'bhg_guesses';
-        $limit         = max( 1, (int) $limit );
+	/**
+	 * Retrieve latest hunts with winners.
+	 *
+	 * @param int $limit Number of hunts to fetch. Default 3.
+	 * @return array List of hunts and winners.
+	 */
+	public static function get_latest_hunts_with_winners( $limit = 3 ) {
+		global $wpdb;
+		$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
+		$guesses_table = $wpdb->prefix . 'bhg_guesses';
+		$limit         = max( 1, (int) $limit );
 
-        $hunts = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT id, title, starting_balance, final_balance, winners_count, closed_at
-                 FROM `$hunts_table`
-                 WHERE status = %s AND final_balance IS NOT NULL AND closed_at IS NOT NULL
-                 ORDER BY closed_at DESC
-                 LIMIT %d",
-                'closed',
-                $limit
-            )
-        );
+		$hunts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id, title, starting_balance, final_balance, winners_count, closed_at
+				 FROM `$hunts_table`
+				 WHERE status = %s AND final_balance IS NOT NULL AND closed_at IS NOT NULL
+				 ORDER BY closed_at DESC
+				 LIMIT %d",
+				'closed',
+				$limit
+			)
+		);
 
-        $out = array();
+		$out = array();
 
-        foreach ( (array) $hunts as $h ) {
-            $winners_count = max( 1, (int) $h->winners_count );
-            $winners       = $wpdb->get_results(
-                $wpdb->prepare(
-                    "SELECT g.user_id, u.display_name, g.guess,
-                            ABS(g.guess - %f) AS diff
-                     FROM `$guesses_table` g
-                     LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
-                     WHERE g.hunt_id = %d
-                     ORDER BY diff ASC, g.id ASC
-                     LIMIT %d",
-                    $h->final_balance,
-                    $h->id,
-                    $winners_count
-                )
-            );
+		foreach ( (array) $hunts as $h ) {
+			$winners_count = max( 1, (int) $h->winners_count );
+			$winners       = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT g.user_id, u.display_name, g.guess,
+							ABS(g.guess - %f) AS diff
+					 FROM `$guesses_table` g
+					 LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
+					 WHERE g.hunt_id = %d
+					 ORDER BY diff ASC, g.id ASC
+					 LIMIT %d",
+					$h->final_balance,
+					$h->id,
+					$winners_count
+				)
+			);
 
-            $out[] = array(
-                'hunt'    => $h,
-                'winners' => $winners,
-            );
-        }
+			$out[] = array(
+				'hunt'    => $h,
+				'winners' => $winners,
+			);
+		}
 
-        return $out;
-    }
+		return $out;
+	}
 
-    /**
-     * Retrieve a hunt by ID.
-     *
-     * @param int $hunt_id Hunt ID.
-     * @return object|null Hunt data or null if not found.
-     */
-    public static function get_hunt( $hunt_id ) {
-        global $wpdb;
-        $hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
+	/**
+	 * Retrieve a hunt by ID.
+	 *
+	 * @param int $hunt_id Hunt ID.
+	 * @return object|null Hunt data or null if not found.
+	 */
+	public static function get_hunt( $hunt_id ) {
+		global $wpdb;
+		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 
-        return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$hunts_table` WHERE id=%d", (int) $hunt_id ) );
-    }
+		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$hunts_table` WHERE id=%d", (int) $hunt_id ) );
+	}
 
-    /**
-     * Get ranked guesses for a hunt.
-     *
-     * @param int $hunt_id Hunt ID.
-     * @return array List of guesses.
-     */
-    public static function get_hunt_guesses_ranked( $hunt_id ) {
-        global $wpdb;
-        $hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
-        $guesses_table = $wpdb->prefix . 'bhg_guesses';
-        $hunt          = self::get_hunt( $hunt_id );
+	/**
+	 * Get ranked guesses for a hunt.
+	 *
+	 * @param int $hunt_id Hunt ID.
+	 * @return array List of guesses.
+	 */
+	public static function get_hunt_guesses_ranked( $hunt_id ) {
+		global $wpdb;
+		$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
+		$guesses_table = $wpdb->prefix . 'bhg_guesses';
+		$hunt          = self::get_hunt( $hunt_id );
 
-        if ( ! $hunt ) { return array(); }
+		if ( ! $hunt ) { return array(); }
 
-        if ( null !== $hunt->final_balance ) {
-            return $wpdb->get_results(
-                $wpdb->prepare(
-                    "SELECT g.*, u.display_name, ABS(g.guess - %f) AS diff
-                     FROM `$guesses_table` g
-                     LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
-                     WHERE g.hunt_id = %d
-                     ORDER BY diff ASC, g.id ASC",
-                    $hunt->final_balance,
-                    $hunt_id
-                )
-            );
-        }
+		if ( null !== $hunt->final_balance ) {
+			return $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT g.*, u.display_name, ABS(g.guess - %f) AS diff
+					 FROM `$guesses_table` g
+					 LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
+					 WHERE g.hunt_id = %d
+					 ORDER BY diff ASC, g.id ASC",
+					$hunt->final_balance,
+					$hunt_id
+				)
+			);
+		}
 
-        return $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT g.*, u.display_name, NULL AS diff
-                 FROM `$guesses_table` g
-                 LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
-                 WHERE g.hunt_id = %d
-                 ORDER BY g.id ASC",
-                $hunt_id
-            )
-        );
-    }
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT g.*, u.display_name, NULL AS diff
+				 FROM `$guesses_table` g
+				 LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
+				 WHERE g.hunt_id = %d
+				 ORDER BY g.id ASC",
+				$hunt_id
+			)
+		);
+	}
 }

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -3,276 +3,276 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class BHG_DB {
 
-    // Static wrapper to support legacy static calls.
-    public static function migrate() {
-        $db = new self();
-        $db->create_tables();
+	// Static wrapper to support legacy static calls.
+	public static function migrate() {
+		$db = new self();
+		$db->create_tables();
 
-        global $wpdb;
-        $tours_table = $wpdb->prefix . 'bhg_tournaments';
+		global $wpdb;
+		$tours_table = $wpdb->prefix . 'bhg_tournaments';
 
-        // Drop legacy "period" column and related index if they exist.
-        if ( $db->column_exists( $tours_table, 'period' ) ) {
-            // Remove unique index first if present.
-            if ( $db->index_exists( $tours_table, 'type_period' ) ) {
-                $wpdb->query( "ALTER TABLE `{$tours_table}` DROP INDEX type_period" );
-            }
+		// Drop legacy "period" column and related index if they exist.
+		if ( $db->column_exists( $tours_table, 'period' ) ) {
+			// Remove unique index first if present.
+			if ( $db->index_exists( $tours_table, 'type_period' ) ) {
+				$wpdb->query( "ALTER TABLE `{$tours_table}` DROP INDEX type_period" );
+			}
 
-            $wpdb->query( "ALTER TABLE `{$tours_table}` DROP COLUMN period" );
-        }
-    }
+			$wpdb->query( "ALTER TABLE `{$tours_table}` DROP COLUMN period" );
+		}
+	}
 
-    public function create_tables() {
-        global $wpdb;
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	public function create_tables() {
+		global $wpdb;
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-        $charset_collate = $wpdb->get_charset_collate();
+		$charset_collate = $wpdb->get_charset_collate();
 
-        $hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
-        $guesses_table = $wpdb->prefix . 'bhg_guesses';
-        $tours_table   = $wpdb->prefix . 'bhg_tournaments';
-        $ads_table     = $wpdb->prefix . 'bhg_ads';
-        $trans_table   = $wpdb->prefix . 'bhg_translations';
-        $aff_table     = $wpdb->prefix . 'bhg_affiliates';
+		$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
+		$guesses_table = $wpdb->prefix . 'bhg_guesses';
+		$tours_table   = $wpdb->prefix . 'bhg_tournaments';
+		$ads_table     = $wpdb->prefix . 'bhg_ads';
+		$trans_table   = $wpdb->prefix . 'bhg_translations';
+		$aff_table     = $wpdb->prefix . 'bhg_affiliates';
 
-        $sql = [];
+		$sql = [];
 
-        // Bonus Hunts
-        $sql[] = "CREATE TABLE {$hunts_table} (
-            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            title VARCHAR(190) NOT NULL,
-            starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
-            num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
-            prizes TEXT NULL,
-            affiliate_site_id BIGINT UNSIGNED NULL,
-            winners_count INT UNSIGNED NOT NULL DEFAULT 3,
-            final_balance DECIMAL(12,2) NULL,
-            status VARCHAR(20) NOT NULL DEFAULT 'open',
-            created_at DATETIME NULL,
-            updated_at DATETIME NULL,
-            closed_at DATETIME NULL,
-            PRIMARY KEY  (id),
-            KEY status (status)
-        ) {$charset_collate};";
+		// Bonus Hunts
+		$sql[] = "CREATE TABLE {$hunts_table} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			title VARCHAR(190) NOT NULL,
+			starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+			num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
+			prizes TEXT NULL,
+			affiliate_site_id BIGINT UNSIGNED NULL,
+			winners_count INT UNSIGNED NOT NULL DEFAULT 3,
+			final_balance DECIMAL(12,2) NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'open',
+			created_at DATETIME NULL,
+			updated_at DATETIME NULL,
+			closed_at DATETIME NULL,
+			PRIMARY KEY  (id),
+			KEY status (status)
+		) {$charset_collate};";
 
-        // Guesses
-        $sql[] = "CREATE TABLE {$guesses_table} (
-            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            hunt_id BIGINT UNSIGNED NOT NULL,
-            user_id BIGINT UNSIGNED NOT NULL,
-            guess DECIMAL(12,2) NOT NULL,
-            created_at DATETIME NULL,
-            PRIMARY KEY  (id),
-            KEY hunt_id (hunt_id),
-            KEY user_id (user_id)
-        ) {$charset_collate};";
+		// Guesses
+		$sql[] = "CREATE TABLE {$guesses_table} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			hunt_id BIGINT UNSIGNED NOT NULL,
+			user_id BIGINT UNSIGNED NOT NULL,
+			guess DECIMAL(12,2) NOT NULL,
+			created_at DATETIME NULL,
+			PRIMARY KEY  (id),
+			KEY hunt_id (hunt_id),
+			KEY user_id (user_id)
+		) {$charset_collate};";
 
-        // Tournaments
-        $sql[] = "CREATE TABLE {$tours_table} (
-            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            title VARCHAR(190) NOT NULL,
-            description TEXT NULL,
-            type VARCHAR(20) NOT NULL,
-            start_date DATE NULL,
-            end_date DATE NULL,
-            status VARCHAR(20) NOT NULL DEFAULT 'active',
-            created_at DATETIME NULL,
-            updated_at DATETIME NULL,
-            PRIMARY KEY  (id),
-            KEY type (type),
-            KEY status (status)
-        ) {$charset_collate};";
+		// Tournaments
+		$sql[] = "CREATE TABLE {$tours_table} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			title VARCHAR(190) NOT NULL,
+			description TEXT NULL,
+			type VARCHAR(20) NOT NULL,
+			start_date DATE NULL,
+			end_date DATE NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'active',
+			created_at DATETIME NULL,
+			updated_at DATETIME NULL,
+			PRIMARY KEY  (id),
+			KEY type (type),
+			KEY status (status)
+		) {$charset_collate};";
 
-        // Ads
-        $sql[] = "CREATE TABLE {$ads_table} (
-            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            title VARCHAR(190) NOT NULL,
-            content TEXT NULL,
-            link_url VARCHAR(255) NULL,
-            placement VARCHAR(50) NOT NULL DEFAULT 'none',
-            visible_to VARCHAR(30) NOT NULL DEFAULT 'all',
-            target_pages TEXT NULL,
-            active TINYINT(1) NOT NULL DEFAULT 1,
-            created_at DATETIME NULL,
-            updated_at DATETIME NULL,
-            PRIMARY KEY  (id),
-            KEY placement (placement),
-            KEY visible_to (visible_to)
-        ) {$charset_collate};";
+		// Ads
+		$sql[] = "CREATE TABLE {$ads_table} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			title VARCHAR(190) NOT NULL,
+			content TEXT NULL,
+			link_url VARCHAR(255) NULL,
+			placement VARCHAR(50) NOT NULL DEFAULT 'none',
+			visible_to VARCHAR(30) NOT NULL DEFAULT 'all',
+			target_pages TEXT NULL,
+			active TINYINT(1) NOT NULL DEFAULT 1,
+			created_at DATETIME NULL,
+			updated_at DATETIME NULL,
+			PRIMARY KEY  (id),
+			KEY placement (placement),
+			KEY visible_to (visible_to)
+		) {$charset_collate};";
 
-        // Translations
-        $sql[] = "CREATE TABLE {$trans_table} (
-            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            tkey VARCHAR(190) NOT NULL,
-            tvalue LONGTEXT NULL,
-            locale VARCHAR(20) NOT NULL DEFAULT 'en_US',
-            created_at DATETIME NULL,
-            updated_at DATETIME NULL,
-            PRIMARY KEY  (id),
-            UNIQUE KEY tkey_locale (tkey, locale)
-        ) {$charset_collate};";
+		// Translations
+		$sql[] = "CREATE TABLE {$trans_table} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			tkey VARCHAR(190) NOT NULL,
+			tvalue LONGTEXT NULL,
+			locale VARCHAR(20) NOT NULL DEFAULT 'en_US',
+			created_at DATETIME NULL,
+			updated_at DATETIME NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY tkey_locale (tkey, locale)
+		) {$charset_collate};";
 
-        // Affiliates
-        $sql[] = "CREATE TABLE {$aff_table} (
-            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-            name VARCHAR(190) NOT NULL,
-            url VARCHAR(255) NULL,
-            status VARCHAR(20) NOT NULL DEFAULT 'active',
-            created_at DATETIME NULL,
-            updated_at DATETIME NULL,
-            PRIMARY KEY  (id),
-            UNIQUE KEY name_unique (name)
-        ) {$charset_collate};";
+		// Affiliates
+		$sql[] = "CREATE TABLE {$aff_table} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			name VARCHAR(190) NOT NULL,
+			url VARCHAR(255) NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'active',
+			created_at DATETIME NULL,
+			updated_at DATETIME NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY name_unique (name)
+		) {$charset_collate};";
 
-        foreach ($sql as $statement) {
-            dbDelta($statement);
-        }
+		foreach ($sql as $statement) {
+			dbDelta($statement);
+		}
 
-        // Idempotent ensure for columns/indexes
-        try {
-            // Hunts: winners_count, affiliate_site_id
-            $need = [
-                'winners_count'    => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
-                'affiliate_site_id'=> "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
-                'final_balance'    => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
-                'status'           => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
-            ];
-            foreach ( $need as $c => $alter ) {
-                if ( ! $this->column_exists( $hunts_table, $c ) ) {
-                    $wpdb->query( $alter );
-                }
-            }
+		// Idempotent ensure for columns/indexes
+		try {
+			// Hunts: winners_count, affiliate_site_id
+			$need = [
+				'winners_count'    => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
+				'affiliate_site_id'=> "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
+				'final_balance'    => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
+				'status'           => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
+			];
+			foreach ( $need as $c => $alter ) {
+				if ( ! $this->column_exists( $hunts_table, $c ) ) {
+					$wpdb->query( $alter );
+				}
+			}
 
-            // Tournaments: make sure common columns exist
-            $tneed = [
-                'title'       => "ALTER TABLE `{$tours_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
-                'description' => "ALTER TABLE `{$tours_table}` ADD COLUMN description TEXT NULL",
-                'type'        => "ALTER TABLE `{$tours_table}` ADD COLUMN type VARCHAR(20) NOT NULL",
-                'start_date'  => "ALTER TABLE `{$tours_table}` ADD COLUMN start_date DATE NULL",
-                'end_date'    => "ALTER TABLE `{$tours_table}` ADD COLUMN end_date DATE NULL",
-                'status'      => "ALTER TABLE `{$tours_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
-            ];
-            foreach ( $tneed as $c => $alter ) {
-                if ( ! $this->column_exists( $tours_table, $c ) ) {
-                    $wpdb->query( $alter );
-                }
-            }
+			// Tournaments: make sure common columns exist
+			$tneed = [
+				'title'       => "ALTER TABLE `{$tours_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
+				'description' => "ALTER TABLE `{$tours_table}` ADD COLUMN description TEXT NULL",
+				'type'        => "ALTER TABLE `{$tours_table}` ADD COLUMN type VARCHAR(20) NOT NULL",
+				'start_date'  => "ALTER TABLE `{$tours_table}` ADD COLUMN start_date DATE NULL",
+				'end_date'    => "ALTER TABLE `{$tours_table}` ADD COLUMN end_date DATE NULL",
+				'status'      => "ALTER TABLE `{$tours_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
+			];
+			foreach ( $tneed as $c => $alter ) {
+				if ( ! $this->column_exists( $tours_table, $c ) ) {
+					$wpdb->query( $alter );
+				}
+			}
 
-            // Ads columns
-            $aneed = [
-                'title'        => "ALTER TABLE `{$ads_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
-                'content'      => "ALTER TABLE `{$ads_table}` ADD COLUMN content TEXT NULL",
-                'link_url'     => "ALTER TABLE `{$ads_table}` ADD COLUMN link_url VARCHAR(255) NULL",
-                'placement'    => "ALTER TABLE `{$ads_table}` ADD COLUMN placement VARCHAR(50) NOT NULL DEFAULT 'none'",
-                'visible_to'   => "ALTER TABLE `{$ads_table}` ADD COLUMN visible_to VARCHAR(30) NOT NULL DEFAULT 'all'",
-                'target_pages' => "ALTER TABLE `{$ads_table}` ADD COLUMN target_pages TEXT NULL",
-                'active'       => "ALTER TABLE `{$ads_table}` ADD COLUMN active TINYINT(1) NOT NULL DEFAULT 1",
-                'created_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN created_at DATETIME NULL",
-                'updated_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN updated_at DATETIME NULL",
-            ];
-            foreach ( $aneed as $c => $alter ) {
-                if ( ! $this->column_exists( $ads_table, $c ) ) {
-                    $wpdb->query( $alter );
-                }
-            }
+			// Ads columns
+			$aneed = [
+				'title'        => "ALTER TABLE `{$ads_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
+				'content'      => "ALTER TABLE `{$ads_table}` ADD COLUMN content TEXT NULL",
+				'link_url'     => "ALTER TABLE `{$ads_table}` ADD COLUMN link_url VARCHAR(255) NULL",
+				'placement'    => "ALTER TABLE `{$ads_table}` ADD COLUMN placement VARCHAR(50) NOT NULL DEFAULT 'none'",
+				'visible_to'   => "ALTER TABLE `{$ads_table}` ADD COLUMN visible_to VARCHAR(30) NOT NULL DEFAULT 'all'",
+				'target_pages' => "ALTER TABLE `{$ads_table}` ADD COLUMN target_pages TEXT NULL",
+				'active'       => "ALTER TABLE `{$ads_table}` ADD COLUMN active TINYINT(1) NOT NULL DEFAULT 1",
+				'created_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN created_at DATETIME NULL",
+				'updated_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN updated_at DATETIME NULL",
+			];
+			foreach ( $aneed as $c => $alter ) {
+				if ( ! $this->column_exists( $ads_table, $c ) ) {
+					$wpdb->query( $alter );
+				}
+			}
 
-            // Translations columns
-            $trneed = [
-                'tkey'       => "ALTER TABLE `{$trans_table}` ADD COLUMN tkey VARCHAR(190) NOT NULL",
-                'tvalue'     => "ALTER TABLE `{$trans_table}` ADD COLUMN tvalue LONGTEXT NULL",
-                'locale'     => "ALTER TABLE `{$trans_table}` ADD COLUMN locale VARCHAR(20) NOT NULL DEFAULT 'en_US'",
-                'created_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN created_at DATETIME NULL",
-                'updated_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN updated_at DATETIME NULL",
-            ];
-            foreach ( $trneed as $c => $alter ) {
-                if ( ! $this->column_exists( $trans_table, $c ) ) {
-                    $wpdb->query( $alter );
-                }
-            }
-            // Ensure unique index
-            if ( ! $this->index_exists( $trans_table, 'tkey_locale' ) ) {
-                $wpdb->query( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY tkey_locale (tkey, locale)" );
-            }
+			// Translations columns
+			$trneed = [
+				'tkey'       => "ALTER TABLE `{$trans_table}` ADD COLUMN tkey VARCHAR(190) NOT NULL",
+				'tvalue'     => "ALTER TABLE `{$trans_table}` ADD COLUMN tvalue LONGTEXT NULL",
+				'locale'     => "ALTER TABLE `{$trans_table}` ADD COLUMN locale VARCHAR(20) NOT NULL DEFAULT 'en_US'",
+				'created_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN created_at DATETIME NULL",
+				'updated_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN updated_at DATETIME NULL",
+			];
+			foreach ( $trneed as $c => $alter ) {
+				if ( ! $this->column_exists( $trans_table, $c ) ) {
+					$wpdb->query( $alter );
+				}
+			}
+			// Ensure unique index
+			if ( ! $this->index_exists( $trans_table, 'tkey_locale' ) ) {
+				$wpdb->query( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY tkey_locale (tkey, locale)" );
+			}
 
-            // Affiliates columns / unique index
-            $afneed = [
-                'name'       => "ALTER TABLE `{$aff_table}` ADD COLUMN name VARCHAR(190) NOT NULL",
-                'url'        => "ALTER TABLE `{$aff_table}` ADD COLUMN url VARCHAR(255) NULL",
-                'status'     => "ALTER TABLE `{$aff_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
-                'created_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN created_at DATETIME NULL",
-                'updated_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN updated_at DATETIME NULL",
-            ];
-            foreach ( $afneed as $c => $alter ) {
-                if ( ! $this->column_exists( $aff_table, $c ) ) {
-                    $wpdb->query( $alter );
-                }
-            }
-            if ( ! $this->index_exists( $aff_table, 'name_unique' ) ) {
-                $wpdb->query( "ALTER TABLE `{$aff_table}` ADD UNIQUE KEY name_unique (name)" );
-            }
+			// Affiliates columns / unique index
+			$afneed = [
+				'name'       => "ALTER TABLE `{$aff_table}` ADD COLUMN name VARCHAR(190) NOT NULL",
+				'url'        => "ALTER TABLE `{$aff_table}` ADD COLUMN url VARCHAR(255) NULL",
+				'status'     => "ALTER TABLE `{$aff_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
+				'created_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN created_at DATETIME NULL",
+				'updated_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN updated_at DATETIME NULL",
+			];
+			foreach ( $afneed as $c => $alter ) {
+				if ( ! $this->column_exists( $aff_table, $c ) ) {
+					$wpdb->query( $alter );
+				}
+			}
+			if ( ! $this->index_exists( $aff_table, 'name_unique' ) ) {
+				$wpdb->query( "ALTER TABLE `{$aff_table}` ADD UNIQUE KEY name_unique (name)" );
+			}
 
-        } catch (Throwable $e) {
-            if (function_exists('error_log')) error_log('[BHG] Schema ensure error: ' . $e->getMessage());
-        }
-    }
+		} catch (Throwable $e) {
+			if (function_exists('error_log')) error_log('[BHG] Schema ensure error: ' . $e->getMessage());
+		}
+	}
 
-    /**
-     * Check if a column exists, falling back when information_schema is not accessible.
-     *
-     * @param string $table  Table name.
-     * @param string $column Column to check.
-     * @return bool
-     */
-    private function column_exists( $table, $column ) {
-        global $wpdb;
+	/**
+	 * Check if a column exists, falling back when information_schema is not accessible.
+	 *
+	 * @param string $table  Table name.
+	 * @param string $column Column to check.
+	 * @return bool
+	 */
+	private function column_exists( $table, $column ) {
+		global $wpdb;
 
-        $table  = esc_sql( $table );
-        $column = esc_sql( $column );
+		$table  = esc_sql( $table );
+		$column = esc_sql( $column );
 
-        $wpdb->last_error = '';
-        $sql    = $wpdb->prepare(
-            "SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND COLUMN_NAME=%s",
-            DB_NAME,
-            $table,
-            $column
-        );
-        $exists = $wpdb->get_var( $sql );
+		$wpdb->last_error = '';
+		$sql    = $wpdb->prepare(
+			"SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND COLUMN_NAME=%s",
+			DB_NAME,
+			$table,
+			$column
+		);
+		$exists = $wpdb->get_var( $sql );
 
-        if ( $wpdb->last_error ) {
-            $wpdb->last_error = '';
-            $exists           = $wpdb->get_var( $wpdb->prepare( "SHOW COLUMNS FROM `{$table}` LIKE %s", $column ) );
-        }
+		if ( $wpdb->last_error ) {
+			$wpdb->last_error = '';
+			$exists           = $wpdb->get_var( $wpdb->prepare( "SHOW COLUMNS FROM `{$table}` LIKE %s", $column ) );
+		}
 
-        return ! empty( $exists );
-    }
+		return ! empty( $exists );
+	}
 
-    /**
-     * Check if an index exists, falling back when information_schema is not accessible.
-     *
-     * @param string $table Table name.
-     * @param string $index Index to check.
-     * @return bool
-     */
-    private function index_exists( $table, $index ) {
-        global $wpdb;
+	/**
+	 * Check if an index exists, falling back when information_schema is not accessible.
+	 *
+	 * @param string $table Table name.
+	 * @param string $index Index to check.
+	 * @return bool
+	 */
+	private function index_exists( $table, $index ) {
+		global $wpdb;
 
-        $table = esc_sql( $table );
-        $index = esc_sql( $index );
+		$table = esc_sql( $table );
+		$index = esc_sql( $index );
 
-        $wpdb->last_error = '';
-        $sql    = $wpdb->prepare(
-            "SELECT INDEX_NAME FROM information_schema.STATISTICS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND INDEX_NAME=%s",
-            DB_NAME,
-            $table,
-            $index
-        );
-        $exists = $wpdb->get_var( $sql );
+		$wpdb->last_error = '';
+		$sql    = $wpdb->prepare(
+			"SELECT INDEX_NAME FROM information_schema.STATISTICS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND INDEX_NAME=%s",
+			DB_NAME,
+			$table,
+			$index
+		);
+		$exists = $wpdb->get_var( $sql );
 
-        if ( $wpdb->last_error ) {
-            $wpdb->last_error = '';
-            $exists           = $wpdb->get_var( $wpdb->prepare( "SHOW INDEX FROM `{$table}` WHERE Key_name=%s", $index ) );
-        }
+		if ( $wpdb->last_error ) {
+			$wpdb->last_error = '';
+			$exists           = $wpdb->get_var( $wpdb->prepare( "SHOW INDEX FROM `{$table}` WHERE Key_name=%s", $index ) );
+		}
 
-        return ! empty( $exists );
-    }
+		return ! empty( $exists );
+	}
 }

--- a/includes/class-bhg-logger.php
+++ b/includes/class-bhg-logger.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 class BHG_Logger {
-    public static function info($msg){ bhg_log($msg); }
-    public static function error($msg){ bhg_log('ERROR: ' . $msg); }
+	public static function info($msg){ bhg_log($msg); }
+	public static function error($msg){ bhg_log('ERROR: ' . $msg); }
 }

--- a/includes/class-bhg-login-redirect.php
+++ b/includes/class-bhg-login-redirect.php
@@ -1,55 +1,55 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
-    class BHG_Login_Redirect {
+	class BHG_Login_Redirect {
 
-        public function __construct() {
-            add_filter( 'login_redirect', array( $this, 'core_login_redirect' ), 10, 3 );
+		public function __construct() {
+			add_filter( 'login_redirect', array( $this, 'core_login_redirect' ), 10, 3 );
 
-            // Nextend Social Login compatibility if plugin active.
-            if ( function_exists( 'NextendSocialLogin' ) ) {
-                add_filter( 'nsl_login_redirect', array( $this, 'nextend_redirect' ), 10, 3 );
-            }
-        }
+			// Nextend Social Login compatibility if plugin active.
+			if ( function_exists( 'NextendSocialLogin' ) ) {
+				add_filter( 'nsl_login_redirect', array( $this, 'nextend_redirect' ), 10, 3 );
+			}
+		}
 
-        public function core_login_redirect( $redirect_to, $requested, $user ) {
-            if ( ! empty( $_REQUEST['redirect_to'] ) ) {
-                $requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );
-                $validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
-                return esc_url_raw( $validated_redirect );
-            }
+		public function core_login_redirect( $redirect_to, $requested, $user ) {
+			if ( ! empty( $_REQUEST['redirect_to'] ) ) {
+				$requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );
+				$validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
+				return esc_url_raw( $validated_redirect );
+			}
 
-            // Fall back to referer if safe.
-            $ref = wp_get_referer();
-            if ( $ref ) {
-                $validated_ref = wp_validate_redirect( $ref, home_url( '/' ) );
-                return esc_url_raw( $validated_ref );
-            }
+			// Fall back to referer if safe.
+			$ref = wp_get_referer();
+			if ( $ref ) {
+				$validated_ref = wp_validate_redirect( $ref, home_url( '/' ) );
+				return esc_url_raw( $validated_ref );
+			}
 
-            $validated_default = wp_validate_redirect( $redirect_to, home_url( '/' ) );
-            return esc_url_raw( $validated_default );
-        }
+			$validated_default = wp_validate_redirect( $redirect_to, home_url( '/' ) );
+			return esc_url_raw( $validated_default );
+		}
 
-        public function nextend_redirect( $redirect_to, $user, $provider ) {
-            if ( ! empty( $_REQUEST['redirect_to'] ) ) {
-                $requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );
-                $validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
-                return esc_url_raw( $validated_redirect );
-            }
+		public function nextend_redirect( $redirect_to, $user, $provider ) {
+			if ( ! empty( $_REQUEST['redirect_to'] ) ) {
+				$requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );
+				$validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
+				return esc_url_raw( $validated_redirect );
+			}
 
-            $ref = wp_get_referer();
-            if ( $ref ) {
-                $validated_ref = wp_validate_redirect( $ref, home_url( '/' ) );
-                return esc_url_raw( $validated_ref );
-            }
+			$ref = wp_get_referer();
+			if ( $ref ) {
+				$validated_ref = wp_validate_redirect( $ref, home_url( '/' ) );
+				return esc_url_raw( $validated_ref );
+			}
 
-            $validated_default = wp_validate_redirect( $redirect_to, home_url( '/' ) );
-            return esc_url_raw( $validated_default );
-        }
-    }
+			$validated_default = wp_validate_redirect( $redirect_to, home_url( '/' ) );
+			return esc_url_raw( $validated_default );
+		}
+	}
 }
 new BHG_Login_Redirect();
 

--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -12,67 +12,67 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  */
 class BHG_Models {
 
-    /**
-     * Close a bonus hunt and determine winners.
-     *
-     * @param int   $hunt_id       Hunt identifier.
-     * @param float $final_balance Final balance for the hunt.
-     *
-     * @return int[] Array of winning user IDs.
-     */
-    public static function close_hunt( $hunt_id, $final_balance ) {
-        global $wpdb;
+	/**
+	 * Close a bonus hunt and determine winners.
+	 *
+	 * @param int   $hunt_id       Hunt identifier.
+	 * @param float $final_balance Final balance for the hunt.
+	 *
+	 * @return int[] Array of winning user IDs.
+	 */
+	public static function close_hunt( $hunt_id, $final_balance ) {
+		global $wpdb;
 
-        $hunt_id       = (int) $hunt_id;
-        $final_balance = (float) $final_balance;
+		$hunt_id       = (int) $hunt_id;
+		$final_balance = (float) $final_balance;
 
-        if ( $hunt_id <= 0 ) {
-            return array();
-        }
+		if ( $hunt_id <= 0 ) {
+			return array();
+		}
 
-        $hunts_tbl   = $wpdb->prefix . 'bhg_bonus_hunts';
-        $guesses_tbl = $wpdb->prefix . 'bhg_guesses';
+		$hunts_tbl   = $wpdb->prefix . 'bhg_bonus_hunts';
+		$guesses_tbl = $wpdb->prefix . 'bhg_guesses';
 
-        // Determine number of winners for this hunt.
-        $winners_count = (int) $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT winners_count FROM {$hunts_tbl} WHERE id = %d",
-                $hunt_id
-            )
-        );
-        if ( $winners_count <= 0 ) {
-            $winners_count = 1;
-        }
+		// Determine number of winners for this hunt.
+		$winners_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT winners_count FROM {$hunts_tbl} WHERE id = %d",
+				$hunt_id
+			)
+		);
+		if ( $winners_count <= 0 ) {
+			$winners_count = 1;
+		}
 
-        // Update hunt status and final details.
-        $now = current_time( 'mysql' );
-        $wpdb->update(
-            $hunts_tbl,
-            array(
-                'status'        => 'closed',
-                'final_balance' => $final_balance,
-                'closed_at'     => $now,
-                'updated_at'    => $now,
-            ),
-            array( 'id' => $hunt_id ),
-            array( '%s', '%f', '%s', '%s' ),
-            array( '%d' )
-        );
+		// Update hunt status and final details.
+		$now = current_time( 'mysql' );
+		$wpdb->update(
+			$hunts_tbl,
+			array(
+				'status'        => 'closed',
+				'final_balance' => $final_balance,
+				'closed_at'     => $now,
+				'updated_at'    => $now,
+			),
+			array( 'id' => $hunt_id ),
+			array( '%s', '%f', '%s', '%s' ),
+			array( '%d' )
+		);
 
-        // Fetch winners based on proximity to final balance.
-        $rows = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT user_id FROM {$guesses_tbl} WHERE hunt_id = %d ORDER BY ABS(guess - %f) ASC, id ASC LIMIT %d",
-                $hunt_id,
-                $final_balance,
-                $winners_count
-            )
-        );
+		// Fetch winners based on proximity to final balance.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT user_id FROM {$guesses_tbl} WHERE hunt_id = %d ORDER BY ABS(guess - %f) ASC, id ASC LIMIT %d",
+				$hunt_id,
+				$final_balance,
+				$winners_count
+			)
+		);
 
-        if ( empty( $rows ) ) {
-            return array();
-        }
+		if ( empty( $rows ) ) {
+			return array();
+		}
 
-        return array_map( 'intval', wp_list_pluck( $rows, 'user_id' ) );
-    }
+		return array_map( 'intval', wp_list_pluck( $rows, 'user_id' ) );
+	}
 }

--- a/includes/class-bhg-settings.php
+++ b/includes/class-bhg-settings.php
@@ -1,42 +1,42 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 class BHG_Settings {
-    public static function render(){
-        BHG_Utils::require_cap();
-        if ($_SERVER['REQUEST_METHOD'] === 'POST' && BHG_Utils::verify_nonce('bhg_save_settings')) {
-            $allow = isset($_POST['allow_guess_edit']) ? 1 : 0;
-            $ads   = isset($_POST['ads_enabled']) ? 1 : 0;
-            $email = sanitize_email($_POST['email_from'] ?? get_bloginfo('admin_email'));
-            BHG_Utils::update_settings([
-                'allow_guess_edit' => $allow,
-                'ads_enabled' => $ads,
-                'email_from' => $email,
-            ]);
-            echo '<div class="updated"><p>' . esc_html__('Settings saved.', 'bonus-hunt-guesser') . '</p></div>';
-        }
-        $s = BHG_Utils::get_settings();
-        ?>
-        <div class="wrap bhg-wrap">
-            <h1><?php echo esc_html__('Bonus Hunt - Settings', 'bonus-hunt-guesser'); ?></h1>
-            <form method="post">
-                <?php BHG_Utils::nonce_field('bhg_save_settings'); ?>
-                <table class="form-table">
-                    <tr>
-                        <th><?php esc_html_e('Allow Guess Editing', 'bonus-hunt-guesser'); ?></th>
-                        <td><label><input type="checkbox" name="allow_guess_edit" <?php checked($s['allow_guess_edit']); ?> /> <?php esc_html_e('Users can edit their guess while hunt is open.', 'bonus-hunt-guesser'); ?></label></td>
-                    </tr>
-                    <tr>
-                        <th><?php esc_html_e('Enable Ads', 'bonus-hunt-guesser'); ?></th>
-                        <td><label><input type="checkbox" name="ads_enabled" <?php checked($s['ads_enabled']); ?> /> <?php esc_html_e('Show ads block on selected pages.', 'bonus-hunt-guesser'); ?></label></td>
-                    </tr>
-                    <tr>
-                        <th><?php esc_html_e('Email From', 'bonus-hunt-guesser'); ?></th>
-                        <td><input type="email" name="email_from" value="<?php echo esc_attr($s['email_from']); ?>" class="regular-text" /></td>
-                    </tr>
-                </table>
-                <?php submit_button(); ?>
-            </form>
-        </div>
-        <?php
-    }
+	public static function render(){
+		BHG_Utils::require_cap();
+		if ($_SERVER['REQUEST_METHOD'] === 'POST' && BHG_Utils::verify_nonce('bhg_save_settings')) {
+			$allow = isset($_POST['allow_guess_edit']) ? 1 : 0;
+			$ads   = isset($_POST['ads_enabled']) ? 1 : 0;
+			$email = sanitize_email($_POST['email_from'] ?? get_bloginfo('admin_email'));
+			BHG_Utils::update_settings([
+				'allow_guess_edit' => $allow,
+				'ads_enabled' => $ads,
+				'email_from' => $email,
+			]);
+			echo '<div class="updated"><p>' . esc_html__('Settings saved.', 'bonus-hunt-guesser') . '</p></div>';
+		}
+		$s = BHG_Utils::get_settings();
+		?>
+		<div class="wrap bhg-wrap">
+			<h1><?php echo esc_html__('Bonus Hunt - Settings', 'bonus-hunt-guesser'); ?></h1>
+			<form method="post">
+				<?php BHG_Utils::nonce_field('bhg_save_settings'); ?>
+				<table class="form-table">
+					<tr>
+						<th><?php esc_html_e('Allow Guess Editing', 'bonus-hunt-guesser'); ?></th>
+						<td><label><input type="checkbox" name="allow_guess_edit" <?php checked($s['allow_guess_edit']); ?> /> <?php esc_html_e('Users can edit their guess while hunt is open.', 'bonus-hunt-guesser'); ?></label></td>
+					</tr>
+					<tr>
+						<th><?php esc_html_e('Enable Ads', 'bonus-hunt-guesser'); ?></th>
+						<td><label><input type="checkbox" name="ads_enabled" <?php checked($s['ads_enabled']); ?> /> <?php esc_html_e('Show ads block on selected pages.', 'bonus-hunt-guesser'); ?></label></td>
+					</tr>
+					<tr>
+						<th><?php esc_html_e('Email From', 'bonus-hunt-guesser'); ?></th>
+						<td><input type="email" name="email_from" value="<?php echo esc_attr($s['email_from']); ?>" class="regular-text" /></td>
+					</tr>
+				</table>
+				<?php submit_button(); ?>
+			</form>
+		</div>
+		<?php
+	}
 }

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -11,603 +11,603 @@ if (!class_exists('BHG_Shortcodes')) {
 
 class BHG_Shortcodes {
 
-    /**
-     * Register plugin shortcodes.
-     */
-    public function __construct() {
-        // Register shortcodes once.
-        add_shortcode( 'bhg_active_hunt', array( $this, 'active_hunt_shortcode' ) );
-        add_shortcode( 'bhg_guess_form', array( $this, 'guess_form_shortcode' ) );
-        add_shortcode( 'bhg_leaderboard', array( $this, 'leaderboard_shortcode' ) );
-        add_shortcode( 'bhg_tournaments', array( $this, 'tournaments_shortcode' ) );
-        add_shortcode( 'bhg_winner_notifications', array( $this, 'winner_notifications_shortcode' ) );
-        add_shortcode( 'bhg_user_profile', array( $this, 'user_profile_shortcode' ) );
-        add_shortcode( 'bhg_best_guessers', array( $this, 'best_guessers_shortcode' ) );
-
-        // Legacy/alias tags if your site used alternatives.
-        add_shortcode( 'bonus_hunt_leaderboard', array( $this, 'leaderboard_shortcode' ) );
-        add_shortcode( 'bonus_hunt_login', array( $this, 'login_hint_shortcode' ) );
-        add_shortcode( 'bhg_active', array( $this, 'active_hunt_shortcode' ) );
-    }
-
-    /** Minimal login hint used by some themes */
-    public function login_hint_shortcode($atts = array()) {
-        if ( is_user_logged_in() ) {
-            return '';
-        }
-
-        $base     = home_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
-        $redirect = add_query_arg( array(), $base );
-
-        return '<p>' . esc_html__( 'Please log in to continue.', 'bonus-hunt-guesser' ) . '</p>'
-             . '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
-    }
-
-    /** [bhg_active_hunt] — list all open hunts */
-    public function active_hunt_shortcode($atts) {
-        global $wpdb;
-        $hunts = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='open' ORDER BY created_at DESC" );
-        if (!$hunts) {
-            return '<div class="bhg-active-hunt"><p>' . esc_html__('No active bonus hunts at the moment.', 'bonus-hunt-guesser') . '</p></div>';
-        }
-
-        ob_start();
-        echo '<div class="bhg-active-hunts">';
-        foreach ($hunts as $hunt) {
-            echo '<div class="bhg-hunt-card" style="border:1px solid #e2e8f0;border-radius:8px;padding:12px;margin:12px 0;">';
-            echo '<h3 style="margin:0 0 8px;">' . esc_html($hunt->title) . '</h3>';
-            echo '<ul class="bhg-hunt-meta" style="list-style:none;margin:0;padding:0">';
-            echo '<li><strong>' . esc_html__('Starting Balance', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(number_format_i18n((float)$hunt->starting_balance, 2)) . '</li>';
-            echo '<li><strong>' . esc_html__('Number of Bonuses', 'bonus-hunt-guesser') . ':</strong> ' . (int)$hunt->num_bonuses . '</li>';
-            if (!empty($hunt->prizes)) {
-                echo '<li><strong>' . esc_html__('Prizes', 'bonus-hunt-guesser') . ':</strong> ' . wp_kses_post($hunt->prizes) . '</li>';
-            }
-            echo '</ul>';
-            echo '</div>';
-        }
-        echo '</div>';
-        return ob_get_clean();
-    }
-
-    /** [bhg_guess_form hunt_id=""] */
-    public function guess_form_shortcode($atts) {
-        $atts = shortcode_atts(array('hunt_id' => 0), $atts, 'bhg_guess_form');
-        $hunt_id = (int) $atts['hunt_id'];
-
-        if ( ! is_user_logged_in() ) {
-            $base     = home_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
-            $redirect = add_query_arg( array(), $base );
-
-            return '<p>' . esc_html__( 'Please log in to submit your guess.', 'bonus-hunt-guesser' ) . '</p>'
-                 . '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
-        }
-
-        global $wpdb;
-        $open_hunts = $wpdb->get_results( "SELECT id, title FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='open' ORDER BY created_at DESC" );
-
-        if ($hunt_id <= 0) {
-            if (!$open_hunts) {
-                return '<p>' . esc_html__('No open hunt found to guess.', 'bonus-hunt-guesser') . '</p>';
-            }
-            if (count($open_hunts) === 1) {
-                $hunt_id = (int)$open_hunts[0]->id;
-            }
-        }
-
-        $user_id = get_current_user_id();
-        $table = $wpdb->prefix . 'bhg_guesses';
-        $existing_id = $hunt_id > 0 ? (int)$wpdb->get_var($wpdb->prepare("SELECT id FROM {$table} WHERE user_id=%d AND hunt_id=%d", $user_id, $hunt_id)) : 0;
-        $existing_guess = $existing_id ? (float) $wpdb->get_var($wpdb->prepare("SELECT guess FROM {$table} WHERE id=%d", $existing_id)) : '';
-
-        $settings = get_option('bhg_plugin_settings');
-        $min = isset($settings['min_guess_amount']) ? (float)$settings['min_guess_amount'] : 0;
-        $max = isset($settings['max_guess_amount']) ? (float)$settings['max_guess_amount'] : 100000;
-
-        ob_start(); ?>
-        <form class="bhg-guess-form" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="border:1px solid #e2e8f0;border-radius:8px;padding:12px;">
-            <input type="hidden" name="action" value="bhg_submit_guess">
-            <?php wp_nonce_field('bhg_submit_guess', 'bhg_nonce'); ?>
-
-            <?php if ($open_hunts && count($open_hunts) > 1) : ?>
-                <label for="bhg-hunt-select"><?php esc_html_e('Choose a hunt:', 'bonus-hunt-guesser'); ?></label>
-                <select id="bhg-hunt-select" name="hunt_id" required>
-                    <option value=""><?php esc_html_e('Select a hunt', 'bonus-hunt-guesser'); ?></option>
-                    <?php foreach ($open_hunts as $oh) : ?>
-                        <option value="<?php echo (int)$oh->id; ?>" <?php if ($hunt_id === (int)$oh->id) echo 'selected'; ?>>
-                            <?php echo esc_html($oh->title); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            <?php else : ?>
-                <input type="hidden" name="hunt_id" value="<?php echo esc_attr($hunt_id); ?>">
-            <?php endif; ?>
-
-            <label for="bhg-guess" style="display:block;margin-top:10px;"><?php esc_html_e('Your guess (final balance):', 'bonus-hunt-guesser'); ?></label>
-            <input type="number" step="0.01" min="<?php echo esc_attr($min); ?>" max="<?php echo esc_attr($max); ?>"
-                   id="bhg-guess" name="guess" value="<?php echo esc_attr($existing_guess); ?>" required>
-            <div class="bhg-error-message" style="color:#dc2626;margin-top:10px;display:none;"></div>
-            <button type="submit" class="bhg-submit-btn button button-primary" style="margin-top:20px;">
-                <?php echo esc_html__('Submit Guess', 'bonus-hunt-guesser'); ?></button>
-        </form>
-        <?php
-        return ob_get_clean();
-    }
-
-    /** [bhg_leaderboard] */
-    public function leaderboard_shortcode($atts) {
-        $a = shortcode_atts(array(
-            'hunt_id' => 0,
-            'orderby' => 'guess',
-            'order'   => 'ASC',
-            'page'    => 1,
-            'per_page'=> 20,
-        ), $atts, 'bhg_leaderboard');
-
-        global $wpdb;
-        $hunt_id = (int)$a['hunt_id'];
-        if ($hunt_id <= 0) {
-            $hunt_id = (int)$wpdb->get_var( "SELECT id FROM {$wpdb->prefix}bhg_bonus_hunts ORDER BY created_at DESC LIMIT 1" );
-            if ($hunt_id <= 0) {
-                return '<p>' . esc_html__('No hunts found.', 'bonus-hunt-guesser') . '</p>';
-            }
-        }
-
-        $g = $wpdb->prefix . 'bhg_guesses';
-        $u = $wpdb->users;
-
-        $order = strtoupper($a['order']) === 'DESC' ? 'DESC' : 'ASC';
-        $map = array(
-            'guess'      => 'g.guess',
-            'user'       => 'u.user_login',
-            'position'   => 'g.id', // stable proxy
-        );
-        $orderby_key = array_key_exists($a['orderby'], $map) ? $a['orderby'] : 'guess';
-        $orderby = $map[$orderby_key];
-        $page    = max(1, (int)$a['page']);
-        $per     = max(1, (int)$a['per_page']);
-        $offset  = ($page - 1) * $per;
-
-        $total = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$g} WHERE hunt_id=%d", $hunt_id));
-        if ($total < 1) {
-            return '<p>' . esc_html__('No guesses yet.', 'bonus-hunt-guesser') . '</p>';
-        }
-
-        $rows = $wpdb->get_results($wpdb->prepare(
-            "SELECT g.*, u.user_login, h.affiliate_site_id
-             FROM {$g} g
-             LEFT JOIN {$u} u ON u.ID = g.user_id
-             LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id
-             WHERE g.hunt_id=%d
-             ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
-            $hunt_id, $per, $offset
-        ));
-
-        wp_enqueue_style(
-            'bhg-shortcodes',
-            BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-            array(),
-            defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-        );
-
-        ob_start();
-        echo '<table class="bhg-leaderboard">';
-        echo '<thead><tr>';
-        echo '<th class="sortable" data-column="position">' . esc_html__('Position', 'bonus-hunt-guesser') . '</th>';
-        echo '<th class="sortable" data-column="user">' . esc_html__('User', 'bonus-hunt-guesser') . '</th>';
-        echo '<th class="sortable" data-column="guess">' . esc_html__('Guess', 'bonus-hunt-guesser') . '</th>';
-        echo '</tr></thead><tbody>';
-
-        $pos = $offset + 1;
-        foreach ($rows as $r) {
-            $site_id = isset($r->affiliate_site_id) ? (int)$r->affiliate_site_id : 0;
-            $is_aff  = $site_id > 0
-                ? (int)get_user_meta((int)$r->user_id, 'bhg_affiliate_website_' . $site_id, true)
-                : (int)get_user_meta((int)$r->user_id, 'bhg_is_affiliate', true);
-            $aff = $is_aff ? 'green' : 'red';
-            $user_label = $r->user_login ? $r->user_login : ('user#' . (int)$r->user_id);
-
-            echo '<tr>';
-            echo '<td data-column="position">' . (int)$pos++ . '</td>';
-            echo '<td data-column="user">' . esc_html($user_label) . ' <span class="bhg-aff-dot bhg-aff-' . esc_attr($aff) . '" aria-hidden="true"></span></td>';
-            echo '<td data-column="guess">' . esc_html(number_format_i18n((float) $r->guess, 2)) . '</td>';
-            echo '</tr>';
-        }
-        echo '</tbody></table>';
-
-        $pages = (int) ceil( $total / $per );
-        if ( $pages > 1 ) {
-            $base = remove_query_arg( 'page', home_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
-            echo '<div class="bhg-pagination">';
-            for ( $p = 1; $p <= $pages; $p++ ) {
-                $is = $p == $page ? ' style="font-weight:bold;"' : '';
-                echo '<a' . $is . ' href="' . esc_url( add_query_arg( array( 'page' => $p ), $base ) ) . '">' . (int) $p . '</a> ';
-            }
-            echo '</div>';
-        }
-
-        return ob_get_clean();
-    }
-
-    /** [bhg_tournaments] list + details (via ?bhg_tournament_id=ID) */
-    public function tournaments_shortcode($atts) {
-        global $wpdb;
-
-        // If a specific tournament ID is requested, render details
-        $details_id = isset($_GET['bhg_tournament_id']) ? absint($_GET['bhg_tournament_id']) : 0;
-        if ($details_id > 0) {
-            $t = $wpdb->prefix . 'bhg_tournaments';
-            $r = $wpdb->prefix . 'bhg_tournament_results';
-            $u = $wpdb->users;
-
-            $tournament = $wpdb->get_row($wpdb->prepare(
-                "SELECT id, type, start_date, end_date, status FROM {$t} WHERE id=%d",
-                $details_id
-            ));
-            if (!$tournament) {
-                return '<p>' . esc_html__('Tournament not found.', 'bonus-hunt-guesser') . '</p>';
-            }
-
-            // Sortable results (whitelisted)
-            $orderby = isset($_GET['orderby']) ? strtolower(sanitize_key($_GET['orderby'])) : 'wins';
-            $order   = isset($_GET['order'])   ? strtolower(sanitize_key($_GET['order']))   : 'desc';
-
-            $allowed = array(
-                'wins'        => 'r.wins',
-                'username'    => 'u.user_login',
-                'last_win_at' => 'r.last_win_date',
-            );
-            if (!isset($allowed[$orderby])) { $orderby = 'wins'; }
-            if ($order !== 'asc' && $order !== 'desc') { $order = 'desc'; }
-            $order_by_sql = $allowed[$orderby] . ' ' . strtoupper($order);
-
-            $rows = $wpdb->get_results($wpdb->prepare(
-                "SELECT r.user_id, r.wins, r.last_win_date, u.user_login
-                 FROM {$r} r
-                 INNER JOIN {$u} u ON u.ID = r.user_id
-                 WHERE r.tournament_id=%d
-                 ORDER BY {$order_by_sql}, r.user_id ASC",
-                $tournament->id
-            ));
-
-            $base = remove_query_arg(array('orderby','order'));
-            $toggle = function($key) use ($orderby, $order, $base) {
-                $next = ($orderby === $key && strtolower($order) === 'asc') ? 'desc' : 'asc';
-                return esc_url(add_query_arg(array('orderby'=>$key,'order'=>$next), $base));
-            };
-
-            ob_start();
-            echo '<div class="bhg-tournament-details" style="border:1px solid #e2e8f0;border-radius:8px;padding:12px;">';
-            echo '<p><a href="' . esc_url(remove_query_arg('bhg_tournament_id')) . '">&larr; ' . esc_html__('Back to tournaments', 'bonus-hunt-guesser') . '</a></p>';
-            echo '<h3 style="margin-top:0;">' . esc_html(ucfirst($tournament->type)) . '</h3>';
-            echo '<p><strong>' . esc_html__('Start', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(mysql2date(get_option('date_format'), $tournament->start_date)) . ' &nbsp; ';
-            echo '<strong>' . esc_html__('End', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(mysql2date(get_option('date_format'), $tournament->end_date)) . ' &nbsp; ';
-            echo '<strong>' . esc_html__('Status', 'bonus-hunt-guesser') . ':</strong> ' . esc_html($tournament->status) . '</p>';
-
-            if (!$rows) {
-                echo '<p>' . esc_html__('No results yet.', 'bonus-hunt-guesser') . '</p>';
-                echo '</div>';
-                return ob_get_clean();
-            }
-
-            echo '<table class="bhg-leaderboard" style="width:100%;border-collapse:collapse">';
-            echo '<thead><tr>';
-            echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">#</th>';
-            echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;"><a href="' . $toggle('username') . '">' . esc_html__('Username', 'bonus-hunt-guesser') . '</a></th>';
-            echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;"><a href="' . $toggle('wins') . '">' . esc_html__('Wins', 'bonus-hunt-guesser') . '</a></th>';
-            echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;"><a href="' . $toggle('last_win_at') . '">' . esc_html__('Last win', 'bonus-hunt-guesser') . '</a></th>';
-            echo '</tr></thead><tbody>';
-
-            $pos = 1;
-            foreach ($rows as $row) {
-                echo '<tr>';
-                echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . (int)$pos++ . '</td>';
-                echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html($row->user_login ?: ('user#' . (int)$row->user_id)) . '</td>';
-                echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . (int)$row->wins . '</td>';
-                echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html($row->last_win_date ? mysql2date(get_option('date_format'), $row->last_win_date) : '—') . '</td>';
-                echo '</tr>';
-            }
-            echo '</tbody></table>';
-            echo '</div>';
-
-            return ob_get_clean();
-        }
-
-        // Otherwise list tournaments with filters
-        $a = shortcode_atts(array('period' => 'all', 'status' => 'active'), $atts, 'bhg_tournaments');
-        $t = $wpdb->prefix . 'bhg_tournaments';
-        $where = array();
-        $args  = array();
-
-        if (in_array($a['period'], array('weekly','monthly','yearly'), true)) {
-            $where[] = "type=%s";
-            $args[]  = $a['period'];
-        }
-        if (in_array($a['status'], array('active','closed'), true)) {
-            $where[] = "status=%s";
-            $args[]  = $a['status'];
-        }
-
-        $sql = "SELECT * FROM {$t}";
-        if ($where) {
-            $sql .= " WHERE " . implode(" AND ", $where);
-        }
-        $sql .= " ORDER BY start_date DESC, id DESC";
-
-        $rows = $args ? $wpdb->get_results( $wpdb->prepare( $sql, ...$args ) ) : $wpdb->get_results( $sql );
-        if (!$rows) {
-            return '<p>' . esc_html__('No tournaments found.', 'bonus-hunt-guesser') . '</p>';
-        }
-
-        $current_url = (isset($_SERVER['REQUEST_URI']) ? esc_url_raw(wp_unslash($_SERVER['REQUEST_URI'])) : home_url('/'));
-
-        ob_start();
-        echo '<form method="get" class="bhg-tournament-filters" style="margin-bottom:10px;">';
-        foreach ( $_GET as $raw_key => $v ) {
-            $key = sanitize_key( $raw_key );
-            if ( $key === 'bhg_period' || $key === 'bhg_status' || $key === 'bhg_tournament_id' ) {
-                continue;
-            }
-            echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( is_array( $v ) ? reset( $v ) : $v ) . '">';
-        }
-        echo '<label style="margin-right:8px;">' . esc_html__('Period:', 'bonus-hunt-guesser') . ' ';
-        echo '<select name="bhg_period">';
-        $periods = array('all'=>__('All','bonus-hunt-guesser'),'weekly'=>__('Weekly','bonus-hunt-guesser'),'monthly'=>__('Monthly','bonus-hunt-guesser'),'yearly'=>__('Yearly','bonus-hunt-guesser'));
-        $period_key = isset($_GET['bhg_period']) ? sanitize_key($_GET['bhg_period']) : $a['period'];
-        foreach ($periods as $key=>$label) {
-            echo '<option value="' . esc_attr($key) . '"' . selected($period_key, $key, false) . '>' . esc_html($label) . '</option>';
-        }
-        echo '</select></label>';
-
-        echo '<label>' . esc_html__('Status:', 'bonus-hunt-guesser') . ' ';
-        echo '<select name="bhg_status">';
-        $statuses = array('active'=>__('Active','bonus-hunt-guesser'),'closed'=>__('Closed','bonus-hunt-guesser'),'all'=>__('All','bonus-hunt-guesser'));
-        $status_key = isset($_GET['bhg_status']) ? sanitize_key($_GET['bhg_status']) : $a['status'];
-        foreach ($statuses as $key=>$label) {
-            echo '<option value="' . esc_attr($key) . '"' . selected($status_key, $key, false) . '>' . esc_html($label) . '</option>';
-        }
-        echo '</select></label> ';
-
-        echo '<button class="button" type="submit" style="margin-left:8px;">'.esc_html__('Filter','bonus-hunt-guesser').'</button>';
-        echo '</form>';
-
-        echo '<table class="bhg-tournaments" style="width:100%;border-collapse:collapse">';
-        echo '<thead><tr>';
-        echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">' . esc_html__('Type', 'bonus-hunt-guesser') . '</th>';
-        echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">' . esc_html__('Start', 'bonus-hunt-guesser') . '</th>';
-        echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">' . esc_html__('End', 'bonus-hunt-guesser') . '</th>';
-        echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">' . esc_html__('Status', 'bonus-hunt-guesser') . '</th>';
-        echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">' . esc_html__('Details', 'bonus-hunt-guesser') . '</th>';
-        echo '</tr></thead><tbody>';
-
-        foreach ($rows as $row) {
-            $detail_url = esc_url(add_query_arg('bhg_tournament_id', (int)$row->id, remove_query_arg(array('orderby','order'), $current_url)));
-            echo '<tr>';
-            echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html(ucfirst($row->type)) . '</td>';
-            echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html(mysql2date(get_option('date_format'), $row->start_date)) . '</td>';
-            echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html(mysql2date(get_option('date_format'), $row->end_date)) . '</td>';
-            echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html($row->status) . '</td>';
-            echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;"><a href="' . $detail_url . '">' . esc_html__('Show details','bonus-hunt-guesser') . '</a></td>';
-            echo '</tr>';
-        }
-
-        echo '</tbody></table>';
-        return ob_get_clean();
-    }
-
-    /** Minimal winners widget: latest closed hunts */
-    public function winner_notifications_shortcode($atts) {
-        global $wpdb;
-
-        $a = shortcode_atts(
-            array('limit' => 5),
-            $atts,
-            'bhg_winner_notifications'
-        );
-
-        $hunts = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT id, title, final_balance, winners_count, closed_at FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='closed' ORDER BY closed_at DESC LIMIT %d",
-                (int) $a['limit']
-            )
-        );
-
-        if ( ! $hunts ) {
-            return '<p>' . esc_html__( 'No closed hunts yet.', 'bonus-hunt-guesser' ) . '</p>';
-        }
-
-        ob_start();
-        echo '<div class="bhg-winner-notifications">';
-        foreach ( $hunts as $hunt ) {
-            $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
-                ? bhg_get_top_winners_for_hunt( $hunt->id, (int) $hunt->winners_count )
-                : array();
-
-            echo '<div class="bhg-winner" style="margin-bottom:15px;">';
-            echo '<p><strong>' . esc_html( $hunt->title ) . '</strong></p>';
-            if ( $hunt->final_balance !== null ) {
-                echo '<p><em>' . esc_html__( 'Final', 'bonus-hunt-guesser' ) . ':</em> ' . esc_html( number_format_i18n( (float) $hunt->final_balance, 2 ) ) . '</p>';
-            }
-
-            if ( $winners ) {
-                echo '<ul class="bhg-winner-list">';
-                foreach ( $winners as $w ) {
-                    $u  = get_userdata( (int) $w->user_id );
-                    $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-                    echo '<li>' . esc_html( $nm ) . ' — ' . esc_html( number_format_i18n( (float) $w->guess, 2 ) ) . ' (' . esc_html( number_format_i18n( (float) $w->diff, 2 ) ) . ')</li>';
-                }
-                echo '</ul>';
-            }
-
-            echo '</div>';
-        }
-        echo '</div>';
-        return ob_get_clean();
-    }
-
-    /** Minimal profile view: affiliate status badge */
-    public function user_profile_shortcode($atts) {
-        if (!is_user_logged_in()) return '<p>' . esc_html__('Please log in to view this content.', 'bonus-hunt-guesser') . '</p>';
-        wp_enqueue_style(
-            'bhg-shortcodes',
-            BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-            array(),
-            defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-        );
-        $user_id = get_current_user_id();
-        $is_affiliate = (int)get_user_meta($user_id, 'bhg_is_affiliate', true);
-        $badge = $is_affiliate ? '<span class="bhg-aff-green" aria-hidden="true"></span>' : '<span class="bhg-aff-red" aria-hidden="true"></span>';
-        return '<div class="bhg-user-profile">' . $badge . ' ' . esc_html(wp_get_current_user()->display_name) . '</div>';
-    }
-
-    /** [bhg_best_guessers] — simple wins leaderboard */
-    public function best_guessers_shortcode($atts) {
-        global $wpdb;
-
-        $wins_tbl = $wpdb->prefix . 'bhg_tournament_results';
-        $tours_tbl = $wpdb->prefix . 'bhg_tournaments';
-        $users_tbl = $wpdb->users;
-
-        $now_ts = current_time('timestamp');
-        $current_month = wp_date('Y-m', $now_ts);
-        $current_year  = wp_date('Y', $now_ts);
-
-        $periods = array(
-            'overall' => array(
-                'label' => esc_html__('Overall', 'bonus-hunt-guesser'),
-                'type'  => '',
-                'start' => '',
-                'end'   => '',
-            ),
-            'monthly' => array(
-                'label' => esc_html__('Monthly', 'bonus-hunt-guesser'),
-                'type'  => 'monthly',
-                'start' => $current_month . '-01',
-                'end'   => wp_date('Y-m-t', strtotime($current_month . '-01', $now_ts)),
-            ),
-            'yearly' => array(
-                'label' => esc_html__('Yearly', 'bonus-hunt-guesser'),
-                'type'  => 'yearly',
-                'start' => $current_year . '-01-01',
-                'end'   => $current_year . '-12-31',
-            ),
-            'alltime' => array(
-                'label' => esc_html__('All-Time', 'bonus-hunt-guesser'),
-                'type'  => 'alltime',
-                'start' => '',
-                'end'   => '',
-            ),
-        );
-
-        $results = array();
-        foreach ($periods as $key => $info) {
-            if ($info['type']) {
-                $where = 't.type = %s';
-                $params = array($info['type']);
-                if (!empty($info['start']) && !empty($info['end'])) {
-                    $where .= ' AND t.start_date >= %s AND t.end_date <= %s';
-                    $params[] = $info['start'];
-                    $params[] = $info['end'];
-                }
-                $sql = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
-                        FROM {$wins_tbl} r
-                        INNER JOIN {$users_tbl} u ON u.ID = r.user_id
-                        INNER JOIN {$tours_tbl} t ON t.id = r.tournament_id
-                        WHERE {$where}
-                        GROUP BY u.ID, u.user_login
-                        ORDER BY total_wins DESC, u.user_login ASC
-                        LIMIT 50";
-                array_unshift($params, $sql);
-                $prepared = call_user_func_array(array($wpdb, 'prepare'), $params);
-                $results[$key] = $wpdb->get_results($prepared);
-            } else {
-                $sql = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
-                        FROM {$wins_tbl} r
-                        INNER JOIN {$users_tbl} u ON u.ID = r.user_id
-                        GROUP BY u.ID, u.user_login
-                        ORDER BY total_wins DESC, u.user_login ASC
-                        LIMIT 50";
-                $results[$key] = $wpdb->get_results( $sql );
-            }
-        }
-
-        $hunts_tbl = $wpdb->prefix . 'bhg_bonus_hunts';
-        $hunts = $wpdb->get_results( "SELECT id, title FROM {$hunts_tbl} WHERE status='closed' ORDER BY created_at DESC LIMIT 50" );
-
-        wp_enqueue_style(
-            'bhg-shortcodes',
-            BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-            array(),
-            defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-        );
-        wp_enqueue_script(
-            'bhg-shortcodes-js',
-            BHG_PLUGIN_URL . 'assets/js/bhg-shortcodes.js',
-            array(),
-            defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
-            true
-        );
-
-        ob_start();
-        echo '<ul class="bhg-tabs">';
-        $first = true;
-        foreach ($periods as $key => $info) {
-            $active = $first ? ' class="active"' : '';
-            echo '<li' . $active . '><a href="#bhg-tab-' . esc_attr($key) . '">' . esc_html($info['label']) . '</a></li>';
-            $first = false;
-        }
-        if ($hunts) {
-            echo '<li><a href="#bhg-tab-hunts">' . esc_html__('Bonus Hunts', 'bonus-hunt-guesser') . '</a></li>';
-        }
-        echo '</ul>';
-
-        $first = true;
-        foreach ($periods as $key => $info) {
-            $active = $first ? ' active' : '';
-            echo '<div id="bhg-tab-' . esc_attr($key) . '" class="bhg-tab-pane' . $active . '">';
-            $rows = isset($results[$key]) ? $results[$key] : array();
-            if (!$rows) {
-                echo '<p>' . esc_html__('No data yet.', 'bonus-hunt-guesser') . '</p>';
-            } else {
-                echo '<table class="bhg-leaderboard"><thead><tr><th>#</th><th>' . esc_html__('User', 'bonus-hunt-guesser') . '</th><th>' . esc_html__('Wins', 'bonus-hunt-guesser') . '</th></tr></thead><tbody>';
-                $pos = 1;
-                foreach ($rows as $r) {
-                    $user_label = $r->user_login ? $r->user_login : 'user#' . (int) $r->user_id;
-                    echo '<tr><td>' . (int) $pos++ . '</td><td>' . esc_html($user_label) . '</td><td>' . (int) $r->total_wins . '</td></tr>';
-                }
-                echo '</tbody></table>';
-            }
-            echo '</div>';
-            $first = false;
-        }
-
-        if ( $hunts ) {
-            $base = remove_query_arg( 'hunt_id', home_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
-            echo '<div id="bhg-tab-hunts" class="bhg-tab-pane">';
-            echo '<ul class="bhg-hunt-history">';
-            foreach ( $hunts as $hunt ) {
-                $url = esc_url( add_query_arg( 'hunt_id', (int) $hunt->id, $base ) );
-                echo '<li><a href="' . $url . '">' . esc_html( $hunt->title ) . '</a></li>';
-            }
-            echo '</ul>';
-            echo '</div>';
-        }
-
-        return ob_get_clean();
-    }
+	/**
+	 * Register plugin shortcodes.
+	 */
+	public function __construct() {
+		// Register shortcodes once.
+		add_shortcode( 'bhg_active_hunt', array( $this, 'active_hunt_shortcode' ) );
+		add_shortcode( 'bhg_guess_form', array( $this, 'guess_form_shortcode' ) );
+		add_shortcode( 'bhg_leaderboard', array( $this, 'leaderboard_shortcode' ) );
+		add_shortcode( 'bhg_tournaments', array( $this, 'tournaments_shortcode' ) );
+		add_shortcode( 'bhg_winner_notifications', array( $this, 'winner_notifications_shortcode' ) );
+		add_shortcode( 'bhg_user_profile', array( $this, 'user_profile_shortcode' ) );
+		add_shortcode( 'bhg_best_guessers', array( $this, 'best_guessers_shortcode' ) );
+
+		// Legacy/alias tags if your site used alternatives.
+		add_shortcode( 'bonus_hunt_leaderboard', array( $this, 'leaderboard_shortcode' ) );
+		add_shortcode( 'bonus_hunt_login', array( $this, 'login_hint_shortcode' ) );
+		add_shortcode( 'bhg_active', array( $this, 'active_hunt_shortcode' ) );
+	}
+
+	/** Minimal login hint used by some themes */
+	public function login_hint_shortcode($atts = array()) {
+		if ( is_user_logged_in() ) {
+			return '';
+		}
+
+		$base     = home_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
+		$redirect = add_query_arg( array(), $base );
+
+		return '<p>' . esc_html__( 'Please log in to continue.', 'bonus-hunt-guesser' ) . '</p>'
+			 . '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
+	}
+
+	/** [bhg_active_hunt] — list all open hunts */
+	public function active_hunt_shortcode($atts) {
+		global $wpdb;
+		$hunts = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='open' ORDER BY created_at DESC" );
+		if (!$hunts) {
+			return '<div class="bhg-active-hunt"><p>' . esc_html__('No active bonus hunts at the moment.', 'bonus-hunt-guesser') . '</p></div>';
+		}
+
+		ob_start();
+		echo '<div class="bhg-active-hunts">';
+		foreach ($hunts as $hunt) {
+			echo '<div class="bhg-hunt-card" style="border:1px solid #e2e8f0;border-radius:8px;padding:12px;margin:12px 0;">';
+			echo '<h3 style="margin:0 0 8px;">' . esc_html($hunt->title) . '</h3>';
+			echo '<ul class="bhg-hunt-meta" style="list-style:none;margin:0;padding:0">';
+			echo '<li><strong>' . esc_html__('Starting Balance', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(number_format_i18n((float)$hunt->starting_balance, 2)) . '</li>';
+			echo '<li><strong>' . esc_html__('Number of Bonuses', 'bonus-hunt-guesser') . ':</strong> ' . (int)$hunt->num_bonuses . '</li>';
+			if (!empty($hunt->prizes)) {
+				echo '<li><strong>' . esc_html__('Prizes', 'bonus-hunt-guesser') . ':</strong> ' . wp_kses_post($hunt->prizes) . '</li>';
+			}
+			echo '</ul>';
+			echo '</div>';
+		}
+		echo '</div>';
+		return ob_get_clean();
+	}
+
+	/** [bhg_guess_form hunt_id=""] */
+	public function guess_form_shortcode($atts) {
+		$atts = shortcode_atts(array('hunt_id' => 0), $atts, 'bhg_guess_form');
+		$hunt_id = (int) $atts['hunt_id'];
+
+		if ( ! is_user_logged_in() ) {
+			$base     = home_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
+			$redirect = add_query_arg( array(), $base );
+
+			return '<p>' . esc_html__( 'Please log in to submit your guess.', 'bonus-hunt-guesser' ) . '</p>'
+				 . '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
+		}
+
+		global $wpdb;
+		$open_hunts = $wpdb->get_results( "SELECT id, title FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='open' ORDER BY created_at DESC" );
+
+		if ($hunt_id <= 0) {
+			if (!$open_hunts) {
+				return '<p>' . esc_html__('No open hunt found to guess.', 'bonus-hunt-guesser') . '</p>';
+			}
+			if (count($open_hunts) === 1) {
+				$hunt_id = (int)$open_hunts[0]->id;
+			}
+		}
+
+		$user_id = get_current_user_id();
+		$table = $wpdb->prefix . 'bhg_guesses';
+		$existing_id = $hunt_id > 0 ? (int)$wpdb->get_var($wpdb->prepare("SELECT id FROM {$table} WHERE user_id=%d AND hunt_id=%d", $user_id, $hunt_id)) : 0;
+		$existing_guess = $existing_id ? (float) $wpdb->get_var($wpdb->prepare("SELECT guess FROM {$table} WHERE id=%d", $existing_id)) : '';
+
+		$settings = get_option('bhg_plugin_settings');
+		$min = isset($settings['min_guess_amount']) ? (float)$settings['min_guess_amount'] : 0;
+		$max = isset($settings['max_guess_amount']) ? (float)$settings['max_guess_amount'] : 100000;
+
+		ob_start(); ?>
+		<form class="bhg-guess-form" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="border:1px solid #e2e8f0;border-radius:8px;padding:12px;">
+			<input type="hidden" name="action" value="bhg_submit_guess">
+			<?php wp_nonce_field('bhg_submit_guess', 'bhg_nonce'); ?>
+
+			<?php if ($open_hunts && count($open_hunts) > 1) : ?>
+				<label for="bhg-hunt-select"><?php esc_html_e('Choose a hunt:', 'bonus-hunt-guesser'); ?></label>
+				<select id="bhg-hunt-select" name="hunt_id" required>
+					<option value=""><?php esc_html_e('Select a hunt', 'bonus-hunt-guesser'); ?></option>
+					<?php foreach ($open_hunts as $oh) : ?>
+						<option value="<?php echo (int)$oh->id; ?>" <?php if ($hunt_id === (int)$oh->id) echo 'selected'; ?>>
+							<?php echo esc_html($oh->title); ?>
+						</option>
+					<?php endforeach; ?>
+				</select>
+			<?php else : ?>
+				<input type="hidden" name="hunt_id" value="<?php echo esc_attr($hunt_id); ?>">
+			<?php endif; ?>
+
+			<label for="bhg-guess" style="display:block;margin-top:10px;"><?php esc_html_e('Your guess (final balance):', 'bonus-hunt-guesser'); ?></label>
+			<input type="number" step="0.01" min="<?php echo esc_attr($min); ?>" max="<?php echo esc_attr($max); ?>"
+				   id="bhg-guess" name="guess" value="<?php echo esc_attr($existing_guess); ?>" required>
+			<div class="bhg-error-message" style="color:#dc2626;margin-top:10px;display:none;"></div>
+			<button type="submit" class="bhg-submit-btn button button-primary" style="margin-top:20px;">
+				<?php echo esc_html__('Submit Guess', 'bonus-hunt-guesser'); ?></button>
+		</form>
+		<?php
+		return ob_get_clean();
+	}
+
+	/** [bhg_leaderboard] */
+	public function leaderboard_shortcode($atts) {
+		$a = shortcode_atts(array(
+			'hunt_id' => 0,
+			'orderby' => 'guess',
+			'order'   => 'ASC',
+			'page'    => 1,
+			'per_page'=> 20,
+		), $atts, 'bhg_leaderboard');
+
+		global $wpdb;
+		$hunt_id = (int)$a['hunt_id'];
+		if ($hunt_id <= 0) {
+			$hunt_id = (int)$wpdb->get_var( "SELECT id FROM {$wpdb->prefix}bhg_bonus_hunts ORDER BY created_at DESC LIMIT 1" );
+			if ($hunt_id <= 0) {
+				return '<p>' . esc_html__('No hunts found.', 'bonus-hunt-guesser') . '</p>';
+			}
+		}
+
+		$g = $wpdb->prefix . 'bhg_guesses';
+		$u = $wpdb->users;
+
+		$order = strtoupper($a['order']) === 'DESC' ? 'DESC' : 'ASC';
+		$map = array(
+			'guess'      => 'g.guess',
+			'user'       => 'u.user_login',
+			'position'   => 'g.id', // stable proxy
+		);
+		$orderby_key = array_key_exists($a['orderby'], $map) ? $a['orderby'] : 'guess';
+		$orderby = $map[$orderby_key];
+		$page    = max(1, (int)$a['page']);
+		$per     = max(1, (int)$a['per_page']);
+		$offset  = ($page - 1) * $per;
+
+		$total = (int)$wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$g} WHERE hunt_id=%d", $hunt_id));
+		if ($total < 1) {
+			return '<p>' . esc_html__('No guesses yet.', 'bonus-hunt-guesser') . '</p>';
+		}
+
+		$rows = $wpdb->get_results($wpdb->prepare(
+			"SELECT g.*, u.user_login, h.affiliate_site_id
+			 FROM {$g} g
+			 LEFT JOIN {$u} u ON u.ID = g.user_id
+			 LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id
+			 WHERE g.hunt_id=%d
+			 ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
+			$hunt_id, $per, $offset
+		));
+
+		wp_enqueue_style(
+			'bhg-shortcodes',
+			BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+			array(),
+			defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+		);
+
+		ob_start();
+		echo '<table class="bhg-leaderboard">';
+		echo '<thead><tr>';
+		echo '<th class="sortable" data-column="position">' . esc_html__('Position', 'bonus-hunt-guesser') . '</th>';
+		echo '<th class="sortable" data-column="user">' . esc_html__('User', 'bonus-hunt-guesser') . '</th>';
+		echo '<th class="sortable" data-column="guess">' . esc_html__('Guess', 'bonus-hunt-guesser') . '</th>';
+		echo '</tr></thead><tbody>';
+
+		$pos = $offset + 1;
+		foreach ($rows as $r) {
+			$site_id = isset($r->affiliate_site_id) ? (int)$r->affiliate_site_id : 0;
+			$is_aff  = $site_id > 0
+				? (int)get_user_meta((int)$r->user_id, 'bhg_affiliate_website_' . $site_id, true)
+				: (int)get_user_meta((int)$r->user_id, 'bhg_is_affiliate', true);
+			$aff = $is_aff ? 'green' : 'red';
+			$user_label = $r->user_login ? $r->user_login : ('user#' . (int)$r->user_id);
+
+			echo '<tr>';
+			echo '<td data-column="position">' . (int)$pos++ . '</td>';
+			echo '<td data-column="user">' . esc_html($user_label) . ' <span class="bhg-aff-dot bhg-aff-' . esc_attr($aff) . '" aria-hidden="true"></span></td>';
+			echo '<td data-column="guess">' . esc_html(number_format_i18n((float) $r->guess, 2)) . '</td>';
+			echo '</tr>';
+		}
+		echo '</tbody></table>';
+
+		$pages = (int) ceil( $total / $per );
+		if ( $pages > 1 ) {
+			$base = remove_query_arg( 'page', home_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
+			echo '<div class="bhg-pagination">';
+			for ( $p = 1; $p <= $pages; $p++ ) {
+				$is = $p == $page ? ' style="font-weight:bold;"' : '';
+				echo '<a' . $is . ' href="' . esc_url( add_query_arg( array( 'page' => $p ), $base ) ) . '">' . (int) $p . '</a> ';
+			}
+			echo '</div>';
+		}
+
+		return ob_get_clean();
+	}
+
+	/** [bhg_tournaments] list + details (via ?bhg_tournament_id=ID) */
+	public function tournaments_shortcode($atts) {
+		global $wpdb;
+
+		// If a specific tournament ID is requested, render details
+		$details_id = isset($_GET['bhg_tournament_id']) ? absint($_GET['bhg_tournament_id']) : 0;
+		if ($details_id > 0) {
+			$t = $wpdb->prefix . 'bhg_tournaments';
+			$r = $wpdb->prefix . 'bhg_tournament_results';
+			$u = $wpdb->users;
+
+			$tournament = $wpdb->get_row($wpdb->prepare(
+				"SELECT id, type, start_date, end_date, status FROM {$t} WHERE id=%d",
+				$details_id
+			));
+			if (!$tournament) {
+				return '<p>' . esc_html__('Tournament not found.', 'bonus-hunt-guesser') . '</p>';
+			}
+
+			// Sortable results (whitelisted)
+			$orderby = isset($_GET['orderby']) ? strtolower(sanitize_key($_GET['orderby'])) : 'wins';
+			$order   = isset($_GET['order'])   ? strtolower(sanitize_key($_GET['order']))   : 'desc';
+
+			$allowed = array(
+				'wins'        => 'r.wins',
+				'username'    => 'u.user_login',
+				'last_win_at' => 'r.last_win_date',
+			);
+			if (!isset($allowed[$orderby])) { $orderby = 'wins'; }
+			if ($order !== 'asc' && $order !== 'desc') { $order = 'desc'; }
+			$order_by_sql = $allowed[$orderby] . ' ' . strtoupper($order);
+
+			$rows = $wpdb->get_results($wpdb->prepare(
+				"SELECT r.user_id, r.wins, r.last_win_date, u.user_login
+				 FROM {$r} r
+				 INNER JOIN {$u} u ON u.ID = r.user_id
+				 WHERE r.tournament_id=%d
+				 ORDER BY {$order_by_sql}, r.user_id ASC",
+				$tournament->id
+			));
+
+			$base = remove_query_arg(array('orderby','order'));
+			$toggle = function($key) use ($orderby, $order, $base) {
+				$next = ($orderby === $key && strtolower($order) === 'asc') ? 'desc' : 'asc';
+				return esc_url(add_query_arg(array('orderby'=>$key,'order'=>$next), $base));
+			};
+
+			ob_start();
+			echo '<div class="bhg-tournament-details" style="border:1px solid #e2e8f0;border-radius:8px;padding:12px;">';
+			echo '<p><a href="' . esc_url(remove_query_arg('bhg_tournament_id')) . '">&larr; ' . esc_html__('Back to tournaments', 'bonus-hunt-guesser') . '</a></p>';
+			echo '<h3 style="margin-top:0;">' . esc_html(ucfirst($tournament->type)) . '</h3>';
+			echo '<p><strong>' . esc_html__('Start', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(mysql2date(get_option('date_format'), $tournament->start_date)) . ' &nbsp; ';
+			echo '<strong>' . esc_html__('End', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(mysql2date(get_option('date_format'), $tournament->end_date)) . ' &nbsp; ';
+			echo '<strong>' . esc_html__('Status', 'bonus-hunt-guesser') . ':</strong> ' . esc_html($tournament->status) . '</p>';
+
+			if (!$rows) {
+				echo '<p>' . esc_html__('No results yet.', 'bonus-hunt-guesser') . '</p>';
+				echo '</div>';
+				return ob_get_clean();
+			}
+
+			echo '<table class="bhg-leaderboard" style="width:100%;border-collapse:collapse">';
+			echo '<thead><tr>';
+			echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">#</th>';
+			echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;"><a href="' . $toggle('username') . '">' . esc_html__('Username', 'bonus-hunt-guesser') . '</a></th>';
+			echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;"><a href="' . $toggle('wins') . '">' . esc_html__('Wins', 'bonus-hunt-guesser') . '</a></th>';
+			echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;"><a href="' . $toggle('last_win_at') . '">' . esc_html__('Last win', 'bonus-hunt-guesser') . '</a></th>';
+			echo '</tr></thead><tbody>';
+
+			$pos = 1;
+			foreach ($rows as $row) {
+				echo '<tr>';
+				echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . (int)$pos++ . '</td>';
+				echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html($row->user_login ?: ('user#' . (int)$row->user_id)) . '</td>';
+				echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . (int)$row->wins . '</td>';
+				echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html($row->last_win_date ? mysql2date(get_option('date_format'), $row->last_win_date) : '—') . '</td>';
+				echo '</tr>';
+			}
+			echo '</tbody></table>';
+			echo '</div>';
+
+			return ob_get_clean();
+		}
+
+		// Otherwise list tournaments with filters
+		$a = shortcode_atts(array('period' => 'all', 'status' => 'active'), $atts, 'bhg_tournaments');
+		$t = $wpdb->prefix . 'bhg_tournaments';
+		$where = array();
+		$args  = array();
+
+		if (in_array($a['period'], array('weekly','monthly','yearly'), true)) {
+			$where[] = "type=%s";
+			$args[]  = $a['period'];
+		}
+		if (in_array($a['status'], array('active','closed'), true)) {
+			$where[] = "status=%s";
+			$args[]  = $a['status'];
+		}
+
+		$sql = "SELECT * FROM {$t}";
+		if ($where) {
+			$sql .= " WHERE " . implode(" AND ", $where);
+		}
+		$sql .= " ORDER BY start_date DESC, id DESC";
+
+		$rows = $args ? $wpdb->get_results( $wpdb->prepare( $sql, ...$args ) ) : $wpdb->get_results( $sql );
+		if (!$rows) {
+			return '<p>' . esc_html__('No tournaments found.', 'bonus-hunt-guesser') . '</p>';
+		}
+
+		$current_url = (isset($_SERVER['REQUEST_URI']) ? esc_url_raw(wp_unslash($_SERVER['REQUEST_URI'])) : home_url('/'));
+
+		ob_start();
+		echo '<form method="get" class="bhg-tournament-filters" style="margin-bottom:10px;">';
+		foreach ( $_GET as $raw_key => $v ) {
+			$key = sanitize_key( $raw_key );
+			if ( $key === 'bhg_period' || $key === 'bhg_status' || $key === 'bhg_tournament_id' ) {
+				continue;
+			}
+			echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( is_array( $v ) ? reset( $v ) : $v ) . '">';
+		}
+		echo '<label style="margin-right:8px;">' . esc_html__('Period:', 'bonus-hunt-guesser') . ' ';
+		echo '<select name="bhg_period">';
+		$periods = array('all'=>__('All','bonus-hunt-guesser'),'weekly'=>__('Weekly','bonus-hunt-guesser'),'monthly'=>__('Monthly','bonus-hunt-guesser'),'yearly'=>__('Yearly','bonus-hunt-guesser'));
+		$period_key = isset($_GET['bhg_period']) ? sanitize_key($_GET['bhg_period']) : $a['period'];
+		foreach ($periods as $key=>$label) {
+			echo '<option value="' . esc_attr($key) . '"' . selected($period_key, $key, false) . '>' . esc_html($label) . '</option>';
+		}
+		echo '</select></label>';
+
+		echo '<label>' . esc_html__('Status:', 'bonus-hunt-guesser') . ' ';
+		echo '<select name="bhg_status">';
+		$statuses = array('active'=>__('Active','bonus-hunt-guesser'),'closed'=>__('Closed','bonus-hunt-guesser'),'all'=>__('All','bonus-hunt-guesser'));
+		$status_key = isset($_GET['bhg_status']) ? sanitize_key($_GET['bhg_status']) : $a['status'];
+		foreach ($statuses as $key=>$label) {
+			echo '<option value="' . esc_attr($key) . '"' . selected($status_key, $key, false) . '>' . esc_html($label) . '</option>';
+		}
+		echo '</select></label> ';
+
+		echo '<button class="button" type="submit" style="margin-left:8px;">'.esc_html__('Filter','bonus-hunt-guesser').'</button>';
+		echo '</form>';
+
+		echo '<table class="bhg-tournaments" style="width:100%;border-collapse:collapse">';
+		echo '<thead><tr>';
+		echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">' . esc_html__('Type', 'bonus-hunt-guesser') . '</th>';
+		echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">' . esc_html__('Start', 'bonus-hunt-guesser') . '</th>';
+		echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">' . esc_html__('End', 'bonus-hunt-guesser') . '</th>';
+		echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">' . esc_html__('Status', 'bonus-hunt-guesser') . '</th>';
+		echo '<th style="text-align:left;border-bottom:1px solid #e2e8f0;padding:6px;">' . esc_html__('Details', 'bonus-hunt-guesser') . '</th>';
+		echo '</tr></thead><tbody>';
+
+		foreach ($rows as $row) {
+			$detail_url = esc_url(add_query_arg('bhg_tournament_id', (int)$row->id, remove_query_arg(array('orderby','order'), $current_url)));
+			echo '<tr>';
+			echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html(ucfirst($row->type)) . '</td>';
+			echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html(mysql2date(get_option('date_format'), $row->start_date)) . '</td>';
+			echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html(mysql2date(get_option('date_format'), $row->end_date)) . '</td>';
+			echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html($row->status) . '</td>';
+			echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;"><a href="' . $detail_url . '">' . esc_html__('Show details','bonus-hunt-guesser') . '</a></td>';
+			echo '</tr>';
+		}
+
+		echo '</tbody></table>';
+		return ob_get_clean();
+	}
+
+	/** Minimal winners widget: latest closed hunts */
+	public function winner_notifications_shortcode($atts) {
+		global $wpdb;
+
+		$a = shortcode_atts(
+			array('limit' => 5),
+			$atts,
+			'bhg_winner_notifications'
+		);
+
+		$hunts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id, title, final_balance, winners_count, closed_at FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status='closed' ORDER BY closed_at DESC LIMIT %d",
+				(int) $a['limit']
+			)
+		);
+
+		if ( ! $hunts ) {
+			return '<p>' . esc_html__( 'No closed hunts yet.', 'bonus-hunt-guesser' ) . '</p>';
+		}
+
+		ob_start();
+		echo '<div class="bhg-winner-notifications">';
+		foreach ( $hunts as $hunt ) {
+			$winners = function_exists( 'bhg_get_top_winners_for_hunt' )
+				? bhg_get_top_winners_for_hunt( $hunt->id, (int) $hunt->winners_count )
+				: array();
+
+			echo '<div class="bhg-winner" style="margin-bottom:15px;">';
+			echo '<p><strong>' . esc_html( $hunt->title ) . '</strong></p>';
+			if ( $hunt->final_balance !== null ) {
+				echo '<p><em>' . esc_html__( 'Final', 'bonus-hunt-guesser' ) . ':</em> ' . esc_html( number_format_i18n( (float) $hunt->final_balance, 2 ) ) . '</p>';
+			}
+
+			if ( $winners ) {
+				echo '<ul class="bhg-winner-list">';
+				foreach ( $winners as $w ) {
+					$u  = get_userdata( (int) $w->user_id );
+					$nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
+					echo '<li>' . esc_html( $nm ) . ' — ' . esc_html( number_format_i18n( (float) $w->guess, 2 ) ) . ' (' . esc_html( number_format_i18n( (float) $w->diff, 2 ) ) . ')</li>';
+				}
+				echo '</ul>';
+			}
+
+			echo '</div>';
+		}
+		echo '</div>';
+		return ob_get_clean();
+	}
+
+	/** Minimal profile view: affiliate status badge */
+	public function user_profile_shortcode($atts) {
+		if (!is_user_logged_in()) return '<p>' . esc_html__('Please log in to view this content.', 'bonus-hunt-guesser') . '</p>';
+		wp_enqueue_style(
+			'bhg-shortcodes',
+			BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+			array(),
+			defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+		);
+		$user_id = get_current_user_id();
+		$is_affiliate = (int)get_user_meta($user_id, 'bhg_is_affiliate', true);
+		$badge = $is_affiliate ? '<span class="bhg-aff-green" aria-hidden="true"></span>' : '<span class="bhg-aff-red" aria-hidden="true"></span>';
+		return '<div class="bhg-user-profile">' . $badge . ' ' . esc_html(wp_get_current_user()->display_name) . '</div>';
+	}
+
+	/** [bhg_best_guessers] — simple wins leaderboard */
+	public function best_guessers_shortcode($atts) {
+		global $wpdb;
+
+		$wins_tbl = $wpdb->prefix . 'bhg_tournament_results';
+		$tours_tbl = $wpdb->prefix . 'bhg_tournaments';
+		$users_tbl = $wpdb->users;
+
+		$now_ts = current_time('timestamp');
+		$current_month = wp_date('Y-m', $now_ts);
+		$current_year  = wp_date('Y', $now_ts);
+
+		$periods = array(
+			'overall' => array(
+				'label' => esc_html__('Overall', 'bonus-hunt-guesser'),
+				'type'  => '',
+				'start' => '',
+				'end'   => '',
+			),
+			'monthly' => array(
+				'label' => esc_html__('Monthly', 'bonus-hunt-guesser'),
+				'type'  => 'monthly',
+				'start' => $current_month . '-01',
+				'end'   => wp_date('Y-m-t', strtotime($current_month . '-01', $now_ts)),
+			),
+			'yearly' => array(
+				'label' => esc_html__('Yearly', 'bonus-hunt-guesser'),
+				'type'  => 'yearly',
+				'start' => $current_year . '-01-01',
+				'end'   => $current_year . '-12-31',
+			),
+			'alltime' => array(
+				'label' => esc_html__('All-Time', 'bonus-hunt-guesser'),
+				'type'  => 'alltime',
+				'start' => '',
+				'end'   => '',
+			),
+		);
+
+		$results = array();
+		foreach ($periods as $key => $info) {
+			if ($info['type']) {
+				$where = 't.type = %s';
+				$params = array($info['type']);
+				if (!empty($info['start']) && !empty($info['end'])) {
+					$where .= ' AND t.start_date >= %s AND t.end_date <= %s';
+					$params[] = $info['start'];
+					$params[] = $info['end'];
+				}
+				$sql = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
+						FROM {$wins_tbl} r
+						INNER JOIN {$users_tbl} u ON u.ID = r.user_id
+						INNER JOIN {$tours_tbl} t ON t.id = r.tournament_id
+						WHERE {$where}
+						GROUP BY u.ID, u.user_login
+						ORDER BY total_wins DESC, u.user_login ASC
+						LIMIT 50";
+				array_unshift($params, $sql);
+				$prepared = call_user_func_array(array($wpdb, 'prepare'), $params);
+				$results[$key] = $wpdb->get_results($prepared);
+			} else {
+				$sql = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
+						FROM {$wins_tbl} r
+						INNER JOIN {$users_tbl} u ON u.ID = r.user_id
+						GROUP BY u.ID, u.user_login
+						ORDER BY total_wins DESC, u.user_login ASC
+						LIMIT 50";
+				$results[$key] = $wpdb->get_results( $sql );
+			}
+		}
+
+		$hunts_tbl = $wpdb->prefix . 'bhg_bonus_hunts';
+		$hunts = $wpdb->get_results( "SELECT id, title FROM {$hunts_tbl} WHERE status='closed' ORDER BY created_at DESC LIMIT 50" );
+
+		wp_enqueue_style(
+			'bhg-shortcodes',
+			BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+			array(),
+			defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+		);
+		wp_enqueue_script(
+			'bhg-shortcodes-js',
+			BHG_PLUGIN_URL . 'assets/js/bhg-shortcodes.js',
+			array(),
+			defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
+			true
+		);
+
+		ob_start();
+		echo '<ul class="bhg-tabs">';
+		$first = true;
+		foreach ($periods as $key => $info) {
+			$active = $first ? ' class="active"' : '';
+			echo '<li' . $active . '><a href="#bhg-tab-' . esc_attr($key) . '">' . esc_html($info['label']) . '</a></li>';
+			$first = false;
+		}
+		if ($hunts) {
+			echo '<li><a href="#bhg-tab-hunts">' . esc_html__('Bonus Hunts', 'bonus-hunt-guesser') . '</a></li>';
+		}
+		echo '</ul>';
+
+		$first = true;
+		foreach ($periods as $key => $info) {
+			$active = $first ? ' active' : '';
+			echo '<div id="bhg-tab-' . esc_attr($key) . '" class="bhg-tab-pane' . $active . '">';
+			$rows = isset($results[$key]) ? $results[$key] : array();
+			if (!$rows) {
+				echo '<p>' . esc_html__('No data yet.', 'bonus-hunt-guesser') . '</p>';
+			} else {
+				echo '<table class="bhg-leaderboard"><thead><tr><th>#</th><th>' . esc_html__('User', 'bonus-hunt-guesser') . '</th><th>' . esc_html__('Wins', 'bonus-hunt-guesser') . '</th></tr></thead><tbody>';
+				$pos = 1;
+				foreach ($rows as $r) {
+					$user_label = $r->user_login ? $r->user_login : 'user#' . (int) $r->user_id;
+					echo '<tr><td>' . (int) $pos++ . '</td><td>' . esc_html($user_label) . '</td><td>' . (int) $r->total_wins . '</td></tr>';
+				}
+				echo '</tbody></table>';
+			}
+			echo '</div>';
+			$first = false;
+		}
+
+		if ( $hunts ) {
+			$base = remove_query_arg( 'hunt_id', home_url( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
+			echo '<div id="bhg-tab-hunts" class="bhg-tab-pane">';
+			echo '<ul class="bhg-hunt-history">';
+			foreach ( $hunts as $hunt ) {
+				$url = esc_url( add_query_arg( 'hunt_id', (int) $hunt->id, $base ) );
+				echo '<li><a href="' . $url . '">' . esc_html( $hunt->title ) . '</a></li>';
+			}
+			echo '</ul>';
+			echo '</div>';
+		}
+
+		return ob_get_clean();
+	}
 }
 
 } // end if class not exists
 
 // Register once on init even if no other bootstrap instantiates the class
 if (!function_exists('bhg_register_shortcodes_once')) {
-    function bhg_register_shortcodes_once() {
-        static $done = false;
-        if ($done) return;
-        $done = true;
-        if (class_exists('BHG_Shortcodes')) {
-            // Instantiate to attach the hooks
-            new BHG_Shortcodes();
-        }
-    }
-    add_action('init', 'bhg_register_shortcodes_once', 20);
+	function bhg_register_shortcodes_once() {
+		static $done = false;
+		if ($done) return;
+		$done = true;
+		if (class_exists('BHG_Shortcodes')) {
+			// Instantiate to attach the hooks
+			new BHG_Shortcodes();
+		}
+	}
+	add_action('init', 'bhg_register_shortcodes_once', 20);
 }

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -2,130 +2,130 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function bhg_seed_demo_on_activation(){
-    // Only seed once
-    if (get_option('bhg_demo_seeded')) return;
+	// Only seed once
+	if (get_option('bhg_demo_seeded')) return;
 
-    // Create demo users (if not exist)
-    $users = array(
-        array('user_login' => 'alice_demo', 'user_email' => 'alice_demo@example.com'),
-        array('user_login' => 'bob_demo', 'user_email' => 'bob_demo@example.com'),
-        array('user_login' => 'charlie_demo', 'user_email' => 'charlie_demo@example.com'),
-    );
-    $user_ids = array();
-    foreach ($users as $u){
-        $uid = username_exists($u['user_login']);
-        if (!$uid){
-            $pass = wp_generate_password(12, false);
-            $uid = wp_create_user($u['user_login'], $pass, $u['user_email']);
-            if (is_wp_error($uid)) { $uid = 0; }
-        }
-        $user_ids[$u['user_login']] = $uid ? intval($uid) : 0;
-    }
+	// Create demo users (if not exist)
+	$users = array(
+		array('user_login' => 'alice_demo', 'user_email' => 'alice_demo@example.com'),
+		array('user_login' => 'bob_demo', 'user_email' => 'bob_demo@example.com'),
+		array('user_login' => 'charlie_demo', 'user_email' => 'charlie_demo@example.com'),
+	);
+	$user_ids = array();
+	foreach ($users as $u){
+		$uid = username_exists($u['user_login']);
+		if (!$uid){
+			$pass = wp_generate_password(12, false);
+			$uid = wp_create_user($u['user_login'], $pass, $u['user_email']);
+			if (is_wp_error($uid)) { $uid = 0; }
+		}
+		$user_ids[$u['user_login']] = $uid ? intval($uid) : 0;
+	}
 
-    global $wpdb;
-    $hunts = $wpdb->prefix . 'bhg_bonus_hunts';
-    $guesses = $wpdb->prefix . 'bhg_guesses';
-    $tournaments = $wpdb->prefix . 'bhg_tournaments';
-    $aff = $wpdb->prefix . 'bhg_affiliate_websites';
-    $ads = $wpdb->prefix . 'bhg_ads';
-    $trans = $wpdb->prefix . 'bhg_translations';
+	global $wpdb;
+	$hunts = $wpdb->prefix . 'bhg_bonus_hunts';
+	$guesses = $wpdb->prefix . 'bhg_guesses';
+	$tournaments = $wpdb->prefix . 'bhg_tournaments';
+	$aff = $wpdb->prefix . 'bhg_affiliate_websites';
+	$ads = $wpdb->prefix . 'bhg_ads';
+	$trans = $wpdb->prefix . 'bhg_translations';
 
-    // Insert affiliate sites
-    $wpdb->insert($aff, array('name'=>'Demo Affiliate 1','slug'=>'demo-aff-1','url'=>'https://demo-affiliate1.test'));
-    $wpdb->insert($aff, array('name'=>'Demo Affiliate 2','slug'=>'demo-aff-2','url'=>'https://demo-affiliate2.test'));
+	// Insert affiliate sites
+	$wpdb->insert($aff, array('name'=>'Demo Affiliate 1','slug'=>'demo-aff-1','url'=>'https://demo-affiliate1.test'));
+	$wpdb->insert($aff, array('name'=>'Demo Affiliate 2','slug'=>'demo-aff-2','url'=>'https://demo-affiliate2.test'));
 
-    // Insert a demo hunt (open) and a demo closed hunt
-    $wpdb->insert($hunts, array(
-        'title' => 'Bonus Hunt – Demo (Open)',
-        'starting_balance' => 2000.00,
-        'num_bonuses' => 10,
-        'prizes' => 'Gift Card €50, Merch',
-        'status' => 'open',
-        'created_at' => current_time('mysql')
-    ));
-    $open_id = intval($wpdb->insert_id);
+	// Insert a demo hunt (open) and a demo closed hunt
+	$wpdb->insert($hunts, array(
+		'title' => 'Bonus Hunt – Demo (Open)',
+		'starting_balance' => 2000.00,
+		'num_bonuses' => 10,
+		'prizes' => 'Gift Card €50, Merch',
+		'status' => 'open',
+		'created_at' => current_time('mysql')
+	));
+	$open_id = intval($wpdb->insert_id);
 
-    $wpdb->insert($hunts, array(
-        'title' => 'Bonus Hunt – Demo (Closed)',
-        'starting_balance' => 1500.00,
-        'num_bonuses' => 8,
-        'prizes' => 'Gift Card €25',
-        'status' => 'closed',
-        'final_balance' => 2420.00,
-        'winner_user_id' => 0,
-        'winner_diff' => 0,
-        'closed_at' => current_time('mysql', true),
-        'created_at' => current_time('mysql')
-    ));
-    $closed_id = intval($wpdb->insert_id);
+	$wpdb->insert($hunts, array(
+		'title' => 'Bonus Hunt – Demo (Closed)',
+		'starting_balance' => 1500.00,
+		'num_bonuses' => 8,
+		'prizes' => 'Gift Card €25',
+		'status' => 'closed',
+		'final_balance' => 2420.00,
+		'winner_user_id' => 0,
+		'winner_diff' => 0,
+		'closed_at' => current_time('mysql', true),
+		'created_at' => current_time('mysql')
+	));
+	$closed_id = intval($wpdb->insert_id);
 
-    // Add demo guesses for closed hunt
-    $grows = array(
-        array('hunt_id'=>$closed_id,'user_id'=>$user_ids['alice_demo'],'guess_amount'=>2450.00),
-        array('hunt_id'=>$closed_id,'user_id'=>$user_ids['bob_demo'],'guess_amount'=>2400.00),
-        array('hunt_id'=>$closed_id,'user_id'=>$user_ids['charlie_demo'],'guess_amount'=>1800.00),
-    );
-    foreach ($grows as $r){
-        if ($r['user_id']) {
-            $wpdb->insert($guesses, array(
-                'hunt_id'=>$r['hunt_id'],
-                'user_id'=>$r['user_id'],
-                'guess_amount'=>$r['guess_amount'],
-                'created_at'=> current_time('mysql')
-            ));
-        }
-    }
+	// Add demo guesses for closed hunt
+	$grows = array(
+		array('hunt_id'=>$closed_id,'user_id'=>$user_ids['alice_demo'],'guess_amount'=>2450.00),
+		array('hunt_id'=>$closed_id,'user_id'=>$user_ids['bob_demo'],'guess_amount'=>2400.00),
+		array('hunt_id'=>$closed_id,'user_id'=>$user_ids['charlie_demo'],'guess_amount'=>1800.00),
+	);
+	foreach ($grows as $r){
+		if ($r['user_id']) {
+			$wpdb->insert($guesses, array(
+				'hunt_id'=>$r['hunt_id'],
+				'user_id'=>$r['user_id'],
+				'guess_amount'=>$r['guess_amount'],
+				'created_at'=> current_time('mysql')
+			));
+		}
+	}
 
-    // Compute winner for the closed hunt (closest)
-    $rows = $wpdb->get_results( "SELECT * FROM `{$closed_id}`" );
-    $final = 2420.00;
-    $winner_id = 0; $winner_diff = null;
-    foreach ($rows as $row){
-        $diff = abs(floatval($row->guess_amount) - $final);
-        if ($winner_diff === null || $diff < $winner_diff){
-            $winner_diff = $diff;
-            $winner_id = intval($row->user_id);
-        }
-    }
-    $wpdb->update($hunts, array('winner_user_id'=>$winner_id, 'winner_diff'=>$winner_diff), array('id'=>$closed_id));
+	// Compute winner for the closed hunt (closest)
+	$rows = $wpdb->get_results( "SELECT * FROM `{$closed_id}`" );
+	$final = 2420.00;
+	$winner_id = 0; $winner_diff = null;
+	foreach ($rows as $row){
+		$diff = abs(floatval($row->guess_amount) - $final);
+		if ($winner_diff === null || $diff < $winner_diff){
+			$winner_diff = $diff;
+			$winner_id = intval($row->user_id);
+		}
+	}
+	$wpdb->update($hunts, array('winner_user_id'=>$winner_id, 'winner_diff'=>$winner_diff), array('id'=>$closed_id));
 
-    // Insert a demo tournament (monthly)
-    $wpdb->insert($tournaments, array(
-        'title' => 'Monthly Tournament (Demo)',
-        'status' => 'active',
-        'created_at' => current_time('mysql')
-    ));
+	// Insert a demo tournament (monthly)
+	$wpdb->insert($tournaments, array(
+		'title' => 'Monthly Tournament (Demo)',
+		'status' => 'active',
+		'created_at' => current_time('mysql')
+	));
 
-    // Translations & Ads samples
-    $wpdb->insert($trans, array('tkey'=>'email_results_title', 'tvalue'=>'The Bonus Hunt has been closed!'));
-    $wpdb->insert($trans, array('tkey'=>'email_final_balance', 'tvalue'=>'Final Balance'));
-    $wpdb->insert($trans, array('tkey'=>'email_winner', 'tvalue'=>'Winner'));
-    $wpdb->insert($ads, array(
-        'title'        => '',
-        'content'      => 'Sponsored by Demo Casino – Play Now',
-        'link_url'     => 'https://example.com',
-        'placement'    => 'footer',
-        'visible_to'   => 'guests',
-        'target_pages' => '',
-        'active'       => 1,
-    ));
+	// Translations & Ads samples
+	$wpdb->insert($trans, array('tkey'=>'email_results_title', 'tvalue'=>'The Bonus Hunt has been closed!'));
+	$wpdb->insert($trans, array('tkey'=>'email_final_balance', 'tvalue'=>'Final Balance'));
+	$wpdb->insert($trans, array('tkey'=>'email_winner', 'tvalue'=>'Winner'));
+	$wpdb->insert($ads, array(
+		'title'        => '',
+		'content'      => 'Sponsored by Demo Casino – Play Now',
+		'link_url'     => 'https://example.com',
+		'placement'    => 'footer',
+		'visible_to'   => 'guests',
+		'target_pages' => '',
+		'active'       => 1,
+	));
 
-    // Create demo pages with shortcodes (with (Demo) suffix)
-    $pages = array(
-        array('title'=>'Bonus Hunt (Demo)', 'content'=>'[bhg_bonus_hunt]'),
-        array('title'=>'Leaderboard (Demo)', 'content'=>'[bhg_leaderboard]'),
-        array('title'=>'Tournaments (Demo)', 'content'=>'[bhg_tournament_leaderboard]'),
-    );
-    foreach ($pages as $p){
-        if (!get_page_by_title($p['title'])){
-            wp_insert_post(array(
-                'post_title' => $p['title'],
-                'post_content' => $p['content'],
-                'post_status' => 'publish',
-                'post_type' => 'page'
-            ));
-        }
-    }
+	// Create demo pages with shortcodes (with (Demo) suffix)
+	$pages = array(
+		array('title'=>'Bonus Hunt (Demo)', 'content'=>'[bhg_bonus_hunt]'),
+		array('title'=>'Leaderboard (Demo)', 'content'=>'[bhg_leaderboard]'),
+		array('title'=>'Tournaments (Demo)', 'content'=>'[bhg_tournament_leaderboard]'),
+	);
+	foreach ($pages as $p){
+		if (!get_page_by_title($p['title'])){
+			wp_insert_post(array(
+				'post_title' => $p['title'],
+				'post_content' => $p['content'],
+				'post_status' => 'publish',
+				'post_type' => 'page'
+			));
+		}
+	}
 
-    update_option('bhg_demo_seeded', 1);
+	update_option('bhg_demo_seeded', 1);
 }

--- a/includes/helpers-aff-dot.php
+++ b/includes/helpers-aff-dot.php
@@ -3,18 +3,18 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 // Renders green/red dot based on affiliate status for current hunt/site context
 if (!function_exists('bhg_render_affiliate_dot')) {
-    function bhg_render_affiliate_dot($user_id, $hunt_affiliate_site_id = 0){
-        $is_aff = false;
-        if (function_exists('bhg_is_user_affiliate_for_site')) {
-            $is_aff = (bool) bhg_is_user_affiliate_for_site($user_id, $hunt_affiliate_site_id);
-        } elseif (function_exists('bhg_is_user_affiliate')) {
-            $is_aff = (bool) bhg_is_user_affiliate($user_id);
-        }
+	function bhg_render_affiliate_dot($user_id, $hunt_affiliate_site_id = 0){
+		$is_aff = false;
+		if (function_exists('bhg_is_user_affiliate_for_site')) {
+			$is_aff = (bool) bhg_is_user_affiliate_for_site($user_id, $hunt_affiliate_site_id);
+		} elseif (function_exists('bhg_is_user_affiliate')) {
+			$is_aff = (bool) bhg_is_user_affiliate($user_id);
+		}
 
-        $cls   = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
-        $label = $is_aff ? esc_attr__('Affiliate', 'bonus-hunt-guesser')
-                         : esc_attr__('Non-affiliate', 'bonus-hunt-guesser');
+		$cls   = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
+		$label = $is_aff ? esc_attr__('Affiliate', 'bonus-hunt-guesser')
+						 : esc_attr__('Non-affiliate', 'bonus-hunt-guesser');
 
-        return '<span class="bhg-aff-dot ' . esc_attr($cls) . '" aria-label="' . $label . '"></span>';
-    }
+		return '<span class="bhg-aff-dot ' . esc_attr($cls) . '" aria-label="' . $label . '"></span>';
+	}
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -8,13 +8,13 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  * @return void
  */
 function bhg_log( $message ) {
-    if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
-        return;
-    }
-    if ( is_array( $message ) || is_object( $message ) ) {
-        $message = print_r( $message, true );
-    }
-    error_log( '[BHG] ' . $message );
+	if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+		return;
+	}
+	if ( is_array( $message ) || is_object( $message ) ) {
+		$message = print_r( $message, true );
+	}
+	error_log( '[BHG] ' . $message );
 }
 
 /**
@@ -23,8 +23,8 @@ function bhg_log( $message ) {
  * @return int
  */
 function bhg_current_user_id() {
-    $uid = get_current_user_id();
-    return $uid ? intval( $uid ) : 0;
+	$uid = get_current_user_id();
+	return $uid ? intval( $uid ) : 0;
 }
 
 /**
@@ -34,11 +34,11 @@ function bhg_current_user_id() {
  * @return string
  */
 function bhg_slugify( $text ) {
-    $text = sanitize_title( $text );
-    if ( ! $text ) {
-        $text = uniqid( 'bhg' );
-    }
-    return $text;
+	$text = sanitize_title( $text );
+	if ( ! $text ) {
+		$text = uniqid( 'bhg' );
+	}
+	return $text;
 }
 
 /**
@@ -47,21 +47,21 @@ function bhg_slugify( $text ) {
  * @return string
  */
 function bhg_admin_cap() {
-    return apply_filters( 'bhg_admin_capability', 'manage_options' );
+	return apply_filters( 'bhg_admin_capability', 'manage_options' );
 }
 
 // Smart login redirect back to referring page.
 add_filter( 'login_redirect', function( $redirect_to, $requested_redirect_to, $user ) {
-    $r = isset( $_REQUEST['bhg_redirect'] ) ? wp_unslash( $_REQUEST['bhg_redirect'] ) : '';
-    if ( ! empty( $r ) ) {
-        $safe     = esc_url_raw( $r );
-        $home_host = wp_parse_url( home_url(), PHP_URL_HOST );
-        $r_host   = wp_parse_url( $safe, PHP_URL_HOST );
-        if ( ! $r_host || $r_host === $home_host ) {
-            return $safe;
-        }
-    }
-    return $redirect_to;
+	$r = isset( $_REQUEST['bhg_redirect'] ) ? wp_unslash( $_REQUEST['bhg_redirect'] ) : '';
+	if ( ! empty( $r ) ) {
+		$safe     = esc_url_raw( $r );
+		$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
+		$r_host   = wp_parse_url( $safe, PHP_URL_HOST );
+		if ( ! $r_host || $r_host === $home_host ) {
+			return $safe;
+		}
+	}
+	return $redirect_to;
 }, 10, 3 );
 
 /**
@@ -70,180 +70,180 @@ add_filter( 'login_redirect', function( $redirect_to, $requested_redirect_to, $u
  * @return bool
  */
 function bhg_is_frontend() {
-    return ! is_admin() && ! wp_doing_ajax() && ! wp_doing_cron();
+	return ! is_admin() && ! wp_doing_ajax() && ! wp_doing_cron();
 }
 
 if ( ! function_exists( 'bhg_t' ) ) {
-    /**
-     * Retrieve a translation value from the database.
-     *
-     * @param string $key     Translation key.
-     * @param string $default Default text if not found.
-     * @return string
-     */
-    function bhg_t( $key, $default = '' ) {
-        global $wpdb;
-        static $cache = [];
+	/**
+	 * Retrieve a translation value from the database.
+	 *
+	 * @param string $key     Translation key.
+	 * @param string $default Default text if not found.
+	 * @return string
+	 */
+	function bhg_t( $key, $default = '' ) {
+		global $wpdb;
+		static $cache = [];
 
-        if ( isset( $cache[ $key ] ) ) {
-            return $cache[ $key ];
-        }
+		if ( isset( $cache[ $key ] ) ) {
+			return $cache[ $key ];
+		}
 
-        $table = $wpdb->prefix . 'bhg_translations';
-        $row   = $wpdb->get_row(
-            $wpdb->prepare( "SELECT tvalue FROM $table WHERE tkey = %s", $key )
-        );
+		$table = $wpdb->prefix . 'bhg_translations';
+		$row   = $wpdb->get_row(
+			$wpdb->prepare( "SELECT tvalue FROM $table WHERE tkey = %s", $key )
+		);
 
-        if ( $row && isset( $row->tvalue ) ) {
-            $cache[ $key ] = $row->tvalue;
-            return $row->tvalue;
-        }
+		if ( $row && isset( $row->tvalue ) ) {
+			$cache[ $key ] = $row->tvalue;
+			return $row->tvalue;
+		}
 
-        return $default;
-    }
+		return $default;
+	}
 }
 
 if ( ! function_exists( 'bhg_get_default_translations' ) ) {
-    /**
-     * Retrieve default translation key/value pairs.
-     *
-     * @return array
-     */
-    function bhg_get_default_translations() {
-        return array(
-            'welcome_message'        => 'Welcome!',
-            'goodbye_message'        => 'Goodbye!',
-            'menu_dashboard'         => 'Dashboard',
-            'menu_bonus_hunts'       => 'Bonus Hunts',
-            'menu_results'           => 'Results',
-            'menu_tournaments'       => 'Tournaments',
-            'menu_users'             => 'Users',
-            'menu_affiliates'        => 'Affiliates',
-            'menu_advertising'       => 'Advertising',
-            'menu_translations'      => 'Translations',
-            'menu_tools'             => 'Tools',
-            'menu_ads'               => 'Ads',
-            'label_start_balance'    => 'Starting Balance',
-            'label_number_bonuses'   => 'Number of Bonuses',
-            'label_prizes'           => 'Prizes',
-            'label_submit_guess'     => 'Submit Guess',
-            'label_guess'            => 'Guess',
-            'label_username'         => 'Username',
-            'label_position'         => 'Position',
-            'label_final_balance'    => 'Final Balance',
-            'label_leaderboard'      => 'Leaderboard',
-            'label_affiliate'        => 'Affiliate',
-            'label_non_affiliate'    => 'Non-affiliate',
-            'label_affiliate_status' => 'Affiliate Status',
-            'label_actions'          => 'Actions',
-            'label_placements'       => 'Placements',
-            'label_visible_to'       => 'Visible To',
-            'label_start_date'       => 'Start Date',
-            'label_end_date'         => 'End Date',
-            'label_email'            => 'Email',
-            'label_real_name'        => 'Real Name',
-            'label_search'           => 'Search',
-            'notice_login_required'  => 'You must be logged in to guess.',
-            'notice_guess_saved'     => 'Your guess has been saved.',
-            'notice_guess_updated'   => 'Your guess has been updated.',
-            'notice_hunt_closed'     => 'This bonus hunt is closed.',
-            'notice_invalid_guess'   => 'Please enter a valid guess.',
-            'notice_not_authorized'  => 'You are not authorized to perform this action.',
-            'notice_translations_saved' => 'Translations saved.',
-            'notice_translations_reset' => 'Translations reset.',
-            'notice_no_active_hunt'  => 'No active bonus hunt found.',
-            'notice_no_results'      => 'No results available.',
-            'notice_user_removed'    => 'User removed.',
-            'notice_ad_saved'        => 'Advertisement saved.',
-            'notice_ad_deleted'      => 'Advertisement deleted.',
-            'notice_settings_saved'  => 'Settings saved.',
-            'notice_profile_updated' => 'Profile updated.',
-            'button_save'            => 'Save',
-            'button_cancel'          => 'Cancel',
-            'button_delete'          => 'Delete',
-            'button_edit'            => 'Edit',
-            'button_view'            => 'View',
-            'button_back'            => 'Back',
-            'msg_no_guesses'         => 'No guesses yet.',
-            'msg_thank_you'          => 'Thank you!',
-            'msg_error'              => 'An error occurred.',
-            'placeholder_enter_guess'=> 'Enter your guess',
-            'notice_login_to_continue'    => 'Please log in to continue.',
-            'button_log_in'               => 'Log in',
-            'notice_no_active_hunts'      => 'No active bonus hunts at the moment.',
-            'notice_login_to_guess'       => 'Please log in to submit your guess.',
-            'notice_no_open_hunt'         => 'No open hunt found to guess.',
-            'label_choose_hunt'           => 'Choose a hunt:',
-            'label_select_hunt'           => 'Select a hunt',
-            'label_guess_final_balance'   => 'Your guess (final balance):',
-            'notice_no_hunts_found'       => 'No hunts found.',
-            'label_user'                  => 'User',
-            'notice_tournament_not_found' => 'Tournament not found.',
-            'label_back_to_tournaments'   => 'Back to tournaments',
-            'label_start'                 => 'Start',
-            'label_end'                   => 'End',
-            'label_status'                => 'Status',
-            'notice_no_results_yet'       => 'No results yet.',
-            'label_wins'                  => 'Wins',
-            'label_last_win'              => 'Last win',
-            'label_period'                => 'Period',
-            'label_all'                   => 'All',
-            'label_weekly'                => 'Weekly',
-            'label_monthly'               => 'Monthly',
-            'label_yearly'                => 'Yearly',
-            'label_active'                => 'Active',
-            'label_closed'                => 'Closed',
-            'button_filter'               => 'Filter',
-            'label_type'                  => 'Type',
-            'label_details'               => 'Details',
-            'label_show_details'          => 'Show details',
-            'notice_no_tournaments'       => 'No tournaments found.',
-            'label_bonus_hunts'           => 'Bonus Hunts',
-            'notice_no_data_yet'          => 'No data yet.',
-            'label_overall'               => 'Overall',
-            'label_all_time'              => 'All-Time',
-            'notice_no_closed_hunts'      => 'No closed hunts yet.',
-            'label_final'                 => 'Final',
-            'label_user_number'           => 'User #%d',
-            'label_diff'                  => 'diff',
-            'notice_login_view_content'   => 'Please log in to view this content.',
-            'label_latest_hunts'          => 'Latest Hunts',
-            'label_bonushunt'             => 'Bonushunt',
-            'label_all_winners'           => 'All Winners',
-            'label_closed_at'             => 'Closed At',
-            'notice_no_winners_yet'       => 'No winners yet.',
-        );
-    }
+	/**
+	 * Retrieve default translation key/value pairs.
+	 *
+	 * @return array
+	 */
+	function bhg_get_default_translations() {
+		return array(
+			'welcome_message'        => 'Welcome!',
+			'goodbye_message'        => 'Goodbye!',
+			'menu_dashboard'         => 'Dashboard',
+			'menu_bonus_hunts'       => 'Bonus Hunts',
+			'menu_results'           => 'Results',
+			'menu_tournaments'       => 'Tournaments',
+			'menu_users'             => 'Users',
+			'menu_affiliates'        => 'Affiliates',
+			'menu_advertising'       => 'Advertising',
+			'menu_translations'      => 'Translations',
+			'menu_tools'             => 'Tools',
+			'menu_ads'               => 'Ads',
+			'label_start_balance'    => 'Starting Balance',
+			'label_number_bonuses'   => 'Number of Bonuses',
+			'label_prizes'           => 'Prizes',
+			'label_submit_guess'     => 'Submit Guess',
+			'label_guess'            => 'Guess',
+			'label_username'         => 'Username',
+			'label_position'         => 'Position',
+			'label_final_balance'    => 'Final Balance',
+			'label_leaderboard'      => 'Leaderboard',
+			'label_affiliate'        => 'Affiliate',
+			'label_non_affiliate'    => 'Non-affiliate',
+			'label_affiliate_status' => 'Affiliate Status',
+			'label_actions'          => 'Actions',
+			'label_placements'       => 'Placements',
+			'label_visible_to'       => 'Visible To',
+			'label_start_date'       => 'Start Date',
+			'label_end_date'         => 'End Date',
+			'label_email'            => 'Email',
+			'label_real_name'        => 'Real Name',
+			'label_search'           => 'Search',
+			'notice_login_required'  => 'You must be logged in to guess.',
+			'notice_guess_saved'     => 'Your guess has been saved.',
+			'notice_guess_updated'   => 'Your guess has been updated.',
+			'notice_hunt_closed'     => 'This bonus hunt is closed.',
+			'notice_invalid_guess'   => 'Please enter a valid guess.',
+			'notice_not_authorized'  => 'You are not authorized to perform this action.',
+			'notice_translations_saved' => 'Translations saved.',
+			'notice_translations_reset' => 'Translations reset.',
+			'notice_no_active_hunt'  => 'No active bonus hunt found.',
+			'notice_no_results'      => 'No results available.',
+			'notice_user_removed'    => 'User removed.',
+			'notice_ad_saved'        => 'Advertisement saved.',
+			'notice_ad_deleted'      => 'Advertisement deleted.',
+			'notice_settings_saved'  => 'Settings saved.',
+			'notice_profile_updated' => 'Profile updated.',
+			'button_save'            => 'Save',
+			'button_cancel'          => 'Cancel',
+			'button_delete'          => 'Delete',
+			'button_edit'            => 'Edit',
+			'button_view'            => 'View',
+			'button_back'            => 'Back',
+			'msg_no_guesses'         => 'No guesses yet.',
+			'msg_thank_you'          => 'Thank you!',
+			'msg_error'              => 'An error occurred.',
+			'placeholder_enter_guess'=> 'Enter your guess',
+			'notice_login_to_continue'    => 'Please log in to continue.',
+			'button_log_in'               => 'Log in',
+			'notice_no_active_hunts'      => 'No active bonus hunts at the moment.',
+			'notice_login_to_guess'       => 'Please log in to submit your guess.',
+			'notice_no_open_hunt'         => 'No open hunt found to guess.',
+			'label_choose_hunt'           => 'Choose a hunt:',
+			'label_select_hunt'           => 'Select a hunt',
+			'label_guess_final_balance'   => 'Your guess (final balance):',
+			'notice_no_hunts_found'       => 'No hunts found.',
+			'label_user'                  => 'User',
+			'notice_tournament_not_found' => 'Tournament not found.',
+			'label_back_to_tournaments'   => 'Back to tournaments',
+			'label_start'                 => 'Start',
+			'label_end'                   => 'End',
+			'label_status'                => 'Status',
+			'notice_no_results_yet'       => 'No results yet.',
+			'label_wins'                  => 'Wins',
+			'label_last_win'              => 'Last win',
+			'label_period'                => 'Period',
+			'label_all'                   => 'All',
+			'label_weekly'                => 'Weekly',
+			'label_monthly'               => 'Monthly',
+			'label_yearly'                => 'Yearly',
+			'label_active'                => 'Active',
+			'label_closed'                => 'Closed',
+			'button_filter'               => 'Filter',
+			'label_type'                  => 'Type',
+			'label_details'               => 'Details',
+			'label_show_details'          => 'Show details',
+			'notice_no_tournaments'       => 'No tournaments found.',
+			'label_bonus_hunts'           => 'Bonus Hunts',
+			'notice_no_data_yet'          => 'No data yet.',
+			'label_overall'               => 'Overall',
+			'label_all_time'              => 'All-Time',
+			'notice_no_closed_hunts'      => 'No closed hunts yet.',
+			'label_final'                 => 'Final',
+			'label_user_number'           => 'User #%d',
+			'label_diff'                  => 'diff',
+			'notice_login_view_content'   => 'Please log in to view this content.',
+			'label_latest_hunts'          => 'Latest Hunts',
+			'label_bonushunt'             => 'Bonushunt',
+			'label_all_winners'           => 'All Winners',
+			'label_closed_at'             => 'Closed At',
+			'notice_no_winners_yet'       => 'No winners yet.',
+		);
+	}
 }
 
 if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
-    /**
-     * Seed default translations, avoiding duplicate entries.
-     *
-     * @return void
-     */
-    function bhg_seed_default_translations_if_empty() {
-        global $wpdb;
+	/**
+	 * Seed default translations, avoiding duplicate entries.
+	 *
+	 * @return void
+	 */
+	function bhg_seed_default_translations_if_empty() {
+		global $wpdb;
 
-        $table = $wpdb->prefix . 'bhg_translations';
+		$table = $wpdb->prefix . 'bhg_translations';
 
-        foreach ( bhg_get_default_translations() as $tkey => $tvalue ) {
-            $tkey = trim( (string) $tkey );
-            if ( '' === $tkey ) {
-                continue; // Skip invalid keys.
-            }
+		foreach ( bhg_get_default_translations() as $tkey => $tvalue ) {
+			$tkey = trim( (string) $tkey );
+			if ( '' === $tkey ) {
+				continue; // Skip invalid keys.
+			}
 
-            $wpdb->replace(
-                $table,
-                array(
-                    'tkey'   => $tkey,
-                    'tvalue' => $tvalue,
-                    'locale' => get_locale(),
-                ),
-                array( '%s', '%s', '%s' )
-            );
-        }
-    }
+			$wpdb->replace(
+				$table,
+				array(
+					'tkey'   => $tkey,
+					'tvalue' => $tvalue,
+					'locale' => get_locale(),
+				),
+				array( '%s', '%s', '%s' )
+			);
+		}
+	}
 }
 
 /**
@@ -253,7 +253,7 @@ if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
  * @return string
  */
 function bhg_format_currency( $amount ) {
-    return '€' . number_format( $amount, 2 );
+	return '€' . number_format( $amount, 2 );
 }
 
 /**
@@ -263,16 +263,16 @@ function bhg_format_currency( $amount ) {
  * @return bool
  */
 function bhg_validate_guess( $guess ) {
-    $settings  = get_option( 'bhg_plugin_settings', [] );
-    $min_guess = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
-    $max_guess = isset( $settings['max_guess_amount'] ) ? (float) $settings['max_guess_amount'] : 100000;
+	$settings  = get_option( 'bhg_plugin_settings', [] );
+	$min_guess = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
+	$max_guess = isset( $settings['max_guess_amount'] ) ? (float) $settings['max_guess_amount'] : 100000;
 
-    if ( ! is_numeric( $guess ) ) {
-        return false;
-    }
+	if ( ! is_numeric( $guess ) ) {
+		return false;
+	}
 
-    $guess = (float) $guess;
-    return ( $guess >= $min_guess && $guess <= $max_guess );
+	$guess = (float) $guess;
+	return ( $guess >= $min_guess && $guess <= $max_guess );
 }
 
 /**
@@ -284,106 +284,106 @@ function bhg_validate_guess( $guess ) {
  * @return string Display name with optional affiliate indicator.
  */
 function bhg_get_user_display_name( $user_id ) {
-    $user = get_userdata( $user_id );
-    if ( ! $user ) {
-        return __( 'Unknown User', 'bonus-hunt-guesser' );
-    }
+	$user = get_userdata( $user_id );
+	if ( ! $user ) {
+		return __( 'Unknown User', 'bonus-hunt-guesser' );
+	}
 
-    $display_name = $user->display_name ?: $user->user_login;
-    $is_affiliate = bhg_is_user_affiliate( $user_id );
+	$display_name = $user->display_name ?: $user->user_login;
+	$is_affiliate = bhg_is_user_affiliate( $user_id );
 
-    if ( $is_affiliate ) {
-        $display_name .= ' <span class="bhg-affiliate-indicator" title="' . esc_attr__( 'Affiliate User', 'bonus-hunt-guesser' ) . '">★</span>';
-    }
+	if ( $is_affiliate ) {
+		$display_name .= ' <span class="bhg-affiliate-indicator" title="' . esc_attr__( 'Affiliate User', 'bonus-hunt-guesser' ) . '">★</span>';
+	}
 
-    return $display_name;
+	return $display_name;
 }
 
 
 if ( ! function_exists( 'bhg_is_user_affiliate' ) ) {
-    /**
-     * Check if a user is an affiliate.
-     *
-     * @param int $user_id User ID.
-     * @return bool
-     */
-    function bhg_is_user_affiliate( $user_id ) {
-        $val = get_user_meta( $user_id, 'bhg_is_affiliate', true );
-        return $val === '1' || 1 === $val || true === $val || 'yes' === $val;
-    }
+	/**
+	 * Check if a user is an affiliate.
+	 *
+	 * @param int $user_id User ID.
+	 * @return bool
+	 */
+	function bhg_is_user_affiliate( $user_id ) {
+		$val = get_user_meta( $user_id, 'bhg_is_affiliate', true );
+		return $val === '1' || 1 === $val || true === $val || 'yes' === $val;
+	}
 }
 if ( ! function_exists( 'bhg_get_user_affiliate_sites' ) ) {
-    /**
-     * Get affiliate site IDs for a user.
-     *
-     * @param int $user_id User ID.
-     * @return array
-     */
-    function bhg_get_user_affiliate_sites( $user_id ) {
-        $ids = get_user_meta( $user_id, 'bhg_affiliate_sites', true );
-        if ( is_array( $ids ) ) {
-            return array_map( 'absint', $ids );
-        }
-        if ( is_string( $ids ) && strlen( $ids ) ) {
-            return array_map( 'absint', array_filter( array_map( 'trim', explode( ',', $ids ) ) ) );
-        }
-        return array();
-    }
+	/**
+	 * Get affiliate site IDs for a user.
+	 *
+	 * @param int $user_id User ID.
+	 * @return array
+	 */
+	function bhg_get_user_affiliate_sites( $user_id ) {
+		$ids = get_user_meta( $user_id, 'bhg_affiliate_sites', true );
+		if ( is_array( $ids ) ) {
+			return array_map( 'absint', $ids );
+		}
+		if ( is_string( $ids ) && strlen( $ids ) ) {
+			return array_map( 'absint', array_filter( array_map( 'trim', explode( ',', $ids ) ) ) );
+		}
+		return array();
+	}
 }
 if ( ! function_exists( 'bhg_set_user_affiliate_sites' ) ) {
-    /**
-     * Store affiliate site IDs for a user.
-     *
-     * @param int   $user_id  User ID.
-     * @param array $site_ids Site IDs.
-     * @return void
-     */
-    function bhg_set_user_affiliate_sites( $user_id, $site_ids ) {
-        $clean = array();
-        if ( is_array( $site_ids ) ) {
-            foreach ( $site_ids as $sid ) {
-                $sid = absint( $sid );
-                if ( $sid ) {
-                    $clean[] = $sid;
-                }
-            }
-        }
-        update_user_meta( $user_id, 'bhg_affiliate_sites', $clean );
-    }
+	/**
+	 * Store affiliate site IDs for a user.
+	 *
+	 * @param int   $user_id  User ID.
+	 * @param array $site_ids Site IDs.
+	 * @return void
+	 */
+	function bhg_set_user_affiliate_sites( $user_id, $site_ids ) {
+		$clean = array();
+		if ( is_array( $site_ids ) ) {
+			foreach ( $site_ids as $sid ) {
+				$sid = absint( $sid );
+				if ( $sid ) {
+					$clean[] = $sid;
+				}
+			}
+		}
+		update_user_meta( $user_id, 'bhg_affiliate_sites', $clean );
+	}
 }
 
 
 if ( ! function_exists( 'bhg_is_user_affiliate_for_site' ) ) {
-    /**
-     * Determine if a user is an affiliate for a specific site.
-     *
-     * @param int $user_id User ID.
-     * @param int $site_id Site ID.
-     * @return bool
-     */
-    function bhg_is_user_affiliate_for_site( $user_id, $site_id ) {
-        if ( ! $site_id ) {
-            return bhg_is_user_affiliate( $user_id );
-        }
-        $sites = bhg_get_user_affiliate_sites( $user_id );
-        return in_array( absint( $site_id ), array_map( 'absint', (array) $sites ), true );
-    }
+	/**
+	 * Determine if a user is an affiliate for a specific site.
+	 *
+	 * @param int $user_id User ID.
+	 * @param int $site_id Site ID.
+	 * @return bool
+	 */
+	function bhg_is_user_affiliate_for_site( $user_id, $site_id ) {
+		if ( ! $site_id ) {
+			return bhg_is_user_affiliate( $user_id );
+		}
+		$sites = bhg_get_user_affiliate_sites( $user_id );
+		return in_array( absint( $site_id ), array_map( 'absint', (array) $sites ), true );
+	}
 }
 
 if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
-    /**
-     * Render affiliate status dot.
-     *
-     * @param int $user_id               User ID.
-     * @param int $hunt_affiliate_site_id Hunt affiliate site ID.
-     * @return string
-     */
-    function bhg_render_affiliate_dot( $user_id, $hunt_affiliate_site_id = 0 ) {
-        $is_aff = bhg_is_user_affiliate_for_site( $user_id, $hunt_affiliate_site_id );
-        $cls    = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
-        $label  = $is_aff ? esc_attr__( 'Affiliate', 'bonus-hunt-guesser' ) : esc_attr__( 'Non-affiliate', 'bonus-hunt-guesser' );
-        return '<span class="bhg-aff-dot ' . esc_attr( $cls ) . '" aria-label="' . $label . '"></span>';
-    }
+	/**
+	 * Render affiliate status dot.
+	 *
+	 * @param int $user_id               User ID.
+	 * @param int $hunt_affiliate_site_id Hunt affiliate site ID.
+	 * @return string
+	 */
+	function bhg_render_affiliate_dot( $user_id, $hunt_affiliate_site_id = 0 ) {
+		$is_aff = bhg_is_user_affiliate_for_site( $user_id, $hunt_affiliate_site_id );
+		$cls    = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
+		$label  = $is_aff ? esc_attr__( 'Affiliate', 'bonus-hunt-guesser' ) : esc_attr__( 'Non-affiliate', 'bonus-hunt-guesser' );
+		return '<span class="bhg-aff-dot ' . esc_attr( $cls ) . '" aria-label="' . $label . '"></span>';
+	}
 }
 
 
@@ -395,246 +395,246 @@ if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
  * @return string
  */
 function bhg_render_ads( $placement = 'footer', $hunt_id = 0 ) {
-    global $wpdb;
-    $tbl = $wpdb->prefix . 'bhg_ads';
-    $placement = sanitize_text_field($placement);
-    $rows = $wpdb->get_results($wpdb->prepare("SELECT content, link_url, visible_to FROM {$tbl} WHERE active=1 AND placement=%s ORDER BY id DESC", $placement));
-    $hunt_site_id = 0;
-    if ($hunt_id) {
-        $hunt_site_id = (int) $wpdb->get_var(
-            $wpdb->prepare("SELECT affiliate_site_id FROM {$wpdb->prefix}bhg_bonus_hunts WHERE id=%d", $hunt_id)
-        );
-    }
-    if (!$rows) return '';
+	global $wpdb;
+	$tbl = $wpdb->prefix . 'bhg_ads';
+	$placement = sanitize_text_field($placement);
+	$rows = $wpdb->get_results($wpdb->prepare("SELECT content, link_url, visible_to FROM {$tbl} WHERE active=1 AND placement=%s ORDER BY id DESC", $placement));
+	$hunt_site_id = 0;
+	if ($hunt_id) {
+		$hunt_site_id = (int) $wpdb->get_var(
+			$wpdb->prepare("SELECT affiliate_site_id FROM {$wpdb->prefix}bhg_bonus_hunts WHERE id=%d", $hunt_id)
+		);
+	}
+	if (!$rows) return '';
 
-    $out = '<div class="bhg-ads bhg-ads-' . esc_attr($placement) . '">';
-    foreach ($rows as $r) {
-        $vis = $r->visible_to ?: 'all';
-        $show = false;
-        if ($vis === 'all') $show = true;
-        elseif ($vis === 'guests' && !is_user_logged_in()) $show = true;
-        elseif ($vis === 'logged_in' && is_user_logged_in()) $show = true;
-        elseif ($vis === 'affiliate' && is_user_logged_in()) {
-            $uid = get_current_user_id();
-            $show = $hunt_site_id > 0
-                ? bhg_is_user_affiliate_for_site($uid, $hunt_site_id)
-                : (bool) get_user_meta($uid, 'bhg_is_affiliate', true);
-        }
-        if (!$show) continue;
-        $msg  = wp_kses_post($r->content);
-        $link = $r->link_url ? esc_url($r->link_url) : '';
-        $out .= '<div class="bhg-ad" style="margin:10px 0;padding:10px;border:1px solid #e2e8f0;border-radius:6px;">';
-        if ($link) { $out .= '<a href="' . $link . '">'; }
-        $out .= $msg;
-        if ($link) { $out .= '</a>'; }
-        $out .= '</div>';
-    }
-    $out .= '</div>';
-    return $out;
+	$out = '<div class="bhg-ads bhg-ads-' . esc_attr($placement) . '">';
+	foreach ($rows as $r) {
+		$vis = $r->visible_to ?: 'all';
+		$show = false;
+		if ($vis === 'all') $show = true;
+		elseif ($vis === 'guests' && !is_user_logged_in()) $show = true;
+		elseif ($vis === 'logged_in' && is_user_logged_in()) $show = true;
+		elseif ($vis === 'affiliate' && is_user_logged_in()) {
+			$uid = get_current_user_id();
+			$show = $hunt_site_id > 0
+				? bhg_is_user_affiliate_for_site($uid, $hunt_site_id)
+				: (bool) get_user_meta($uid, 'bhg_is_affiliate', true);
+		}
+		if (!$show) continue;
+		$msg  = wp_kses_post($r->content);
+		$link = $r->link_url ? esc_url($r->link_url) : '';
+		$out .= '<div class="bhg-ad" style="margin:10px 0;padding:10px;border:1px solid #e2e8f0;border-radius:6px;">';
+		if ($link) { $out .= '<a href="' . $link . '">'; }
+		$out .= $msg;
+		if ($link) { $out .= '</a>'; }
+		$out .= '</div>';
+	}
+	$out .= '</div>';
+	return $out;
 }
 
 // Demo reset and seed data.
 if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
-    /**
-     * Reset demo tables and seed sample data.
-     *
-     * @return bool
-     */
-    function bhg_reset_demo_and_seed() {
-        global $wpdb;
+	/**
+	 * Reset demo tables and seed sample data.
+	 *
+	 * @return bool
+	 */
+	function bhg_reset_demo_and_seed() {
+		global $wpdb;
 
-        $p = $wpdb->prefix;
+		$p = $wpdb->prefix;
 
-        // Ensure tables exist before touching
-        $tables = array(
-            "{$p}bhg_guesses",
-            "{$p}bhg_bonus_hunts",
-            "{$p}bhg_tournaments",
-            "{$p}bhg_tournament_results",
-            "{$p}bhg_hunt_winners",
-            "{$p}bhg_ads",
-            "{$p}bhg_translations",
-            "{$p}bhg_affiliate_websites",
-        );
+		// Ensure tables exist before touching
+		$tables = array(
+			"{$p}bhg_guesses",
+			"{$p}bhg_bonus_hunts",
+			"{$p}bhg_tournaments",
+			"{$p}bhg_tournament_results",
+			"{$p}bhg_hunt_winners",
+			"{$p}bhg_ads",
+			"{$p}bhg_translations",
+			"{$p}bhg_affiliate_websites",
+		);
 
-        // Soft delete (DELETE) to preserve schema even if user lacks TRIGGER/TRUNCATE
-        foreach ($tables as $tbl) {
-            // Skip translations/affiliates if table missing
-            $exists = $wpdb->get_var( $wpdb->prepare("SHOW TABLES LIKE %s", $tbl) );
-            if ($exists !== $tbl) continue;
-            if (strpos($tbl, 'bhg_translations') !== false || strpos($tbl, 'bhg_affiliate_websites') !== false) {
-                // keep existing; we'll upsert below
-                continue;
-            }
-            $wpdb->query( "DELETE FROM `{$tbl}`" );
-        }
+		// Soft delete (DELETE) to preserve schema even if user lacks TRIGGER/TRUNCATE
+		foreach ($tables as $tbl) {
+			// Skip translations/affiliates if table missing
+			$exists = $wpdb->get_var( $wpdb->prepare("SHOW TABLES LIKE %s", $tbl) );
+			if ($exists !== $tbl) continue;
+			if (strpos($tbl, 'bhg_translations') !== false || strpos($tbl, 'bhg_affiliate_websites') !== false) {
+				// keep existing; we'll upsert below
+				continue;
+			}
+			$wpdb->query( "DELETE FROM `{$tbl}`" );
+		}
 
-        // Seed affiliate websites (idempotent upsert by slug)
-        $aff_tbl = "{$p}bhg_affiliate_websites";
-        if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $aff_tbl)) === $aff_tbl) {
-            $affs = array(
-                array('name'=>'Main Site','slug'=>'main-site','url'=>home_url('/')),
-                array('name'=>'Casino Hub','slug'=>'casino-hub','url'=>home_url('/casino')),
-            );
-            foreach ($affs as $a) {
-                $id = $wpdb->get_var($wpdb->prepare("SELECT id FROM `{$aff_tbl}` WHERE slug=%s", $a['slug']));
-                if ($id) {
-                    $wpdb->update($aff_tbl, $a, array('id'=>(int)$id), array('%s','%s','%s'), array('%d'));
-                } else {
-                    $wpdb->insert($aff_tbl, $a, array('%s','%s','%s'));
-                }
-            }
-        }
+		// Seed affiliate websites (idempotent upsert by slug)
+		$aff_tbl = "{$p}bhg_affiliate_websites";
+		if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $aff_tbl)) === $aff_tbl) {
+			$affs = array(
+				array('name'=>'Main Site','slug'=>'main-site','url'=>home_url('/')),
+				array('name'=>'Casino Hub','slug'=>'casino-hub','url'=>home_url('/casino')),
+			);
+			foreach ($affs as $a) {
+				$id = $wpdb->get_var($wpdb->prepare("SELECT id FROM `{$aff_tbl}` WHERE slug=%s", $a['slug']));
+				if ($id) {
+					$wpdb->update($aff_tbl, $a, array('id'=>(int)$id), array('%s','%s','%s'), array('%d'));
+				} else {
+					$wpdb->insert($aff_tbl, $a, array('%s','%s','%s'));
+				}
+			}
+		}
 
-        // Seed hunts
-        $hunts_tbl = "{$p}bhg_bonus_hunts";
-        if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $hunts_tbl)) === $hunts_tbl) {
-            $now = current_time('mysql', 1);
-            // Open hunt
-            $wpdb->insert($hunts_tbl, array(
-                'title' => __('Bonus Hunt – Demo Open', 'bonus-hunt-guesser'),
-                'starting_balance' => 2000.00,
-                'num_bonuses' => 10,
-                'prizes' => __('Gift card + swag', 'bonus-hunt-guesser'),
-                'status' => 'open',
-                'affiliate_site_id' => (int) $wpdb->get_var( "SELECT id FROM {$p}bhg_affiliate_websites ORDER BY id ASC LIMIT 1" ),
-                'created_at' => $now,
-                'updated_at' => $now,
-            ), array('%s','%f','%d','%s','%s','%d','%s','%s'));
-            $open_id = (int) $wpdb->insert_id;
+		// Seed hunts
+		$hunts_tbl = "{$p}bhg_bonus_hunts";
+		if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $hunts_tbl)) === $hunts_tbl) {
+			$now = current_time('mysql', 1);
+			// Open hunt
+			$wpdb->insert($hunts_tbl, array(
+				'title' => __('Bonus Hunt – Demo Open', 'bonus-hunt-guesser'),
+				'starting_balance' => 2000.00,
+				'num_bonuses' => 10,
+				'prizes' => __('Gift card + swag', 'bonus-hunt-guesser'),
+				'status' => 'open',
+				'affiliate_site_id' => (int) $wpdb->get_var( "SELECT id FROM {$p}bhg_affiliate_websites ORDER BY id ASC LIMIT 1" ),
+				'created_at' => $now,
+				'updated_at' => $now,
+			), array('%s','%f','%d','%s','%s','%d','%s','%s'));
+			$open_id = (int) $wpdb->insert_id;
 
-            // Closed hunt with winner
-            $wpdb->insert($hunts_tbl, array(
-                'title' => __('Bonus Hunt – Demo Closed', 'bonus-hunt-guesser'),
-                'starting_balance' => 1500.00,
-                'num_bonuses' => 8,
-                'prizes' => __('T-shirt', 'bonus-hunt-guesser'),
-                'status' => 'closed',
-                'final_balance' => 1875.50,
-                'winner_user_id' => 1,
-                'winner_diff' => 12.50,
-                'closed_at' => gmdate('Y-m-d H:i:s', time() - 86400),
-                'created_at' => $now,
-                'updated_at' => $now,
-            ), array('%s','%f','%d','%s','%s','%f','%d','%f','%s','%s','%s'));
-            $closed_id = (int) $wpdb->insert_id;
+			// Closed hunt with winner
+			$wpdb->insert($hunts_tbl, array(
+				'title' => __('Bonus Hunt – Demo Closed', 'bonus-hunt-guesser'),
+				'starting_balance' => 1500.00,
+				'num_bonuses' => 8,
+				'prizes' => __('T-shirt', 'bonus-hunt-guesser'),
+				'status' => 'closed',
+				'final_balance' => 1875.50,
+				'winner_user_id' => 1,
+				'winner_diff' => 12.50,
+				'closed_at' => gmdate('Y-m-d H:i:s', time() - 86400),
+				'created_at' => $now,
+				'updated_at' => $now,
+			), array('%s','%f','%d','%s','%s','%f','%d','%f','%s','%s','%s'));
+			$closed_id = (int) $wpdb->insert_id;
 
-            // Seed guesses for open hunt
-            $g_tbl = "{$p}bhg_guesses";
-            $users = $wpdb->get_col( "SELECT ID FROM {$wpdb->users} ORDER BY ID ASC LIMIT 5" );
-            if (empty($users)) { $users = array(1); }
-            $val = 2100.00;
-            foreach ($users as $uid) {
-                $wpdb->insert($g_tbl, array(
-                    'hunt_id' => $open_id,
-                    'user_id' => (int)$uid,
-                    'guess' => $val,
-                    'created_at' => $now,
-                    'updated_at' => $now,
-                ), array('%d','%d','%f','%s','%s'));
-                $val += 23.45;
-            }
-        }
+			// Seed guesses for open hunt
+			$g_tbl = "{$p}bhg_guesses";
+			$users = $wpdb->get_col( "SELECT ID FROM {$wpdb->users} ORDER BY ID ASC LIMIT 5" );
+			if (empty($users)) { $users = array(1); }
+			$val = 2100.00;
+			foreach ($users as $uid) {
+				$wpdb->insert($g_tbl, array(
+					'hunt_id' => $open_id,
+					'user_id' => (int)$uid,
+					'guess' => $val,
+					'created_at' => $now,
+					'updated_at' => $now,
+				), array('%d','%d','%f','%s','%s'));
+				$val += 23.45;
+			}
+		}
 
-        // Tournaments + results based on closed hunts
-        $t_tbl = "{$p}bhg_tournaments";
-        $r_tbl = "{$p}bhg_tournament_results";
-        if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $t_tbl)) === $t_tbl) {
-            // Wipe results only
-            if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $r_tbl)) === $r_tbl) {
-                $wpdb->query( "DELETE FROM `{$r_tbl}`" );
-            }
-            $closed = $wpdb->get_results( "SELECT winner_user_id, closed_at FROM {$hunts_tbl} WHERE status='closed' AND winner_user_id IS NOT NULL" );
-            foreach ($closed as $row) {
-                $ts = $row->closed_at ? strtotime($row->closed_at) : time();
-                $isoYear = date('o', $ts);
-                $week = str_pad(date('W', $ts), 2, '0', STR_PAD_LEFT);
-                $weekKey = $isoYear . '-W' . $week;
-                $monthKey = date('Y-m', $ts);
-                $yearKey = date('Y', $ts);
+		// Tournaments + results based on closed hunts
+		$t_tbl = "{$p}bhg_tournaments";
+		$r_tbl = "{$p}bhg_tournament_results";
+		if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $t_tbl)) === $t_tbl) {
+			// Wipe results only
+			if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $r_tbl)) === $r_tbl) {
+				$wpdb->query( "DELETE FROM `{$r_tbl}`" );
+			}
+			$closed = $wpdb->get_results( "SELECT winner_user_id, closed_at FROM {$hunts_tbl} WHERE status='closed' AND winner_user_id IS NOT NULL" );
+			foreach ($closed as $row) {
+				$ts = $row->closed_at ? strtotime($row->closed_at) : time();
+				$isoYear = date('o', $ts);
+				$week = str_pad(date('W', $ts), 2, '0', STR_PAD_LEFT);
+				$weekKey = $isoYear . '-W' . $week;
+				$monthKey = date('Y-m', $ts);
+				$yearKey = date('Y', $ts);
 
-                $ensure = function($type, $period) use ($wpdb, $t_tbl) {
-                    $now = current_time('mysql', 1);
-                    $start = $now; $end = $now;
-                    if ($type === 'weekly') {
-                        $start = date('Y-m-d', strtotime($period . '-1'));
-                        $end   = date('Y-m-d', strtotime($period . '-7'));
-                    } elseif ($type === 'monthly') {
-                        $start = $period . '-01';
-                        $end   = date('Y-m-t', strtotime($start));
-                    } elseif ($type === 'yearly') {
-                        $start = $period . '-01-01';
-                        $end   = $period . '-12-31';
-                    }
-                    $id = $wpdb->get_var($wpdb->prepare(
-                        "SELECT id FROM {$t_tbl} WHERE type=%s AND start_date=%s AND end_date=%s",
-                        $type,
-                        $start,
-                        $end
-                    ));
-                    if ($id) return (int) $id;
-                    $wpdb->insert($t_tbl, array(
-                        'type'=>$type,'start_date'=>$start,'end_date'=>$end,'status'=>'active',
-                        'created_at'=>$now,'updated_at'=>$now
-                    ), array('%s','%s','%s','%s','%s','%s'));
-                    return (int)$wpdb->insert_id;
-                };
+				$ensure = function($type, $period) use ($wpdb, $t_tbl) {
+					$now = current_time('mysql', 1);
+					$start = $now; $end = $now;
+					if ($type === 'weekly') {
+						$start = date('Y-m-d', strtotime($period . '-1'));
+						$end   = date('Y-m-d', strtotime($period . '-7'));
+					} elseif ($type === 'monthly') {
+						$start = $period . '-01';
+						$end   = date('Y-m-t', strtotime($start));
+					} elseif ($type === 'yearly') {
+						$start = $period . '-01-01';
+						$end   = $period . '-12-31';
+					}
+					$id = $wpdb->get_var($wpdb->prepare(
+						"SELECT id FROM {$t_tbl} WHERE type=%s AND start_date=%s AND end_date=%s",
+						$type,
+						$start,
+						$end
+					));
+					if ($id) return (int) $id;
+					$wpdb->insert($t_tbl, array(
+						'type'=>$type,'start_date'=>$start,'end_date'=>$end,'status'=>'active',
+						'created_at'=>$now,'updated_at'=>$now
+					), array('%s','%s','%s','%s','%s','%s'));
+					return (int)$wpdb->insert_id;
+				};
 
-                $uids = (int)$row->winner_user_id;
-                foreach (array(
-                    $ensure('weekly', $weekKey),
-                    $ensure('monthly', $monthKey),
-                    $ensure('yearly', $yearKey)
-                ) as $tid) {
-                    if ($tid && $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $r_tbl)) === $r_tbl) {
-                        $wpdb->query($wpdb->prepare(
-                            "INSERT INTO {$r_tbl} (tournament_id, user_id, wins) VALUES (%d, %d, 1)
-                             ON DUPLICATE KEY UPDATE wins = wins + 1",
-                            $tid, $uids
-                        ));
-                    }
-                }
-            }
-        }
+				$uids = (int)$row->winner_user_id;
+				foreach (array(
+					$ensure('weekly', $weekKey),
+					$ensure('monthly', $monthKey),
+					$ensure('yearly', $yearKey)
+				) as $tid) {
+					if ($tid && $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $r_tbl)) === $r_tbl) {
+						$wpdb->query($wpdb->prepare(
+							"INSERT INTO {$r_tbl} (tournament_id, user_id, wins) VALUES (%d, %d, 1)
+							 ON DUPLICATE KEY UPDATE wins = wins + 1",
+							$tid, $uids
+						));
+					}
+				}
+			}
+		}
 
-        // Seed translations (upsert)
-        $tr_tbl = "{$p}bhg_translations";
-        if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $tr_tbl)) === $tr_tbl) {
-            $pairs = array(
-                'email_results_title' => 'The Bonus Hunt has been closed!',
-                'email_final_balance' => 'Final Balance',
-                'email_winner' => 'Winner',
-                'email_congrats_subject' => 'Congratulations! You won the Bonus Hunt',
-                'email_congrats_body' => 'You had the closest guess. Great job!',
-                'email_hunt' => 'Hunt',
-            );
-            foreach ($pairs as $k=>$v) {
-                $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM {$tr_tbl} WHERE tkey=%s", $k));
-                if ($exists) {
-                    $wpdb->update($tr_tbl, array('tvalue'=>$v), array('id'=>$exists), array('%s'), array('%d'));
-                } else {
-                    $wpdb->insert($tr_tbl, array('tkey'=>$k, 'tvalue'=>$v), array('%s','%s'));
-                }
-            }
-        }
+		// Seed translations (upsert)
+		$tr_tbl = "{$p}bhg_translations";
+		if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $tr_tbl)) === $tr_tbl) {
+			$pairs = array(
+				'email_results_title' => 'The Bonus Hunt has been closed!',
+				'email_final_balance' => 'Final Balance',
+				'email_winner' => 'Winner',
+				'email_congrats_subject' => 'Congratulations! You won the Bonus Hunt',
+				'email_congrats_body' => 'You had the closest guess. Great job!',
+				'email_hunt' => 'Hunt',
+			);
+			foreach ($pairs as $k=>$v) {
+				$exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM {$tr_tbl} WHERE tkey=%s", $k));
+				if ($exists) {
+					$wpdb->update($tr_tbl, array('tvalue'=>$v), array('id'=>$exists), array('%s'), array('%d'));
+				} else {
+					$wpdb->insert($tr_tbl, array('tkey'=>$k, 'tvalue'=>$v), array('%s','%s'));
+				}
+			}
+		}
 
-        // Seed ads
-        $ads_tbl = "{$p}bhg_ads";
-        if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $ads_tbl)) === $ads_tbl) {
-            $now = current_time('mysql', 1);
-            $wpdb->insert($ads_tbl, array(
-                'title'        => '',
-                'content'      => '<strong>Play responsibly.</strong> <a href="'.esc_url(home_url('/promo')).'">See promo</a>',
-                'link_url'     => '',
-                'placement'    => 'footer',
-                'visible_to'   => 'all',
-                'target_pages' => '',
-                'active'       => 1,
-                'created_at'   => $now,
-                'updated_at'   => $now,
-            ), array('%s','%s','%s','%s','%s','%s','%d','%s','%s'));
-        }
+		// Seed ads
+		$ads_tbl = "{$p}bhg_ads";
+		if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $ads_tbl)) === $ads_tbl) {
+			$now = current_time('mysql', 1);
+			$wpdb->insert($ads_tbl, array(
+				'title'        => '',
+				'content'      => '<strong>Play responsibly.</strong> <a href="'.esc_url(home_url('/promo')).'">See promo</a>',
+				'link_url'     => '',
+				'placement'    => 'footer',
+				'visible_to'   => 'all',
+				'target_pages' => '',
+				'active'       => 1,
+				'created_at'   => $now,
+				'updated_at'   => $now,
+			), array('%s','%s','%s','%s','%s','%s','%d','%s','%s'));
+		}
 
-        return true;
-    }
+		return true;
+	}
 }

--- a/includes/upgrade/add-winners-limit.php
+++ b/includes/upgrade/add-winners-limit.php
@@ -2,29 +2,29 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 function bhg_upgrade_add_winners_limit_column(){
-    global $wpdb;
-    $hunts = $wpdb->prefix . 'bhg_bonus_hunts';
-    $charset_collate = $wpdb->get_charset_collate();
+	global $wpdb;
+	$hunts = $wpdb->prefix . 'bhg_bonus_hunts';
+	$charset_collate = $wpdb->get_charset_collate();
 
-    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-    // Ensure table exists & has winners_count column
-    $sql = "CREATE TABLE {$hunts} (
-        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-        title VARCHAR(190) NOT NULL,
-        starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
-        num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
-        prizes TEXT NULL,
-        affiliate_site_id BIGINT UNSIGNED NULL,
-        winners_count INT UNSIGNED NOT NULL DEFAULT 3,
-        final_balance DECIMAL(12,2) NULL,
-        status VARCHAR(20) NOT NULL DEFAULT 'open',
-        created_at DATETIME NULL,
-        updated_at DATETIME NULL,
-        closed_at DATETIME NULL,
-        PRIMARY KEY  (id),
-        KEY status (status)
-    ) {$charset_collate};";
+	// Ensure table exists & has winners_count column
+	$sql = "CREATE TABLE {$hunts} (
+		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+		title VARCHAR(190) NOT NULL,
+		starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+		num_bonuses INT UNSIGNED NOT NULL DEFAULT 0,
+		prizes TEXT NULL,
+		affiliate_site_id BIGINT UNSIGNED NULL,
+		winners_count INT UNSIGNED NOT NULL DEFAULT 3,
+		final_balance DECIMAL(12,2) NULL,
+		status VARCHAR(20) NOT NULL DEFAULT 'open',
+		created_at DATETIME NULL,
+		updated_at DATETIME NULL,
+		closed_at DATETIME NULL,
+		PRIMARY KEY  (id),
+		KEY status (status)
+	) {$charset_collate};";
 
-    dbDelta( $sql );
+	dbDelta( $sql );
 }


### PR DESCRIPTION
## Summary
- replace leading spaces with tabs in all PHP files to follow WordPress coding standards

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68baf079c5708333ae4f50159915ff7c