### PR TITLE
Add edit/delete controls for ads and support "none" placement

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -335,14 +335,18 @@ class BHG_Admin {
 		global $wpdb;
 		$table = $wpdb->prefix . 'bhg_ads';
 
-		$id       = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-		$title    = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
-		$content  = isset( $_POST['content'] ) ? wp_kses_post( wp_unslash( $_POST['content'] ) ) : '';
-		$link     = isset( $_POST['link_url'] ) ? esc_url_raw( wp_unslash( $_POST['link_url'] ) ) : '';
-		$place    = isset( $_POST['placement'] ) ? sanitize_text_field( wp_unslash( $_POST['placement'] ) ) : 'none';
-		$visible  = isset( $_POST['visible_to'] ) ? sanitize_text_field( wp_unslash( $_POST['visible_to'] ) ) : 'all';
-		$targets  = isset( $_POST['target_pages'] ) ? sanitize_text_field( wp_unslash( $_POST['target_pages'] ) ) : '';
-		$active   = isset($_POST['active']) ? 1 : 0;
+                $id       = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+                $title    = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
+                $content  = isset( $_POST['content'] ) ? wp_kses_post( wp_unslash( $_POST['content'] ) ) : '';
+                $link     = isset( $_POST['link_url'] ) ? esc_url_raw( wp_unslash( $_POST['link_url'] ) ) : '';
+                $place    = isset( $_POST['placement'] ) ? sanitize_text_field( wp_unslash( $_POST['placement'] ) ) : 'none';
+                $allowed_places = array( 'none', 'footer', 'bottom', 'sidebar', 'shortcode' );
+                if ( ! in_array( $place, $allowed_places, true ) ) {
+                        $place = 'none';
+                }
+                $visible  = isset( $_POST['visible_to'] ) ? sanitize_text_field( wp_unslash( $_POST['visible_to'] ) ) : 'all';
+                $targets  = isset( $_POST['target_pages'] ) ? sanitize_text_field( wp_unslash( $_POST['target_pages'] ) ) : '';
+                $active   = isset( $_POST['active'] ) ? 1 : 0;
 
 		$data = [
 			'title'        => $title,


### PR DESCRIPTION
## Summary
- show edit and delete buttons in advertising admin list
- allow ads to be saved without placement via new "none" option

## Testing
- `php -l admin/views/advertising.php`
- `php -l admin/class-bhg-admin.php`
- `phpcs admin/class-bhg-admin.php admin/views/advertising.php` *(fails: numerous WordPress coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2a8b86bc833384d548943511c14e