### PR TITLE
Sanitize tournament edit query param

### DIFF
--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -11,7 +11,7 @@ if ( ! in_array( $table, $allowed_tables, true ) ) {
 }
 $table   = esc_sql( $table );
 
-$edit_id = isset( $_GET['edit'] ) ? (int) $_GET['edit'] : 0;
+$edit_id = isset( $_GET['edit'] ) ? (int) wp_unslash( $_GET['edit'] ) : 0;
 $row     = $edit_id
 	? $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id ) )
 	: null;


### PR DESCRIPTION
## Summary
- Sanitize `$_GET['edit']` in tournaments admin view with `wp_unslash` before casting

## Testing
- `/root/.local/share/mise/installs/php/8.4.12/.composer/vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary admin/views/tournaments.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb1f132dc08333b29da0c9bbface41