### PR TITLE
Add paginated hunt editor and results button

### DIFF
--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -1,0 +1,145 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! current_user_can( 'manage_options' ) ) {
+        wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
+}
+
+global $wpdb;
+
+$id   = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
+$hunt = bhg_get_hunt( $id );
+if ( ! $hunt ) {
+        echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt', 'bonus-hunt-guesser' ) . '</p></div>';
+        return;
+}
+
+$aff_table = $wpdb->prefix . 'bhg_affiliates';
+if ( isset( $allowed_tables ) && ! in_array( $aff_table, $allowed_tables, true ) ) {
+        wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+}
+$aff_table = esc_sql( $aff_table );
+$affs      = $wpdb->get_results( "SELECT id, name FROM {$aff_table} ORDER BY name ASC" );
+$sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+
+$paged    = max( 1, isset( $_GET['ppaged'] ) ? (int) wp_unslash( $_GET['ppaged'] ) : 1 );
+$per_page = 30;
+$data     = bhg_get_hunt_participants( $id, $paged, $per_page );
+$rows     = $data['rows'];
+$total    = (int) $data['total'];
+$pages    = max( 1, (int) ceil( $total / $per_page ) );
+$base     = remove_query_arg( 'ppaged' );
+?>
+<div class="wrap">
+  <h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
+
+  <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
+        <?php wp_nonce_field( 'bhg_save_hunt' ); ?>
+        <input type="hidden" name="action" value="bhg_save_hunt" />
+        <input type="hidden" name="id" value="<?php echo (int) $hunt->id; ?>" />
+
+        <table class="form-table" role="presentation">
+          <tbody>
+                <tr>
+                  <th scope="row"><label for="bhg_title"><?php echo esc_html__( 'Title', 'bonus-hunt-guesser' ); ?></label></th>
+                  <td><input required class="regular-text" id="bhg_title" name="title" value="<?php echo esc_attr( $hunt->title ); ?>"></td>
+                </tr>
+                <tr>
+                  <th scope="row"><label for="bhg_starting"><?php echo esc_html__( 'Starting Balance', 'bonus-hunt-guesser' ); ?></label></th>
+                  <td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value="<?php echo esc_attr( $hunt->starting_balance ); ?>"></td>
+                </tr>
+                <tr>
+                  <th scope="row"><label for="bhg_num"><?php echo esc_html__( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></label></th>
+                  <td><input type="number" min="0" id="bhg_num" name="num_bonuses" value="<?php echo esc_attr( $hunt->num_bonuses ); ?>"></td>
+                </tr>
+                <tr>
+                  <th scope="row"><label for="bhg_prizes"><?php echo esc_html__( 'Prizes', 'bonus-hunt-guesser' ); ?></label></th>
+                  <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"><?php echo esc_textarea( $hunt->prizes ); ?></textarea></td>
+                </tr>
+                <tr>
+                  <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__( 'Affiliate Site', 'bonus-hunt-guesser' ); ?></label></th>
+                  <td>
+                        <select id="bhg_affiliate" name="affiliate_site_id">
+                          <option value="0"><?php echo esc_html__( 'None', 'bonus-hunt-guesser' ); ?></option>
+                          <?php foreach ( $affs as $a ) : ?>
+                                <option value="<?php echo (int) $a->id; ?>" <?php selected( $sel, (int) $a->id ); ?>><?php echo esc_html( $a->name ); ?></option>
+                          <?php endforeach; ?>
+                        </select>
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row"><label for="bhg_winners"><?php echo esc_html__( 'Number of Winners', 'bonus-hunt-guesser' ); ?></label></th>
+                  <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
+                </tr>
+                <tr>
+                  <th scope="row"><label for="bhg_final"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>
+                  <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '—', 'bonus-hunt-guesser' ) ); ?>"></td>
+                </tr>
+                <tr>
+                  <th scope="row"><label for="bhg_status"><?php echo esc_html__( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
+                  <td>
+                        <select id="bhg_status" name="status">
+                          <option value="open" <?php selected( $hunt->status, 'open' ); ?>><?php echo esc_html__( 'Open', 'bonus-hunt-guesser' ); ?></option>
+                          <option value="closed" <?php selected( $hunt->status, 'closed' ); ?>><?php echo esc_html__( 'Closed', 'bonus-hunt-guesser' ); ?></option>
+                        </select>
+                  </td>
+                </tr>
+          </tbody>
+        </table>
+        <?php submit_button( __( 'Save Hunt', 'bonus-hunt-guesser' ) ); ?>
+  </form>
+
+  <h2 class="bhg-margin-top-large"><?php esc_html_e( 'Participants', 'bonus-hunt-guesser' ); ?></h2>
+  <p><?php echo esc_html( sprintf( _n( '%s participant', '%s participants', $total, 'bonus-hunt-guesser' ), number_format_i18n( $total ) ) ); ?></p>
+
+  <table class="widefat striped">
+        <thead>
+          <tr>
+                <th><?php esc_html_e( 'User', 'bonus-hunt-guesser' ); ?></th>
+                <th><?php esc_html_e( 'Guess', 'bonus-hunt-guesser' ); ?></th>
+                <th><?php esc_html_e( 'Date', 'bonus-hunt-guesser' ); ?></th>
+                <th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php if ( empty( $rows ) ) : ?>
+                <tr><td colspan="4"><?php esc_html_e( 'No participants yet.', 'bonus-hunt-guesser' ); ?></td></tr>
+          <?php else : foreach ( $rows as $r ) :
+                $u    = get_userdata( (int) $r->user_id );
+                $name = $u ? $u->display_name : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
+          ?>
+                <tr>
+                  <td><a href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . (int) $r->user_id ) ); ?>"><?php echo esc_html( $name ); ?></a></td>
+                  <td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
+                  <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+                  <td>
+                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( __( 'Delete this guess?', 'bonus-hunt-guesser' ) ); ?>');" class="bhg-inline-form">
+                          <?php wp_nonce_field( 'bhg_delete_guess' ); ?>
+                          <input type="hidden" name="action" value="bhg_delete_guess">
+                          <input type="hidden" name="guess_id" value="<?php echo (int) $r->id; ?>">
+                          <button type="submit" class="button-link-delete"><?php esc_html_e( 'Remove', 'bonus-hunt-guesser' ); ?></button>
+                        </form>
+                  </td>
+                </tr>
+          <?php endforeach; endif; ?>
+        </tbody>
+  </table>
+
+  <?php if ( $pages > 1 ) : ?>
+        <div class="tablenav">
+          <div class="tablenav-pages">
+                <?php
+                echo paginate_links(
+                        [
+                                'base'      => add_query_arg( 'ppaged', '%#%', $base ),
+                                'format'    => '',
+                                'prev_text' => '&laquo;',
+                                'next_text' => '&raquo;',
+                                'total'     => $pages,
+                                'current'   => $paged,
+                        ]
+                );
+                ?>
+          </div>
+        </div>
+  <?php endif; ?>
+</div>

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -26,6 +26,11 @@ $guesses_table = esc_sql( $guesses_table );
 
 $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
 
