### PR TITLE
Localize admin status strings

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -28,8 +28,24 @@ if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
 
 // Fetch ads
 $ads = $wpdb->get_results(
-	"SELECT * FROM {$table} ORDER BY id DESC"
+        "SELECT * FROM {$table} ORDER BY id DESC"
 );
+
+$placement_labels = [
+        'none'      => __( 'None', 'bonus-hunt-guesser' ),
+        'footer'    => __( 'Footer', 'bonus-hunt-guesser' ),
+        'bottom'    => __( 'Bottom', 'bonus-hunt-guesser' ),
+        'sidebar'   => __( 'Sidebar', 'bonus-hunt-guesser' ),
+        'shortcode' => __( 'Shortcode', 'bonus-hunt-guesser' ),
+];
+
+$visible_labels = [
+        'all'            => __( 'All', 'bonus-hunt-guesser' ),
+        'guests'         => __( 'Guests', 'bonus-hunt-guesser' ),
+        'logged_in'      => __( 'Logged In', 'bonus-hunt-guesser' ),
+        'affiliates'     => __( 'Affiliates', 'bonus-hunt-guesser' ),
+        'non_affiliates' => __( 'Non Affiliates', 'bonus-hunt-guesser' ),
+];
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Advertising', 'bonus-hunt-guesser'); ?></h1>
@@ -53,8 +69,14 @@ $ads = $wpdb->get_results(
 		<tr>
 		  <td><?php echo (int)$ad->id; ?></td>
 		  <td><?php echo isset($ad->title) && $ad->title !== '' ? esc_html($ad->title) : wp_kses_post(wp_trim_words($ad->content, 12)); ?></td>
-		  <td><?php echo esc_html(isset($ad->placement)? $ad->placement : 'none'); ?></td>
-		  <td><?php echo esc_html(isset($ad->visible_to)? $ad->visible_to : 'all'); ?></td>
+                  <td><?php
+                        $pl = isset( $ad->placement ) ? ( $placement_labels[ $ad->placement ] ?? $ad->placement ) : $placement_labels['none'];
+                        echo esc_html( $pl );
+                  ?></td>
+                  <td><?php
+                        $vis = isset( $ad->visible_to ) ? ( $visible_labels[ $ad->visible_to ] ?? $ad->visible_to ) : $visible_labels['all'];
+                        echo esc_html( $vis );
+                  ?></td>
 		  <td><?php echo (int)$ad->active === 1 ? esc_html__('Yes','bonus-hunt-guesser') : esc_html__('No','bonus-hunt-guesser'); ?></td>
 		  <td>
 			<a class="button" href="<?php echo esc_url(add_query_arg(['edit'=> (int)$ad->id])); ?>"><?php echo esc_html__('Edit', 'bonus-hunt-guesser'); ?></a>
@@ -100,19 +122,12 @@ $ads = $wpdb->get_results(
 		  <td>
 			<select id="bhg_ad_place" name="placement">
 			  <?php
-				$placement_opts   = ['none', 'footer', 'bottom', 'sidebar', 'shortcode'];
-				$placement_labels = [
-					'none'      => __('None', 'bonus-hunt-guesser'),
-					'footer'    => __('Footer', 'bonus-hunt-guesser'),
-					'bottom'    => __('Bottom', 'bonus-hunt-guesser'),
-					'sidebar'   => __('Sidebar', 'bonus-hunt-guesser'),
-					'shortcode' => __('Shortcode', 'bonus-hunt-guesser'),
-				];
-				$sel = $ad ? ($ad->placement ?? 'none') : 'none';
-				foreach ( $placement_opts as $o ) {
-					$label = $placement_labels[ $o ] ?? $o;
-					echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
-				}
+                                $placement_opts = array_keys( $placement_labels );
+                                $sel            = $ad ? ( $ad->placement ?? 'none' ) : 'none';
+                                foreach ( $placement_opts as $o ) {
+                                        $label = $placement_labels[ $o ] ?? $o;
+                                        echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
+                                }
 			  ?>
 			</select>
 		  </td>
@@ -122,19 +137,12 @@ $ads = $wpdb->get_results(
 		  <td>
 			<select id="bhg_ad_vis" name="visible_to">
 			  <?php
-				$visible_opts   = ['all', 'guests', 'logged_in', 'affiliates', 'non_affiliates'];
-				$visible_labels = [
-					'all'            => __('All', 'bonus-hunt-guesser'),
-					'guests'         => __('Guests', 'bonus-hunt-guesser'),
-					'logged_in'      => __('Logged In', 'bonus-hunt-guesser'),
-					'affiliates'     => __('Affiliates', 'bonus-hunt-guesser'),
-					'non_affiliates' => __('Non Affiliates', 'bonus-hunt-guesser'),
-				];
-				$sel = $ad ? ($ad->visible_to ?? 'all') : 'all';
-				foreach ( $visible_opts as $o ) {
-					$label = $visible_labels[ $o ] ?? $o;
-					echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
-				}
+                                $visible_opts = array_keys( $visible_labels );
+                                $sel          = $ad ? ( $ad->visible_to ?? 'all' ) : 'all';
+                                foreach ( $visible_opts as $o ) {
+                                        $label = $visible_labels[ $o ] ?? $o;
+                                        echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
+                                }
 			  ?>
 			</select>
 		  </td>

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -12,6 +12,11 @@ $row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$table` WHERE id
 
 // List
 $rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
+
+$status_labels = [
+        'active'   => __( 'Active', 'bonus-hunt-guesser' ),
+        'inactive' => __( 'Inactive', 'bonus-hunt-guesser' ),
+];
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Affiliates', 'bonus-hunt-guesser'); ?></h1>
@@ -35,7 +40,7 @@ $rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 		  <td><?php echo (int)$r->id; ?></td>
 		  <td><?php echo esc_html($r->name); ?></td>
 		  <td><?php echo esc_html($r->url); ?></td>
-		  <td><?php echo esc_html($r->status); ?></td>
+                  <td><?php echo esc_html( $status_labels[ $r->status ] ?? $r->status ); ?></td>
 		  <td>
 			<a class="button" href="<?php echo esc_url(add_query_arg(['edit'=>(int)$r->id])); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
 			<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline" onsubmit="return confirm('<?php echo esc_js(__('Delete this affiliate?', 'bonus-hunt-guesser')); ?>');">
@@ -68,9 +73,9 @@ $rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 		<th><label for="aff_status"><?php esc_html_e('Status','bonus-hunt-guesser'); ?></label></th>
 		<td>
 		  <select id="aff_status" name="status">
-			<?php $opts=['active','inactive']; $cur = $row->status ?? 'active'; foreach ($opts as $o): ?>
-			  <option value="<?php echo esc_attr($o); ?>" <?php selected($cur, $o); ?>><?php echo esc_html(ucfirst($o)); ?></option>
-			<?php endforeach; ?>
+                        <?php $opts = array_keys( $status_labels ); $cur = $row->status ?? 'active'; foreach ( $opts as $o ) : ?>
+                          <option value="<?php echo esc_attr( $o ); ?>" <?php selected( $cur, $o ); ?>><?php echo esc_html( $status_labels[ $o ] ); ?></option>
+                        <?php endforeach; ?>
 		  </select>
 		</td>
 	  </tr>

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -40,6 +40,11 @@ if ( 'list' === $view ) :
                 )
         );
 
+        $status_labels = [
+                'open'   => __( 'Open', 'bonus-hunt-guesser' ),
+                'closed' => __( 'Closed', 'bonus-hunt-guesser' ),
+        ];
+
         $total    = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$hunts_table}" );
         $base_url = remove_query_arg( [ 'paged' ] );
 ?>
@@ -73,7 +78,7 @@ if ( 'list' === $view ) :
 		  <td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
                   <td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  <td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
-		  <td><?php echo esc_html( $h->status ); ?></td>
+                  <td><?php echo esc_html( $status_labels[ $h->status ] ?? $h->status ); ?></td>
 		  <td>
 			<a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Edit', 'bonus-hunt-guesser' ); ?></a>
 			<?php if ( 'open' === $h->status ) : ?>

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -83,7 +83,7 @@ function bhg_insert_demo_data() {
 	$wpdb->insert(
 		$wpdb->prefix . 'bhg_bonus_hunts',
 		array(
-			'title' => 'Demo Bonus Hunt',
+                        'title' => __( 'Demo Bonus Hunt', 'bonus-hunt-guesser' ),
 			'starting_balance' => 2000,
 			'number_of_bonuses' => 10,
 			'status' => 'active',

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -22,6 +22,11 @@ $rows = $wpdb->get_results(
 $total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $t" );
 $pages = max(1, (int) ceil($total / $per_page));
 
+$status_labels = [
+        'open'   => __( 'Open', 'bonus-hunt-guesser' ),
+        'closed' => __( 'Closed', 'bonus-hunt-guesser' ),
+];
+
 ?>
 <div class="wrap">
   <h1><?php esc_html_e('Bonus Hunts','bonus-hunt-guesser'); ?></h1>
@@ -45,7 +50,7 @@ $pages = max(1, (int) ceil($total / $per_page));
 		  <td><strong><a href="<?php echo esc_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id) ); ?>"><?php echo esc_html($r->title); ?></a></strong></td>
 		  <td><?php echo esc_html(number_format_i18n((float)$r->start_balance, 2)); ?></td>
                   <td><?php echo ($r->final_balance !== null) ? esc_html( number_format_i18n( (float) $r->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-		  <td><?php echo esc_html($r->status); ?></td>
+                  <td><?php echo esc_html( $status_labels[ $r->status ] ?? $r->status ); ?></td>
 		  <td><?php echo (int)$r->winners_limit; ?></td>
                   <td><?php echo $r->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  <td>

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -23,7 +23,12 @@ $labels = [
 	'monthly'   => __( 'Monthly', 'bonus-hunt-guesser' ),
 	'quarterly' => __( 'Quarterly', 'bonus-hunt-guesser' ),
 	'yearly'    => __( 'Yearly', 'bonus-hunt-guesser' ),
-	'alltime'   => __( 'Alltime', 'bonus-hunt-guesser' ),
+        'alltime'   => __( 'Alltime', 'bonus-hunt-guesser' ),
+];
+
+$status_labels = [
+        'active'   => __( 'Active', 'bonus-hunt-guesser' ),
+        'archived' => __( 'Archived', 'bonus-hunt-guesser' ),
 ];
 ?>
 <div class="wrap">
@@ -52,7 +57,7 @@ $labels = [
 		  <td><?php echo esc_html( $labels[ $r->type ] ?? $r->type ); ?></td>
 		  <td><?php echo esc_html($r->start_date); ?></td>
 		  <td><?php echo esc_html($r->end_date); ?></td>
-		  <td><?php echo esc_html($r->status); ?></td>
+                  <td><?php echo esc_html( $status_labels[ $r->status ] ?? $r->status ); ?></td>
 		  <td>
 			<a class="button" href="<?php echo esc_url(add_query_arg(['edit' => (int)$r->id])); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
 		  </td>
@@ -100,15 +105,15 @@ $labels = [
 	  <tr>
 		<th><label for="bhg_t_status"><?php esc_html_e('Status','bonus-hunt-guesser'); ?></label></th>
 		<td>
-		  <?php $st = ['active','archived']; $cur = $row->status ?? 'active'; ?>
-		  <select id="bhg_t_status" name="status">
-			<?php foreach ($st as $v): ?>
-			  <option value="<?php echo esc_attr($v); ?>" <?php selected($cur, $v); ?>><?php echo esc_html(ucfirst($v)); ?></option>
-			<?php endforeach; ?>
-		  </select>
-		</td>
-	  </tr>
-	</table>
+                  <?php $st = array_keys( $status_labels ); $cur = $row->status ?? 'active'; ?>
+                  <select id="bhg_t_status" name="status">
+                        <?php foreach ( $st as $v ) : ?>
+                          <option value="<?php echo esc_attr( $v ); ?>" <?php selected( $cur, $v ); ?>><?php echo esc_html( $status_labels[ $v ] ); ?></option>
+                        <?php endforeach; ?>
+                  </select>
+                </td>
+          </tr>
+        </table>
 	<?php submit_button($row ? __('Update Tournament','bonus-hunt-guesser') : __('Create Tournament','bonus-hunt-guesser')); ?>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- localize placement and visibility values in advertising admin
- translate affiliate website status labels
- map bonus hunt and tournament statuses through translatable labels
- wrap default demo hunt title with translation helper

## Testing
- `phpcs --standard=WordPress admin/views/advertising.php` *(fails: 214 errors, 57 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2a862b3c8333b1d7d722a1ce470f