### PR TITLE
Localize placeholder dashes across admin and templates

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -266,8 +266,8 @@ class BHG_Admin {
 						$winner_names[] = $wu->user_login;
 					}
 				}
-				$winner_first = $winner_names ? $winner_names[0] : '—';
-				$winner_list  = $winner_names ? implode(', ', $winner_names) : '—';
+                                $winner_first = $winner_names ? $winner_names[0] : esc_html__( '—', 'bonus-hunt-guesser' );
+                                $winner_list  = $winner_names ? implode( ', ', $winner_names ) : esc_html__( '—', 'bonus-hunt-guesser' );
 
 				foreach ($rows as $r) {
 					$u = get_userdata((int) $r->user_id);

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -71,7 +71,7 @@ if ( 'list' === $view ) :
 		  <td><?php echo (int) $h->id; ?></td>
 		  <td><a href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html( $h->title ); ?></a></td>
 		  <td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-		  <td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : '—'; ?></td>
+                  <td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  <td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
 		  <td><?php echo esc_html( $h->status ); ?></td>
 		  <td>
@@ -119,7 +119,7 @@ if ( 'close' === $view ) :
 	else :
 ?>
 <div class="wrap">
-  <h1 class="wp-heading-inline"><?php echo esc_html__( 'Close Bonus Hunt', 'bonus-hunt-guesser' ); ?> — <?php echo esc_html( $hunt->title ); ?></h1>
+  <h1 class="wp-heading-inline"><?php echo esc_html__( 'Close Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
   <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-400 bhg-margin-top-small">
 	<?php wp_nonce_field( 'bhg_close_hunt' ); ?>
 	<input type="hidden" name="action" value="bhg_close_hunt" />
@@ -237,7 +237,7 @@ if ($view === 'edit') :
 	);
 ?>
 <div class="wrap">
-  <h1 class="wp-heading-inline"><?php echo esc_html__('Edit Bonus Hunt', 'bonus-hunt-guesser'); ?> — <?php echo esc_html($hunt->title); ?></h1>
+  <h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 
   <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900 bhg-margin-top-small">
 	<?php wp_nonce_field('bhg_save_hunt'); ?>
@@ -290,7 +290,7 @@ if ($view === 'edit') :
 		</tr>
 		<tr>
 		  <th scope="row"><label for="bhg_final"><?php echo esc_html__('Final Balance', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr($hunt->final_balance); ?>" placeholder="—"></td>
+                  <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '—', 'bonus-hunt-guesser' ) ); ?>"></td>
 		</tr>
 		<tr>
 		  <th scope="row"><label for="bhg_status"><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></label></th>

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -49,13 +49,14 @@ $hunts = bhg_get_latest_closed_hunts( 3 );
 				  foreach ( $winners as $w ) {
 					  $u  = get_userdata( (int) $w->user_id );
 					  $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-					  $out[] = sprintf(
-						  '%s — %s (%s %s)',
-						  esc_html( $nm ),
-						  esc_html( number_format_i18n( (float) $w->guess, 2 ) ),
-						  esc_html__( 'diff', 'bonus-hunt-guesser' ),
-						  esc_html( number_format_i18n( (float) $w->diff, 2 ) )
-					  );
+                                          $out[] = sprintf(
+                                                  '%s %s %s (%s %s)',
+                                                  esc_html( $nm ),
+                                                  esc_html__( '—', 'bonus-hunt-guesser' ),
+                                                  esc_html( number_format_i18n( (float) $w->guess, 2 ) ),
+                                                  esc_html__( 'diff', 'bonus-hunt-guesser' ),
+                                                  esc_html( number_format_i18n( (float) $w->diff, 2 ) )
+                                          );
 				  }
 				  echo esc_html( implode( ' • ', $out ) );
 			  } else {
@@ -64,8 +65,8 @@ $hunts = bhg_get_latest_closed_hunts( 3 );
 			  ?>
 			</td>
 			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-			<td><?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : '—'; ?></td>
-			<td><?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : '—'; ?></td>
+                        <td><?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+                        <td><?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  </tr>
 		<?php endforeach; ?>
 	  <?php else : ?>

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -55,7 +55,7 @@ $pages = max(1, (int) ceil($total / $per_page));
 		<tr>
 		  <td><a href="<?php echo esc_url( admin_url('user-edit.php?user_id='.(int)$r->user_id) ); ?>"><?php echo esc_html($name); ?></a></td>
 		  <td><?php echo esc_html(number_format_i18n((float)$r->guess, 2)); ?></td>
-		  <td><?php echo $r->created_at ? esc_html(date_i18n(get_option('date_format').' '.get_option('time_format'), strtotime($r->created_at))) : '—'; ?></td>
+                  <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  <td>
 			<form method="post" style="display:inline">
 			  <?php wp_nonce_field('bhg_remove_guess_action','bhg_remove_guess_nonce'); ?>

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -44,10 +44,10 @@ $pages = max(1, (int) ceil($total / $per_page));
 		  <td><?php echo (int)$r->id; ?></td>
 		  <td><strong><a href="<?php echo esc_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id) ); ?>"><?php echo esc_html($r->title); ?></a></strong></td>
 		  <td><?php echo esc_html(number_format_i18n((float)$r->start_balance, 2)); ?></td>
-		  <td><?php echo ($r->final_balance !== null) ? esc_html(number_format_i18n((float)$r->final_balance, 2)) : '—'; ?></td>
+                  <td><?php echo ($r->final_balance !== null) ? esc_html( number_format_i18n( (float) $r->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  <td><?php echo esc_html($r->status); ?></td>
 		  <td><?php echo (int)$r->winners_limit; ?></td>
-		  <td><?php echo $r->closed_at ? esc_html(date_i18n(get_option('date_format').' '.get_option('time_format'), strtotime($r->closed_at))) : '—'; ?></td>
+                  <td><?php echo $r->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  <td>
 			<?php
 			  $results_url = wp_nonce_url( admin_url('admin.php?page=bhg-hunt-results&id='.(int)$r->id), 'bhg_view_results_'.(int)$r->id, 'bhg_nonce' );

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -336,7 +336,7 @@ echo '<a' . $class . ' href="' . esc_url( add_query_arg( array( 'page' => $p ), 
 					   }
 					   echo '<td>' . $guess_cell . '</td>';
 					   echo '<td>';
-					   echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : '&mdash;';
+                                           echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html__( '&mdash;', 'bonus-hunt-guesser' );
 					   echo '</td>';
 					   echo '</tr>';
 			   }
@@ -422,12 +422,12 @@ echo '<a' . $class . ' href="' . esc_url( add_query_arg( array( 'page' => $p ), 
 					   echo '<td>' . esc_html( $row->title ) . '</td>';
 					   echo '<td>' . esc_html( number_format_i18n( (float) $row->starting_balance, 2 ) ) . '</td>';
 					   echo '<td>';
-					   echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : '&mdash;';
-					   echo '</td>';
-					   echo '<td>' . esc_html( $row->status ) . '</td>';
-					   if ( $show_aff ) {
-							   echo '<td>' . esc_html( $row->aff_name ? $row->aff_name : '—' ) . '</td>';
-					   }
+                                           echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html__( '&mdash;', 'bonus-hunt-guesser' );
+                                           echo '</td>';
+                                           echo '<td>' . esc_html( $row->status ) . '</td>';
+                                           if ( $show_aff ) {
+                                                           echo '<td>' . ( $row->aff_name ? esc_html( $row->aff_name ) : esc_html__( '—', 'bonus-hunt-guesser' ) ) . '</td>';
+                                           }
 					   echo '</tr>';
 			   }
 			   echo '</tbody></table>';
@@ -606,7 +606,7 @@ echo '<td>' . esc_html( $row->user_login ?: sprintf(
                                        (int) $row->user_id
                                ) ) . '</td>';
 echo '<td>' . (int)$row->wins . '</td>';
-echo '<td>' . esc_html($row->last_win_date ? mysql2date(get_option('date_format'), $row->last_win_date) : '—') . '</td>';
+echo '<td>' . ( $row->last_win_date ? esc_html( mysql2date( get_option( 'date_format' ), $row->last_win_date ) ) : esc_html__( '—', 'bonus-hunt-guesser' ) ) . '</td>';
 				echo '</tr>';
 			}
 			echo '</tbody></table>';
@@ -766,7 +766,7 @@ echo '<td><a href="' . $detail_url . '">' . esc_html__('Show details','bonus-hun
 				foreach ( $winners as $w ) {
 					$u  = get_userdata( (int) $w->user_id );
 					$nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-					echo '<li>' . esc_html( $nm ) . ' — ' . esc_html( number_format_i18n( (float) $w->guess, 2 ) ) . ' (' . esc_html( number_format_i18n( (float) $w->diff, 2 ) ) . ')</li>';
+                                        echo '<li>' . esc_html( $nm ) . ' ' . esc_html__( '—', 'bonus-hunt-guesser' ) . ' ' . esc_html( number_format_i18n( (float) $w->guess, 2 ) ) . ' (' . esc_html( number_format_i18n( (float) $w->diff, 2 ) ) . ')</li>';
 				}
 				echo '</ul>';
 			}


### PR DESCRIPTION
## Summary
- Wrap standalone dashes with translation functions in Bonus Hunts admin views
- Localize dash placeholders in dashboard, hunts list/edit pages, and shortcode outputs
- Ensure winner placeholders use translatable em dashes

## Testing
- `php -l admin/views/bonus-hunts.php admin/views/dashboard.php admin/views/hunts-list.php admin/views/hunts-edit.php includes/class-bhg-shortcodes.php admin/class-bhg-admin.php`
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs admin/views/bonus-hunts.php admin/views/dashboard.php admin/views/hunts-list.php admin/views/hunts-edit.php includes/class-bhg-shortcodes.php admin/class-bhg-admin.php` *(fails: WordPress coding standards violations)*


------
https://chatgpt.com/codex/tasks/task_e_68bb28199eac83338892a32cf59ecc69