### PR TITLE
Unslash view parameter in bonus hunts admin view

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -24,7 +24,7 @@ if ( ! in_array( $hunts_table, $allowed_tables, true ) || ! in_array( $guesses_t
 $hunts_table   = esc_sql( $hunts_table );
 $guesses_table = esc_sql( $guesses_table );
 
-$view = isset( $_GET['view'] ) ? sanitize_text_field( $_GET['view'] ) : 'list';
+$view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
 
 /** LIST VIEW */
 if ( 'list' === $view ) :


### PR DESCRIPTION
## Summary
- sanitize `view` query var using `wp_unslash` before `sanitize_text_field`

## Testing
- `php -l admin/views/bonus-hunts.php`
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs admin/views/bonus-hunts.php` *(fails: Referenced sniff "WordPress" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bb06f4a1e88333932c8d26eccc2e3e