### PR TITLE
Fix affiliate visibility key

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -414,7 +414,7 @@ function bhg_render_ads( $placement = 'footer', $hunt_id = 0 ) {
 		if ($vis === 'all') $show = true;
 		elseif ($vis === 'guests' && !is_user_logged_in()) $show = true;
 		elseif ($vis === 'logged_in' && is_user_logged_in()) $show = true;
-		elseif ($vis === 'affiliate' && is_user_logged_in()) {
+		elseif ($vis === 'affiliates' && is_user_logged_in()) {
 			$uid = get_current_user_id();
 			$show = $hunt_site_id > 0
 				? bhg_is_user_affiliate_for_site($uid, $hunt_site_id)


### PR DESCRIPTION
## Summary
- Fix ad visibility check to use `affiliates` audience key

## Testing
- `wp cache flush` *(fails: command not found)*
- `php -l includes/helpers.php`
- `phpcs includes/helpers.php | head -n 20`
- Custom PHP script rendering an affiliate-only ad


------
https://chatgpt.com/codex/tasks/task_e_68bb03a120888333ae6658be7e27e155