### PR TITLE
Sanitize checkbox inputs in admin handlers

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -342,7 +342,7 @@ class BHG_Admin {
 		$place    = isset( $_POST['placement'] ) ? sanitize_text_field( wp_unslash( $_POST['placement'] ) ) : 'none';
 		$visible  = isset( $_POST['visible_to'] ) ? sanitize_text_field( wp_unslash( $_POST['visible_to'] ) ) : 'all';
 		$targets  = isset( $_POST['target_pages'] ) ? sanitize_text_field( wp_unslash( $_POST['target_pages'] ) ) : '';
-		$active   = isset($_POST['active']) ? 1 : 0;
+               $active   = isset( $_POST['active'] ) ? absint( wp_unslash( $_POST['active'] ) ) : 0;
 
 		$data = [
 			'title'        => $title,
@@ -488,7 +488,7 @@ class BHG_Admin {
 		$user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;
 		if ( $user_id ) {
 			$real_name    = isset( $_POST['bhg_real_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bhg_real_name'] ) ) : '';
-			$is_affiliate = isset( $_POST['bhg_is_affiliate'] ) ? 1 : 0;
+                       $is_affiliate = isset( $_POST['bhg_is_affiliate'] ) ? absint( wp_unslash( $_POST['bhg_is_affiliate'] ) ) : 0;
 			update_user_meta( $user_id, 'bhg_real_name', $real_name );
 			update_user_meta( $user_id, 'bhg_is_affiliate', $is_affiliate );
 		}


### PR DESCRIPTION
## Summary
- ensure ad activation flag sanitized via `wp_unslash` and `absint`
- sanitize affiliate status checkbox before storing user meta

## Testing
- `phpcs admin/class-bhg-admin.php` *(fails: numerous pre-existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2a825d888333ad3ac12748c893ba