### PR TITLE
Rename dashboard submenu and show recent hunts

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -49,21 +49,20 @@ class BHG_Admin {
 		add_submenu_page($slug, __('Translations', 'bonus-hunt-guesser'),__('Translations', 'bonus-hunt-guesser'),$cap, 'bhg-translations',            [$this, 'translations']);
 		add_submenu_page($slug, __('Database', 'bonus-hunt-guesser'),    __('Database', 'bonus-hunt-guesser'),    $cap, 'bhg-database',                [$this, 'database']);
 		add_submenu_page($slug, __('Settings', 'bonus-hunt-guesser'),    __('Settings', 'bonus-hunt-guesser'),    $cap, 'bhg-settings',                [$this, 'settings']);
-		add_submenu_page(
-			$slug,
-			__('BHG Tools', 'bonus-hunt-guesser'),
-			__('BHG Tools', 'bonus-hunt-guesser'),
-			$cap,
-			'bhg-tools',
-			[$this, 'bhg_tools_page']
-		);
+                add_submenu_page(
+                        $slug,
+                        __('BHG Tools', 'bonus-hunt-guesser'),
+                        __('BHG Tools', 'bonus-hunt-guesser'),
+                        $cap,
+                        'bhg-tools',
+                        [$this, 'bhg_tools_page']
+                );
 
-		// NOTE: By default, WordPress adds a submenu item that duplicates the
-		// top-level “Bonus Hunt” menu. The previous `remove_submenu_page()`
-		// call removed this submenu, but it also inadvertently removed our
-		// custom “Dashboard” submenu. Removing the call ensures the Dashboard
-		// item remains visible under the "Bonus Hunt" menu.
-	}
+                // WordPress automatically adds a submenu item that duplicates the
+                // top-level "Bonus Hunt" menu. Remove that default item so the first
+                // submenu is the custom "Dashboard" page.
+                remove_submenu_page( $slug, $slug );
+        }
 
 	/** Enqueue admin assets on BHG screens. */
 	public function assets( $hook ) {

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -25,7 +25,7 @@ $hunts = bhg_get_latest_closed_hunts( 3 );
   <table class="widefat striped">
 	<thead>
 	  <tr>
-		<th><?php esc_html_e( 'Bonushunt', 'bonus-hunt-guesser' ); ?></th>
+                <th><?php esc_html_e( 'Bonus Hunt', 'bonus-hunt-guesser' ); ?></th>
 		<th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
 		<th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
 		<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>


### PR DESCRIPTION
## Summary
- Ensure Bonus Hunt menu shows custom Dashboard submenu and hide default duplicate
- Label dashboard table column as "Bonus Hunt" when listing recent hunts

## Testing
- `phpcs admin/class-bhg-admin.php admin/views/dashboard.php` *(fails: Referenced sniff "Generic.Strings.UnnecessaryHeredoc" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2a86c1e88333b1fc5f924acf534e