### PR TITLE
Add translation editing and refine demo tools

### DIFF
--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -1,55 +1,59 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+/**
+ * Demo data seeding utilities.
+ *
+ * @package BonusHuntGuesser
+ */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles demo reseeding actions.
+ */
 class BHG_Demo {
+	/**
+	 * Register handlers for demo reseeding.
+	 */
 	public function __construct() {
-		add_action('admin_menu', [$this,'demo_menu']);
-		add_action('admin_post_bhg_demo_reseed', [$this,'reseed']);
+		add_action( 'admin_post_bhg_demo_reseed', array( $this, 'reseed' ) );
 	}
 
-	public function demo_menu() {
-		add_submenu_page(
-			'bhg_dashboard',
-			__('Demo Tools','bonus-hunt-guesser'),
-			__('Demo Tools','bonus-hunt-guesser'),
-			'manage_options',
-			'bhg_demo',
-			[$this,'render_demo']
+	/**
+	 * Reseed demo data.
+	 *
+	 * @return void
+	 */
+	public function reseed() {
+		check_admin_referer( 'bhg_demo_reseed' );
+		global $wpdb;
+
+		// Wipe demo data.
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}bhg_bonus_hunts WHERE title LIKE '%(Demo)%'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( "DELETE FROM {$wpdb->prefix}bhg_tournaments WHERE title LIKE '%(Demo)%'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		// Insert demo hunt.
+		$wpdb->insert(
+			"{$wpdb->prefix}bhg_bonus_hunts",
+			array(
+				'title'            => 'Sample Hunt (Demo)',
+				'starting_balance' => 1000,
+				'num_bonuses'      => 5,
+				'status'           => 'open',
+			)
 		);
-	}
 
-	public function render_demo() {
-		echo '<div class="wrap"><h1>Demo Tools</h1>';
-               echo '<form method="post" action="'.admin_url('admin-post.php').'">';
-               echo '<input type="hidden" name="action" value="bhg_demo_reseed" />';
-               wp_nonce_field( 'bhg_demo_reseed' );
-               submit_button(__('Reset & Reseed Demo','bonus-hunt-guesser'));
-               echo '</form></div>';
-       }
+		// Insert demo tournament.
+		$wpdb->insert(
+			"{$wpdb->prefix}bhg_tournaments",
+			array(
+				'title'  => 'August Tournament (Demo)',
+				'status' => 'active',
+			)
+		);
 
-       public function reseed() {
-               check_admin_referer( 'bhg_demo_reseed' );
-               global $wpdb;
-
-               // Wipe demo data
-               $wpdb->query( "DELETE FROM {$wpdb->prefix}bhg_bonus_hunts WHERE title LIKE '%(Demo)%'" );
-               $wpdb->query( "DELETE FROM {$wpdb->prefix}bhg_tournaments WHERE title LIKE '%(Demo)%'" );
-
-		// Insert demo hunt
-		$wpdb->insert("{$wpdb->prefix}bhg_bonus_hunts",[
-			'title'=>'Sample Hunt (Demo)',
-			'starting_balance'=>1000,
-			'num_bonuses'=>5,
-			'status'=>'open'
-		]);
-
-		// Insert demo tournament
-		$wpdb->insert("{$wpdb->prefix}bhg_tournaments",[
-			'title'=>'August Tournament (Demo)',
-			'status'=>'active'
-		]);
-
-		wp_safe_redirect( admin_url( 'admin.php?page=bhg_demo&demo_reset=1' ) );
+		wp_safe_redirect( admin_url( 'admin.php?page=bhg-tools&demo_reset=1' ) );
 		exit;
 	}
 }

--- a/admin/views/demo-tools.php
+++ b/admin/views/demo-tools.php
@@ -1,14 +1,33 @@
 <?php
-if (!defined('ABSPATH')) {
+/**
+ * Demo tools view.
+ *
+ * @package BonusHuntGuesser
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
+}
+
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
+}
+
+$notice = '';
+// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+if ( isset( $_GET['demo_reset'] ) && 1 === absint( $_GET['demo_reset'] ) ) {
+	$notice = __( 'Demo data reseeded.', 'bonus-hunt-guesser' );
 }
 ?>
 <div class="wrap">
-	<h1><?php esc_html_e('Demo Tools', 'bonus-hunt-guesser'); ?></h1>
-	<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
-		<input type="hidden" name="action" value="bhg_demo_reseed">
-		<?php wp_nonce_field('bhg_demo_reseed_action', 'bhg_demo_reseed_nonce'); ?>
-		<p><?php esc_html_e('This will delete all demo data and pages, then recreate fresh demo content.', 'bonus-hunt-guesser'); ?></p>
-		<p><input type="submit" class="button button-primary" value="<?php esc_attr_e('Reset & Reseed Demo Data', 'bonus-hunt-guesser'); ?>"></p>
+	<h1><?php esc_html_e( 'Demo Tools', 'bonus-hunt-guesser' ); ?></h1>
+	<?php if ( $notice ) : ?>
+	<div class="notice notice-success"><p><?php echo esc_html( $notice ); ?></p></div>
+	<?php endif; ?>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+	<input type="hidden" name="action" value="bhg_demo_reseed">
+	<?php wp_nonce_field( 'bhg_demo_reseed' ); ?>
+	<p><?php esc_html_e( 'This will delete all demo data and pages, then recreate fresh demo content.', 'bonus-hunt-guesser' ); ?></p>
+	<p><input type="submit" class="button button-primary" value="<?php esc_attr_e( 'Reset & Reseed Demo Data', 'bonus-hunt-guesser' ); ?>"></p>
 	</form>
 </div>

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -1,8 +1,16 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+/**
+ * Translations management view.
+ *
+ * @package BonusHuntGuesser
+ */
 
-if (!current_user_can('manage_options')) {
-	wp_die(esc_html__('You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser'));
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 global $wpdb;
@@ -13,78 +21,95 @@ if ( function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
 }
 
 $default_translations = function_exists( 'bhg_get_default_translations' ) ? bhg_get_default_translations() : array();
-$default_keys        = array_keys( $default_translations );
+$default_keys         = array_keys( $default_translations );
 
-// Handle form submission
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bhg_save_translation'])) {
-	// Verify nonce
-	if (!isset($_POST['bhg_nonce']) || !wp_verify_nonce($_POST['bhg_nonce'], 'bhg_save_translation_action')) {
-		wp_die(esc_html__('Security check failed.', 'bonus-hunt-guesser'));
+// Handle form submission.
+if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] && isset( $_POST['bhg_save_translation'] ) ) {
+	// Verify nonce.
+	if ( ! isset( $_POST['bhg_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bhg_nonce'] ) ), 'bhg_save_translation_action' ) ) {
+		wp_die( esc_html__( 'Security check failed.', 'bonus-hunt-guesser' ) );
 	}
 
-	// Sanitize input
-	$tkey   = isset($_POST['tkey']) ? sanitize_text_field(wp_unslash($_POST['tkey'])) : '';
-	$tvalue = isset($_POST['tvalue']) ? sanitize_textarea_field(wp_unslash($_POST['tvalue'])) : '';
+	// Sanitize input.
+	$tkey   = isset( $_POST['tkey'] ) ? sanitize_text_field( wp_unslash( $_POST['tkey'] ) ) : '';
+	$tvalue = isset( $_POST['tvalue'] ) ? sanitize_textarea_field( wp_unslash( $_POST['tvalue'] ) ) : '';
 
-	// Validate input
-	if ($tkey === '') {
-		$error = __('Key field is required.', 'bonus-hunt-guesser');
+	// Validate input.
+	if ( '' === $tkey ) {
+		$bhg_error = __( 'Key field is required.', 'bonus-hunt-guesser' );
 	} else {
 		$wpdb->replace(
 			$table,
-			array('tkey' => $tkey, 'tvalue' => $tvalue),
-			array('%s', '%s')
+			array(
+				'tkey'   => $tkey,
+				'tvalue' => $tvalue,
+			),
+			array( '%s', '%s' )
 		);
-		$notice = __('Translation saved.', 'bonus-hunt-guesser');
+		$bhg_notice = __( 'Translation saved.', 'bonus-hunt-guesser' );
 	}
 }
 
-// Fetch rows
-$rows = $wpdb->get_results( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC" );
+// Fetch rows.
+$rows = $wpdb->get_results( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 ?>
 <div class="wrap">
-  <h1><?php esc_html_e('Translations', 'bonus-hunt-guesser'); ?></h1>
+	<h1><?php esc_html_e( 'Translations', 'bonus-hunt-guesser' ); ?></h1>
 
-  <style>
+	<style>
 	.bhg-default-row td { background-color: #fffbcc; }
-  </style>
+	</style>
 
-  <?php if (!empty($notice)): ?>
-	<div class="notice notice-success"><p><?php echo esc_html($notice); ?></p></div>
-  <?php endif; ?>
-  <?php if (!empty($error)): ?>
-	<div class="notice notice-error"><p><?php echo esc_html($error); ?></p></div>
-  <?php endif; ?>
+	<?php if ( ! empty( $bhg_notice ) ) : ?>
+	<div class="notice notice-success"><p><?php echo esc_html( $bhg_notice ); ?></p></div>
+	<?php endif; ?>
+	<?php if ( ! empty( $bhg_error ) ) : ?>
+	<div class="notice notice-error"><p><?php echo esc_html( $bhg_error ); ?></p></div>
+	<?php endif; ?>
 
-  <form method="post">
-	<?php wp_nonce_field('bhg_save_translation_action', 'bhg_nonce'); ?>
+	<form method="post">
+	<?php wp_nonce_field( 'bhg_save_translation_action', 'bhg_nonce' ); ?>
 	<table class="form-table" role="presentation">
-	  <tbody>
-		<tr>
-		  <th scope="row"><label for="tkey"><?php esc_html_e('Key','bonus-hunt-guesser'); ?></label></th>
-		  <td><input name="tkey" id="tkey" type="text" class="regular-text" required></td>
-		</tr>
-		<tr>
-		  <th scope="row"><label for="tvalue"><?php esc_html_e('Value','bonus-hunt-guesser'); ?></label></th>
-		  <td><textarea name="tvalue" id="tvalue" class="large-text" rows="4"></textarea></td>
-		</tr>
-	  </tbody>
-	</table>
-		  <p class="submit"><button type="submit" name="bhg_save_translation" class="button button-primary"><?php esc_html_e('Save', 'bonus-hunt-guesser'); ?></button></p>
-  </form>
-
-  <h2><?php esc_html_e('Existing keys', 'bonus-hunt-guesser'); ?></h2>
-  <table class="widefat striped">
-	<thead><tr><th><?php esc_html_e('Key', 'bonus-hunt-guesser'); ?></th><th><?php esc_html_e('Value', 'bonus-hunt-guesser'); ?></th></tr></thead>
 	<tbody>
-	  <?php if ($rows): foreach ($rows as $r): ?>
-		<tr<?php echo in_array( $r->tkey, $default_keys, true ) ? ' class="bhg-default-row"' : ''; ?>>
-		  <td><code><?php echo esc_html($r->tkey); ?></code></td>
-		  <td><?php echo esc_html($r->tvalue); ?></td>
-		</tr>
-	  <?php endforeach; else: ?>
-		<tr><td colspan="2"><?php esc_html_e('No translations yet.','bonus-hunt-guesser'); ?></td></tr>
-	  <?php endif; ?>
+	<tr>
+	<th scope="row"><label for="tkey"><?php esc_html_e( 'Key', 'bonus-hunt-guesser' ); ?></label></th>
+	<td><input name="tkey" id="tkey" type="text" class="regular-text" required></td>
+	</tr>
+	<tr>
+	<th scope="row"><label for="tvalue"><?php esc_html_e( 'Value', 'bonus-hunt-guesser' ); ?></label></th>
+	<td><textarea name="tvalue" id="tvalue" class="large-text" rows="4"></textarea></td>
+	</tr>
 	</tbody>
-  </table>
+	</table>
+	<p class="submit"><button type="submit" name="bhg_save_translation" id="bhg_save_translation" class="button button-primary"><?php esc_html_e( 'Save', 'bonus-hunt-guesser' ); ?></button></p>
+	</form>
+
+	<h2><?php esc_html_e( 'Existing keys', 'bonus-hunt-guesser' ); ?></h2>
+	<table class="widefat striped">
+	<thead><tr><th><?php esc_html_e( 'Key', 'bonus-hunt-guesser' ); ?></th><th><?php esc_html_e( 'Value', 'bonus-hunt-guesser' ); ?></th><th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th></tr></thead>
+	<tbody>
+	<?php
+	if ( $rows ) :
+		foreach ( $rows as $r ) :
+			?>
+	<tr<?php echo in_array( $r->tkey, $default_keys, true ) ? ' class="bhg-default-row"' : ''; ?>>
+	<td><code><?php echo esc_html( $r->tkey ); ?></code></td>
+	<td><?php echo esc_html( $r->tvalue ); ?></td>
+	<td><a href="#" class="bhg-edit-translation" onclick="bhgEditTranslation('<?php echo esc_js( $r->tkey ); ?>','<?php echo esc_js( $r->tvalue ); ?>');return false;"><?php esc_html_e( 'Edit', 'bonus-hunt-guesser' ); ?></a></td>
+	</tr>
+			<?php endforeach; else : ?>
+	<tr><td colspan="3"><?php esc_html_e( 'No translations yet.', 'bonus-hunt-guesser' ); ?></td></tr>
+	<?php endif; ?>
+	</tbody>
+	</table>
+	<script>
+	function bhgEditTranslation( key, value ) {
+	document.getElementById( 'tkey' ).value = key;
+	document.getElementById( 'tvalue' ).value = value;
+	document.getElementById( 'bhg_save_translation' ).textContent = '<?php echo esc_js( __( 'Update', 'bonus-hunt-guesser' ) ); ?>';
+	}
+	document.getElementById( 'tkey' ).addEventListener( 'input', function() {
+	document.getElementById( 'bhg_save_translation' ).textContent = '<?php echo esc_js( __( 'Save', 'bonus-hunt-guesser' ) ); ?>';
+	} );
+	</script>
 </div>


### PR DESCRIPTION
## Summary
- allow editing existing translations from the Translations screen
- tidy demo tools page with success notice and capability checks
- remove legacy demo menu handler and document demo reseed utility

## Testing
- `phpcs admin/views/translations.php admin/views/demo-tools.php admin/class-bhg-demo.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb2a8db41083339fb6d4610c54ea83