### PR TITLE
chore: document PHPCS and tidy helper style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Coding Standards
+
+This project follows the [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards).
+
+### Setup
+1. Install PHP_CodeSniffer and the WordPress standard:
+   ```bash
+   composer global require wp-coding-standards/wpcs squizlabs/php_codesniffer
+   phpcs --config-set installed_paths $(composer global config home)/vendor/wp-coding-standards/wpcs
+   ```
+
+### Running PHPCS
+Run the sniffer from the project root:
+```bash
+phpcs
+```
+
+Fix fixable issues automatically with:
+```bash
+phpcbf
+```

--- a/includes/helpers-aff-dot.php
+++ b/includes/helpers-aff-dot.php
@@ -1,20 +1,35 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+/**
+ * Helper functions for rendering affiliate indicators.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
 
-// Renders green/red dot based on affiliate status for current hunt/site context
-if (!function_exists('bhg_render_affiliate_dot')) {
-	function bhg_render_affiliate_dot($user_id, $hunt_affiliate_site_id = 0){
-		$is_aff = false;
-		if (function_exists('bhg_is_user_affiliate_for_site')) {
-			$is_aff = (bool) bhg_is_user_affiliate_for_site($user_id, $hunt_affiliate_site_id);
-		} elseif (function_exists('bhg_is_user_affiliate')) {
-			$is_aff = (bool) bhg_is_user_affiliate($user_id);
+if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+}
+
+if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
+		/**
+		 * Render a green/red dot based on affiliate status for the current hunt/site.
+		 *
+		 * @param int $user_id               User ID.
+		 * @param int $hunt_affiliate_site_id Affiliate site ID. Optional.
+		 *
+		 * @return string HTML span element representing the affiliate dot.
+		 */
+	function bhg_render_affiliate_dot( $user_id, $hunt_affiliate_site_id = 0 ) {
+			$is_aff = false;
+		if ( function_exists( 'bhg_is_user_affiliate_for_site' ) ) {
+				$is_aff = (bool) bhg_is_user_affiliate_for_site( $user_id, $hunt_affiliate_site_id );
+		} elseif ( function_exists( 'bhg_is_user_affiliate' ) ) {
+				$is_aff = (bool) bhg_is_user_affiliate( $user_id );
 		}
 
-		$cls   = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
-		$label = $is_aff ? esc_attr__('Affiliate', 'bonus-hunt-guesser')
-						 : esc_attr__('Non-affiliate', 'bonus-hunt-guesser');
+			$cls   = $is_aff ? 'bhg-aff-green' : 'bhg-aff-red';
+			$label = $is_aff ? esc_attr__( 'Affiliate', 'bonus-hunt-guesser' )
+											: esc_attr__( 'Non-affiliate', 'bonus-hunt-guesser' );
 
-		return '<span class="bhg-aff-dot ' . esc_attr($cls) . '" aria-label="' . $label . '"></span>';
+			return '<span class="bhg-aff-dot ' . esc_attr( $cls ) . '" aria-label="' . $label . '"></span>';
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,8 +3,10 @@
 <description>WordPress coding standards for the Bonus Hunt Guesser plugin.</description>
 <rule ref="WordPress"/>
 <arg name="tab-width" value="4"/>
+<arg name="extensions" value="php"/>
 <file>bonus-hunt-guesser.php</file>
 <file>admin</file>
 <file>includes</file>
 <exclude-pattern>vendor/*</exclude-pattern>
+<exclude-pattern>wpcs/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Summary
- document coding standard usage in CONTRIBUTING
- add WordPress PHPCS config tuning
- clean up affiliate dot helper to satisfy PHPCS

## Testing
- `wpcs/vendor/bin/phpcs includes/helpers-aff-dot.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb20332cac8333bc493022c1d7a96f