### PR TITLE
Load Ads component during plugin initialization

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -154,6 +154,7 @@ spl_autoload_register( function ( $class ) {
 		'BHG_Utils' => 'includes/class-bhg-utils.php',
 		'BHG_Models' => 'includes/class-bhg-models.php',
 		'BHG_Front_Menus' => 'includes/class-bhg-front-menus.php',
+		'BHG_Ads' => 'includes/class-bhg-ads.php',
 		'BHG_Demo' => 'admin/class-bhg-demo.php',
 	];
 	
@@ -291,6 +292,10 @@ function bhg_init_plugin() {
 	}
 	if ( class_exists( 'BHG_Front_Menus' ) ) {
 		new BHG_Front_Menus();
+	}
+
+	if ( class_exists( 'BHG_Ads' ) ) {
+		BHG_Ads::init();
 	}
 
 	if ( class_exists( 'BHG_DB' ) ) {


### PR DESCRIPTION
## Summary
- load `BHG_Ads` via autoloader
- initialize ads after menus so footer ads and shortcodes register

## Testing
- `php -l bonus-hunt-guesser.php`


------
https://chatgpt.com/codex/tasks/task_e_68baf68210108333a3a84740fd9ede55