+if ( 'edit' === $view ) {
+        require __DIR__ . '/bonus-hunts-edit.php';
+        return;
+}
+
 /** LIST VIEW */
 if ( 'list' === $view ) :
         $current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
@@ -76,11 +81,11 @@ if ( 'list' === $view ) :
 		  <td><?php echo esc_html( $h->status ); ?></td>
 		  <td>
 			<a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Edit', 'bonus-hunt-guesser' ); ?></a>
-			<?php if ( 'open' === $h->status ) : ?>
-			  <a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'close', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
-			<?php elseif ( $h->final_balance !== null ) : ?>
-			  <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
-			<?php endif; ?>
+                        <?php if ( 'open' === $h->status ) : ?>
+                          <a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'close', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
+                        <?php elseif ( 'closed' === $h->status && null !== $h->final_balance ) : ?>
+                          <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
+                        <?php endif; ?>
 		  </td>
 		</tr>
           <?php endforeach; endif; ?>
@@ -210,136 +215,5 @@ if ($view === 'add') : ?>
 	</table>
 	<?php submit_button(__('Create Bonus Hunt', 'bonus-hunt-guesser')); ?>
   </form>
-</div>
-<?php endif; ?>
-
-<?php
-/** EDIT VIEW */
-if ($view === 'edit') :
-        $id    = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
-	$hunt  = $wpdb->get_row(
-		$wpdb->prepare( "SELECT * FROM {$hunts_table} WHERE id = %d", $id )
-	);
-	if (!$hunt) {
-		echo '<div class="notice notice-error"><p>'.esc_html__('Invalid hunt', 'bonus-hunt-guesser').'</p></div>';
-		return;
-	}
-	$users_table = $wpdb->users;
-	if ( ! in_array( $users_table, $allowed_tables, true ) ) {
-		wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
-	}
-	$users_table = esc_sql( $users_table );
-	$guesses     = $wpdb->get_results(
-		$wpdb->prepare(
-			"SELECT g.*, u.display_name FROM {$guesses_table} g LEFT JOIN {$users_table} u ON u.ID = g.user_id WHERE g.hunt_id = %d ORDER BY g.id ASC",
-			$id
-		)
-	);
-?>
-<div class="wrap">
-  <h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
-
-  <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-	<?php wp_nonce_field('bhg_save_hunt'); ?>
-	<input type="hidden" name="action" value="bhg_save_hunt" />
-	<input type="hidden" name="id" value="<?php echo (int)$hunt->id; ?>" />
-
-	<table class="form-table" role="presentation">
-	  <tbody>
-		<tr>
-		  <th scope="row"><label for="bhg_title"><?php echo esc_html__('Title', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input required class="regular-text" id="bhg_title" name="title" value="<?php echo esc_attr($hunt->title); ?>"></td>
-		</tr>
-		<tr>
-		  <th scope="row"><label for="bhg_starting"><?php echo esc_html__('Starting Balance', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value="<?php echo esc_attr($hunt->starting_balance); ?>"></td>
-		</tr>
-		<tr>
-		  <th scope="row"><label for="bhg_num"><?php echo esc_html__('Number of Bonuses', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" min="0" id="bhg_num" name="num_bonuses" value="<?php echo esc_attr($hunt->num_bonuses); ?>"></td>
-		</tr>
-		<tr>
-		  <th scope="row"><label for="bhg_prizes"><?php echo esc_html__('Prizes', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"><?php echo esc_textarea($hunt->prizes); ?></textarea></td>
-		</tr>
-		<tr>
-		  <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__('Affiliate Site', 'bonus-hunt-guesser'); ?></label></th>
-		  <td>
-			<?php
-			$aff_table = $wpdb->prefix . 'bhg_affiliates';
-			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
-				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
-			}
-			$aff_table = esc_sql( $aff_table );
-			$affs      = $wpdb->get_results(
-				"SELECT id, name FROM {$aff_table} ORDER BY name ASC"
-			);
-			$sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
-			?>
-			<select id="bhg_affiliate" name="affiliate_site_id">
-			  <option value="0"><?php echo esc_html__('None', 'bonus-hunt-guesser'); ?></option>
-			  <?php foreach ($affs as $a): ?>
-				<option value="<?php echo (int)$a->id; ?>" <?php if ($sel === (int)$a->id) echo 'selected'; ?>><?php echo esc_html($a->name); ?></option>
-			  <?php endforeach; ?>
-			</select>
-		  </td>
-		</tr>
-		<tr>
-		  <th scope="row"><label for="bhg_winners"><?php echo esc_html__('Number of Winners', 'bonus-hunt-guesser'); ?></label></th>
-		  <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr($hunt->winners_count ?: 3); ?>"></td>
-		</tr>
-		<tr>
-		  <th scope="row"><label for="bhg_final"><?php echo esc_html__('Final Balance', 'bonus-hunt-guesser'); ?></label></th>
-                  <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '—', 'bonus-hunt-guesser' ) ); ?>"></td>
-		</tr>
-		<tr>
-		  <th scope="row"><label for="bhg_status"><?php echo esc_html__('Status', 'bonus-hunt-guesser'); ?></label></th>
-		  <td>
-			<select id="bhg_status" name="status">
-			  <option value="open" <?php selected($hunt->status, 'open'); ?>><?php echo esc_html__('Open', 'bonus-hunt-guesser'); ?></option>
-			  <option value="closed" <?php selected($hunt->status, 'closed'); ?>><?php echo esc_html__('Closed', 'bonus-hunt-guesser'); ?></option>
-			</select>
-		  </td>
-		</tr>
-	  </tbody>
-	</table>
-	<?php submit_button(__('Save Hunt', 'bonus-hunt-guesser')); ?>
-  </form>
-
-  <h2 class="bhg-margin-top-large"><?php echo esc_html__('Participants', 'bonus-hunt-guesser'); ?></h2>
-  <table class="widefat striped">
-	<thead>
-	  <tr>
-		<th><?php echo esc_html__('User', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Guess', 'bonus-hunt-guesser'); ?></th>
-		<th><?php echo esc_html__('Actions', 'bonus-hunt-guesser'); ?></th>
-	  </tr>
-	</thead>
-	<tbody>
-	  <?php if (empty($guesses)) : ?>
-		<tr><td colspan="3"><?php echo esc_html__('No participants yet.', 'bonus-hunt-guesser'); ?></td></tr>
-	  <?php else : foreach ($guesses as $g) : ?>
-		<tr>
-		  <td>
-			<?php
-                          /* translators: %d: user ID. */
-                          $name = $g->display_name ? $g->display_name : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $g->user_id );
-			  $url  = admin_url('user-edit.php?user_id=' . (int)$g->user_id);
-			  echo '<a href="' . esc_url($url) . '">' . esc_html($name) . '</a>';
-			?>
-		  </td>
-		  <td><?php echo esc_html(number_format_i18n((float)($g->guess ?? 0), 2)); ?></td>
-		  <td>
-			<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" onsubmit="return confirm('<?php echo esc_js(__('Delete this guess?', 'bonus-hunt-guesser')); ?>');" class="bhg-inline-form">
-			  <?php wp_nonce_field('bhg_delete_guess'); ?>
-			  <input type="hidden" name="action" value="bhg_delete_guess">
-			  <input type="hidden" name="guess_id" value="<?php echo (int)$g->id; ?>">
-			  <button type="submit" class="button-link-delete"><?php echo esc_html__('Remove', 'bonus-hunt-guesser'); ?></button>
-			</form>
-		  </td>
-		</tr>
-	  <?php endforeach; endif; ?>
-	</tbody>
-  </table>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- show final balance and conditional results link on hunt list
- introduce dedicated edit view with paginated participant management
- include winners limit field when creating or editing hunts

## Testing
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs admin/views/bonus-hunts.php admin/views/bonus-hunts-edit.php` *(fails: numerous WordPress coding standard warnings/errors)*


------
https://chatgpt.com/codex/tasks/task_e_68bb2a8858b483338c39c3f39bed7d95