### PR TITLE
Add advertising shortcode and expand handler

### DIFF
--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -5,8 +5,9 @@ class BHG_Ads {
 
 	/** Initialize front-end hooks for ads */
 	public static function init() {
-		add_action('wp_footer', ['BHG_Ads', 'render_footer']);
-		add_shortcode('bhg_ad', ['BHG_Ads', 'shortcode']);
+		add_action( 'wp_footer', [ 'BHG_Ads', 'render_footer' ] );
+		add_shortcode( 'bhg_ad', [ 'BHG_Ads', 'shortcode' ] );
+		add_shortcode( 'bhg_advertising', [ 'BHG_Ads', 'shortcode' ] );
 	}
 
 
@@ -29,16 +30,16 @@ class BHG_Ads {
 		$visibility = is_string($visibility) ? strtolower($visibility) : 'all';
 		switch ($visibility) {
 			case 'logged_in':
-				return is_user_logged_in();
+		return is_user_logged_in();
 			case 'guests':
-				return !is_user_logged_in();
+		return !is_user_logged_in();
 			case 'affiliates':
-				return self::user_is_affiliate();
+		return self::user_is_affiliate();
 			case 'non_affiliates':
-				return is_user_logged_in() ? ! self::user_is_affiliate() : false;
+		return is_user_logged_in() ? ! self::user_is_affiliate() : false;
 			case 'all':
 			default:
-				return true;
+		return true;
 		}
 	}
 
@@ -108,19 +109,59 @@ class BHG_Ads {
 		}
 	}
 
-	/** Shortcode: [bhg_ad id="123"] renders a single ad row regardless of placement. */
-	public static function shortcode($atts = []) {
-		$a = shortcode_atts(['id' => 0], $atts, 'bhg_ad');
-		$id = isset($a['id']) ? (int)$a['id'] : 0;
-		if ($id <= 0) return '';
+	/**
+	 * Shortcode handler for rendering a single ad row regardless of placement.
+	 *
+	 * Usage examples:
+	 * [bhg_ad id="123"]
+	 * [bhg_advertising ad="123" status="inactive"]
+	 *
+	 * @param array  $atts    Shortcode attributes.
+	 * @param string $content Content enclosed by shortcode (unused).
+	 * @param string $tag     Shortcode tag.
+	 *
+	 * @return string
+	 */
+	public static function shortcode( $atts = [], $content = '', $tag = '' ) {
+		$a = shortcode_atts(
+		[
+		'id'     => 0,
+		'ad'     => 0,
+		'status' => 'active',
+		],
+		$atts,
+		$tag
+		);
+		
+		$id = $a['id'] ? (int) $a['id'] : (int) $a['ad'];
+		if ( $id <= 0 ) {
+		return '';
+		}
+		
+		$status = strtolower( trim( $a['status'] ) );
+		
 		global $wpdb;
 		$table = $wpdb->prefix . 'bhg_ads';
-		$row = $wpdb->get_row($wpdb->prepare("SELECT id, content, placement, visible_to, target_pages, active, link_url FROM `$table` WHERE id=%d", $id));
-		if (!$row) return '';
-		if ((int)$row->active !== 1) return ''; // respect active flag
-		if (!self::visibility_ok($row->visible_to)) return '';
-		if (!self::page_target_ok($row->target_pages)) return '';
-		return self::render_ad_row($row);
+		$row   = $wpdb->get_row( $wpdb->prepare( "SELECT id, content, placement, visible_to, target_pages, active, link_url FROM `$table` WHERE id=%d", $id ) );
+		if ( ! $row ) {
+		return '';
+		}
+		
+		if ( 'all' !== $status ) {
+		$expected = ( 'inactive' === $status ) ? 0 : 1;
+		if ( (int) $row->active !== $expected ) {
+		return '';
+		}
+		}
+		
+		if ( ! self::visibility_ok( $row->visible_to ) ) {
+		return '';
+		}
+		if ( ! self::page_target_ok( $row->target_pages ) ) {
+		return '';
+		}
+		
+		return self::render_ad_row( $row );
 	}
 
 }


### PR DESCRIPTION
## Summary
- register `bhg_advertising` shortcode in `BHG_Ads::init`
- expand shortcode handler to accept `ad` and `status` attributes

## Testing
- `php -l includes/class-bhg-ads.php`


------
https://chatgpt.com/codex/tasks/task_e_68bafaeeb8b48333bc33d0047c0848ac