### PR TITLE
Add uninstall script for cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Uninstall script for Bonus Hunt Guesser.
+ *
+ * @package BonusHuntGuesser
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+// Delete plugin options.
+delete_option( 'bhg_version' );
+delete_option( 'bhg_plugin_settings' );
+
+delete_site_option( 'bhg_version' );
+delete_site_option( 'bhg_plugin_settings' );
+
+global $wpdb;
+
+$tables = array(
+	'bhg_bonus_hunts',
+	'bhg_guesses',
+	'bhg_tournaments',
+	'bhg_tournament_results',
+	'bhg_ads',
+	'bhg_translations',
+	'bhg_affiliates',
+);
+
+foreach ( $tables as $table ) {
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}{$table}" );
+}


### PR DESCRIPTION
## Summary
- add uninstall.php to remove plugin options
- drop plugin custom tables using `$wpdb->prefix`

## Testing
- `php -l uninstall.php`
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs --standard=WordPress --report=json uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb2611bd908333a388f5c038f41239