### PR TITLE
Allow filtering currency symbol and use number_format_i18n

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -252,13 +252,17 @@ if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
 }
 
 /**
- * Format an amount as Euro currency.
+ * Format an amount as currency.
+ *
+ * Allows the currency symbol to be customized via the `bhg_currency_symbol` filter.
  *
  * @param float $amount Amount to format.
  * @return string
  */
 function bhg_format_currency( $amount ) {
-	return '€' . number_format( $amount, 2 );
+	$symbol = apply_filters( 'bhg_currency_symbol', '€' );
+
+	return sprintf( '%s%s', $symbol, number_format_i18n( $amount, 2 ) );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Use WordPress `number_format_i18n` for localized currency formatting
- Make currency symbol customizable via `bhg_currency_symbol` filter

## Testing
- `phpcs --standard=PSR12 includes/helpers.php` *(fails: WordPress standard not installed; PSR12 reports many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1490d7848333a8ab24e97899c9f1