### PR TITLE
Add shortcode translation defaults

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -217,6 +217,17 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
                         'notice_no_guesses_found'     => 'No guesses found.',
                         'msg_no_ads_yet'              => 'No ads yet.',
                         'notice_no_winners_yet'       => 'No winners yet.',
+				// Shortcode labels for public views.
+				'sc_hunt'                     => 'Hunt',
+				'sc_guess'                    => 'Guess',
+				'sc_final'                    => 'Final',
+				'sc_title'                    => 'Title',
+				'sc_start_balance'            => 'Start Balance',
+				'sc_final_balance'            => 'Final Balance',
+				'sc_status'                   => 'Status',
+				'sc_affiliate'                => 'Affiliate',
+				'sc_position'                 => 'Position',
+				'sc_user'                     => 'User',
                 );
         }
 }


### PR DESCRIPTION
## Summary
- include default translations for strings used in public shortcodes

## Testing
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs includes/helpers.php` (fails: FOUND 458 ERRORS AND 214 WARNINGS AFFECTING 273 LINES)


------
https://chatgpt.com/codex/tasks/task_e_68bb180266c483339d9eee13cb0baee2