### PR TITLE
Use translatable user ID labels

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -293,7 +293,8 @@ if ($view === 'edit') :
 		<tr>
 		  <td>
 			<?php
-			  $name = $g->display_name ? $g->display_name : ('user#' . (int)$g->user_id);
+                          /* translators: %d: user ID. */
+                          $name = $g->display_name ? $g->display_name : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $g->user_id );
 			  $url  = admin_url('user-edit.php?user_id=' . (int)$g->user_id);
 			  echo '<a href="' . esc_url($url) . '">' . esc_html($name) . '</a>';
 			?>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -724,7 +724,8 @@ function bhg_generate_leaderboard_html( $timeframe ) {
 
 	$pos = $offset + 1;
 	foreach ( $rows as $row ) {
-		$user_label = $row->user_login ? $row->user_login : 'user#' . (int) $row->user_id;
+               /* translators: %d: user ID. */
+               $user_label = $row->user_login ? $row->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $row->user_id );
 		echo '<tr>';
 		echo '<td>' . (int) $pos++ . '</td>';
 		echo '<td>' . esc_html( $user_label ) . '</td>';

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -207,7 +207,8 @@ class BHG_Shortcodes {
 				? (int)get_user_meta((int)$r->user_id, 'bhg_affiliate_website_' . $site_id, true)
 				: (int)get_user_meta((int)$r->user_id, 'bhg_is_affiliate', true);
 			$aff = $is_aff ? 'green' : 'red';
-			$user_label = $r->user_login ? $r->user_login : ('user#' . (int)$r->user_id);
+                       /* translators: %d: user ID. */
+                       $user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
 
 			echo '<tr>';
 			echo '<td data-column="position">' . (int)$pos++ . '</td>';
@@ -577,7 +578,11 @@ class BHG_Shortcodes {
 			foreach ($rows as $row) {
 				echo '<tr>';
 				echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . (int)$pos++ . '</td>';
-				echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html($row->user_login ?: ('user#' . (int)$row->user_id)) . '</td>';
+                               echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html( $row->user_login ?: sprintf(
+                                       /* translators: %d: user ID. */
+                                       __( 'user#%d', 'bonus-hunt-guesser' ),
+                                       (int) $row->user_id
+                               ) ) . '</td>';
 				echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . (int)$row->wins . '</td>';
 				echo '<td style="padding:6px;border-bottom:1px solid #f1f5f9;">' . esc_html($row->last_win_date ? mysql2date(get_option('date_format'), $row->last_win_date) : '—') . '</td>';
 				echo '</tr>';
@@ -868,7 +873,8 @@ class BHG_Shortcodes {
 				echo '<table class="bhg-leaderboard"><thead><tr><th>#</th><th>' . esc_html__('User', 'bonus-hunt-guesser') . '</th><th>' . esc_html__('Wins', 'bonus-hunt-guesser') . '</th></tr></thead><tbody>';
 				$pos = 1;
 				foreach ($rows as $r) {
-					$user_label = $r->user_login ? $r->user_login : 'user#' . (int) $r->user_id;
+                                       /* translators: %d: user ID. */
+                                       $user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
 					echo '<tr><td>' . (int) $pos++ . '</td><td>' . esc_html($user_label) . '</td><td>' . (int) $r->total_wins . '</td></tr>';
 				}
 				echo '</tbody></table>';


### PR DESCRIPTION
## Summary
- replace hard-coded `user#` labels with translatable `sprintf` calls
- add translator comments for the new placeholders

## Testing
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs includes/class-bhg-shortcodes.php bonus-hunt-guesser.php admin/views/bonus-hunts.php | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68bb094b52208333bf1cd2a5d8237d20