### PR TITLE
Remove duplicate settings nonce field

### DIFF
--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -51,9 +51,8 @@ if (!empty($error)) {
 	<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
 		<input type="hidden" name="action" value="bhg_save_settings">
 		<?php wp_nonce_field('bhg_save_settings_nonce', 'bhg_settings_nonce'); ?>
-		
-		<?php wp_nonce_field('bhg_save_settings'); ?>
-<table class="form-table">
+
+		<table class="form-table">
 			<tr>
 				<th scope="row">
 					<label for="bhg_default_tournament_period">


### PR DESCRIPTION
## Summary
- remove duplicate `wp_nonce_field('bhg_save_settings')` from settings view

## Testing
- `phpcs admin/views/settings.php` *(fails: 139 errors, 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2390a65083338b7df3195877cfd1