### PR TITLE
Reindent PHP files to use tabs per WordPress standards

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -49,20 +49,20 @@ class BHG_Admin {
 		add_submenu_page($slug, __('Translations', 'bonus-hunt-guesser'),__('Translations', 'bonus-hunt-guesser'),$cap, 'bhg-translations',            [$this, 'translations']);
 		add_submenu_page($slug, __('Database', 'bonus-hunt-guesser'),    __('Database', 'bonus-hunt-guesser'),    $cap, 'bhg-database',                [$this, 'database']);
 		add_submenu_page($slug, __('Settings', 'bonus-hunt-guesser'),    __('Settings', 'bonus-hunt-guesser'),    $cap, 'bhg-settings',                [$this, 'settings']);
-                add_submenu_page(
-                        $slug,
-                        __('BHG Tools', 'bonus-hunt-guesser'),
-                        __('BHG Tools', 'bonus-hunt-guesser'),
-                        $cap,
-                        'bhg-tools',
-                        [$this, 'bhg_tools_page']
-                );
+				add_submenu_page(
+						$slug,
+						__('BHG Tools', 'bonus-hunt-guesser'),
+						__('BHG Tools', 'bonus-hunt-guesser'),
+						$cap,
+						'bhg-tools',
+						[$this, 'bhg_tools_page']
+				);
 
-                // WordPress automatically adds a submenu item that duplicates the
-                // top-level "Bonus Hunt" menu. Remove that default item so the first
-                // submenu is the custom "Dashboard" page.
-                remove_submenu_page( $slug, $slug );
-        }
+				// WordPress automatically adds a submenu item that duplicates the
+				// top-level "Bonus Hunt" menu. Remove that default item so the first
+				// submenu is the custom "Dashboard" page.
+				remove_submenu_page( $slug, $slug );
+		}
 
 	/** Enqueue admin assets on BHG screens. */
 	public function assets( $hook ) {
@@ -265,8 +265,8 @@ class BHG_Admin {
 						$winner_names[] = $wu->user_login;
 					}
 				}
-                                $winner_first = $winner_names ? $winner_names[0] : esc_html__( '—', 'bonus-hunt-guesser' );
-                                $winner_list  = $winner_names ? implode( ', ', $winner_names ) : esc_html__( '—', 'bonus-hunt-guesser' );
+								$winner_first = $winner_names ? $winner_names[0] : esc_html__( '—', 'bonus-hunt-guesser' );
+								$winner_list  = $winner_names ? implode( ', ', $winner_names ) : esc_html__( '—', 'bonus-hunt-guesser' );
 
 				foreach ($rows as $r) {
 					$u = get_userdata((int) $r->user_id);
@@ -341,7 +341,7 @@ class BHG_Admin {
 		$place    = isset( $_POST['placement'] ) ? sanitize_text_field( wp_unslash( $_POST['placement'] ) ) : 'none';
 		$visible  = isset( $_POST['visible_to'] ) ? sanitize_text_field( wp_unslash( $_POST['visible_to'] ) ) : 'all';
 		$targets  = isset( $_POST['target_pages'] ) ? sanitize_text_field( wp_unslash( $_POST['target_pages'] ) ) : '';
-               $active   = isset( $_POST['active'] ) ? absint( wp_unslash( $_POST['active'] ) ) : 0;
+			   $active   = isset( $_POST['active'] ) ? absint( wp_unslash( $_POST['active'] ) ) : 0;
 
 		$data = [
 			'title'        => $title,
@@ -487,7 +487,7 @@ class BHG_Admin {
 		$user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;
 		if ( $user_id ) {
 			$real_name    = isset( $_POST['bhg_real_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bhg_real_name'] ) ) : '';
-                       $is_affiliate = isset( $_POST['bhg_is_affiliate'] ) ? absint( wp_unslash( $_POST['bhg_is_affiliate'] ) ) : 0;
+					   $is_affiliate = isset( $_POST['bhg_is_affiliate'] ) ? absint( wp_unslash( $_POST['bhg_is_affiliate'] ) ) : 0;
 			update_user_meta( $user_id, 'bhg_real_name', $real_name );
 			update_user_meta( $user_id, 'bhg_is_affiliate', $is_affiliate );
 		}

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -28,23 +28,23 @@ if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
 
 // Fetch ads
 $ads = $wpdb->get_results(
-        "SELECT * FROM {$table} ORDER BY id DESC"
+		"SELECT * FROM {$table} ORDER BY id DESC"
 );
 
 $placement_labels = [
-        'none'      => __( 'None', 'bonus-hunt-guesser' ),
-        'footer'    => __( 'Footer', 'bonus-hunt-guesser' ),
-        'bottom'    => __( 'Bottom', 'bonus-hunt-guesser' ),
-        'sidebar'   => __( 'Sidebar', 'bonus-hunt-guesser' ),
-        'shortcode' => __( 'Shortcode', 'bonus-hunt-guesser' ),
+		'none'      => __( 'None', 'bonus-hunt-guesser' ),
+		'footer'    => __( 'Footer', 'bonus-hunt-guesser' ),
+		'bottom'    => __( 'Bottom', 'bonus-hunt-guesser' ),
+		'sidebar'   => __( 'Sidebar', 'bonus-hunt-guesser' ),
+		'shortcode' => __( 'Shortcode', 'bonus-hunt-guesser' ),
 ];
 
 $visible_labels = [
-        'all'            => __( 'All', 'bonus-hunt-guesser' ),
-        'guests'         => __( 'Guests', 'bonus-hunt-guesser' ),
-        'logged_in'      => __( 'Logged In', 'bonus-hunt-guesser' ),
-        'affiliates'     => __( 'Affiliates', 'bonus-hunt-guesser' ),
-        'non_affiliates' => __( 'Non Affiliates', 'bonus-hunt-guesser' ),
+		'all'            => __( 'All', 'bonus-hunt-guesser' ),
+		'guests'         => __( 'Guests', 'bonus-hunt-guesser' ),
+		'logged_in'      => __( 'Logged In', 'bonus-hunt-guesser' ),
+		'affiliates'     => __( 'Affiliates', 'bonus-hunt-guesser' ),
+		'non_affiliates' => __( 'Non Affiliates', 'bonus-hunt-guesser' ),
 ];
 ?>
 <div class="wrap">
@@ -69,14 +69,14 @@ $visible_labels = [
 		<tr>
 		  <td><?php echo (int)$ad->id; ?></td>
 		  <td><?php echo isset($ad->title) && $ad->title !== '' ? esc_html($ad->title) : wp_kses_post(wp_trim_words($ad->content, 12)); ?></td>
-                  <td><?php
-                        $pl = isset( $ad->placement ) ? ( $placement_labels[ $ad->placement ] ?? $ad->placement ) : $placement_labels['none'];
-                        echo esc_html( $pl );
-                  ?></td>
-                  <td><?php
-                        $vis = isset( $ad->visible_to ) ? ( $visible_labels[ $ad->visible_to ] ?? $ad->visible_to ) : $visible_labels['all'];
-                        echo esc_html( $vis );
-                  ?></td>
+				  <td><?php
+						$pl = isset( $ad->placement ) ? ( $placement_labels[ $ad->placement ] ?? $ad->placement ) : $placement_labels['none'];
+						echo esc_html( $pl );
+				  ?></td>
+				  <td><?php
+						$vis = isset( $ad->visible_to ) ? ( $visible_labels[ $ad->visible_to ] ?? $ad->visible_to ) : $visible_labels['all'];
+						echo esc_html( $vis );
+				  ?></td>
 		  <td><?php echo (int)$ad->active === 1 ? esc_html__('Yes','bonus-hunt-guesser') : esc_html__('No','bonus-hunt-guesser'); ?></td>
 		  <td>
 			<a class="button" href="<?php echo esc_url(add_query_arg(['edit'=> (int)$ad->id])); ?>"><?php echo esc_html__('Edit', 'bonus-hunt-guesser'); ?></a>
@@ -89,12 +89,12 @@ $visible_labels = [
 
   <h2 style="margin-top:2em"><?php echo $edit_id ? esc_html__('Edit Ad', 'bonus-hunt-guesser') : esc_html__('Add Ad', 'bonus-hunt-guesser'); ?></h2>
   <?php
-        $ad = null;
-        if ( $edit_id ) {
-                $ad = $wpdb->get_row(
-                        $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id )
-                );
-        }
+		$ad = null;
+		if ( $edit_id ) {
+				$ad = $wpdb->get_row(
+						$wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id )
+				);
+		}
   ?>
   <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="max-width:800px">
 	<?php wp_nonce_field('bhg_save_ad'); ?>
@@ -122,12 +122,12 @@ $visible_labels = [
 		  <td>
 			<select id="bhg_ad_place" name="placement">
 			  <?php
-                                $placement_opts = array_keys( $placement_labels );
-                                $sel            = $ad ? ( $ad->placement ?? 'none' ) : 'none';
-                                foreach ( $placement_opts as $o ) {
-                                        $label = $placement_labels[ $o ] ?? $o;
-                                        echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
-                                }
+								$placement_opts = array_keys( $placement_labels );
+								$sel            = $ad ? ( $ad->placement ?? 'none' ) : 'none';
+								foreach ( $placement_opts as $o ) {
+										$label = $placement_labels[ $o ] ?? $o;
+										echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
+								}
 			  ?>
 			</select>
 		  </td>
@@ -137,12 +137,12 @@ $visible_labels = [
 		  <td>
 			<select id="bhg_ad_vis" name="visible_to">
 			  <?php
-                                $visible_opts = array_keys( $visible_labels );
-                                $sel          = $ad ? ( $ad->visible_to ?? 'all' ) : 'all';
-                                foreach ( $visible_opts as $o ) {
-                                        $label = $visible_labels[ $o ] ?? $o;
-                                        echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
-                                }
+								$visible_opts = array_keys( $visible_labels );
+								$sel          = $ad ? ( $ad->visible_to ?? 'all' ) : 'all';
+								foreach ( $visible_opts as $o ) {
+										$label = $visible_labels[ $o ] ?? $o;
+										echo '<option value="' . esc_attr( $o ) . '" ' . selected( $sel, $o, false ) . '>' . esc_html( $label ) . '</option>';
+								}
 			  ?>
 			</select>
 		  </td>

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -14,8 +14,8 @@ $row = $edit_id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$table` WHERE id
 $rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
 
 $status_labels = [
-        'active'   => __( 'Active', 'bonus-hunt-guesser' ),
-        'inactive' => __( 'Inactive', 'bonus-hunt-guesser' ),
+		'active'   => __( 'Active', 'bonus-hunt-guesser' ),
+		'inactive' => __( 'Inactive', 'bonus-hunt-guesser' ),
 ];
 ?>
 <div class="wrap">
@@ -40,7 +40,7 @@ $status_labels = [
 		  <td><?php echo (int)$r->id; ?></td>
 		  <td><?php echo esc_html($r->name); ?></td>
 		  <td><?php echo esc_html($r->url); ?></td>
-                  <td><?php echo esc_html( $status_labels[ $r->status ] ?? $r->status ); ?></td>
+				  <td><?php echo esc_html( $status_labels[ $r->status ] ?? $r->status ); ?></td>
 		  <td>
 			<a class="button" href="<?php echo esc_url(add_query_arg(['edit'=>(int)$r->id])); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
 			<form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline" onsubmit="return confirm('<?php echo esc_js(__('Delete this affiliate?', 'bonus-hunt-guesser')); ?>');">
@@ -73,9 +73,9 @@ $status_labels = [
 		<th><label for="aff_status"><?php esc_html_e('Status','bonus-hunt-guesser'); ?></label></th>
 		<td>
 		  <select id="aff_status" name="status">
-                        <?php $opts = array_keys( $status_labels ); $cur = $row->status ?? 'active'; foreach ( $opts as $o ) : ?>
-                          <option value="<?php echo esc_attr( $o ); ?>" <?php selected( $cur, $o ); ?>><?php echo esc_html( $status_labels[ $o ] ); ?></option>
-                        <?php endforeach; ?>
+						<?php $opts = array_keys( $status_labels ); $cur = $row->status ?? 'active'; foreach ( $opts as $o ) : ?>
+						  <option value="<?php echo esc_attr( $o ); ?>" <?php selected( $cur, $o ); ?>><?php echo esc_html( $status_labels[ $o ] ); ?></option>
+						<?php endforeach; ?>
 		  </select>
 		</td>
 	  </tr>

--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -1,7 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 if ( ! current_user_can( 'manage_options' ) ) {
-        wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
 global $wpdb;
@@ -9,13 +9,13 @@ global $wpdb;
 $id   = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
 $hunt = bhg_get_hunt( $id );
 if ( ! $hunt ) {
-        echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt', 'bonus-hunt-guesser' ) . '</p></div>';
-        return;
+		echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt', 'bonus-hunt-guesser' ) . '</p></div>';
+		return;
 }
 
 $aff_table = $wpdb->prefix . 'bhg_affiliates';
 if ( isset( $allowed_tables ) && ! in_array( $aff_table, $allowed_tables, true ) ) {
-        wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+		wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
 $aff_table = esc_sql( $aff_table );
 $affs      = $wpdb->get_results( "SELECT id, name FROM {$aff_table} ORDER BY name ASC" );
@@ -33,113 +33,113 @@ $base     = remove_query_arg( 'ppaged' );
   <h1 class="wp-heading-inline"><?php echo esc_html__( 'Edit Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 
   <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-900 bhg-margin-top-small">
-        <?php wp_nonce_field( 'bhg_save_hunt' ); ?>
-        <input type="hidden" name="action" value="bhg_save_hunt" />
-        <input type="hidden" name="id" value="<?php echo (int) $hunt->id; ?>" />
+		<?php wp_nonce_field( 'bhg_save_hunt' ); ?>
+		<input type="hidden" name="action" value="bhg_save_hunt" />
+		<input type="hidden" name="id" value="<?php echo (int) $hunt->id; ?>" />
 
-        <table class="form-table" role="presentation">
-          <tbody>
-                <tr>
-                  <th scope="row"><label for="bhg_title"><?php echo esc_html__( 'Title', 'bonus-hunt-guesser' ); ?></label></th>
-                  <td><input required class="regular-text" id="bhg_title" name="title" value="<?php echo esc_attr( $hunt->title ); ?>"></td>
-                </tr>
-                <tr>
-                  <th scope="row"><label for="bhg_starting"><?php echo esc_html__( 'Starting Balance', 'bonus-hunt-guesser' ); ?></label></th>
-                  <td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value="<?php echo esc_attr( $hunt->starting_balance ); ?>"></td>
-                </tr>
-                <tr>
-                  <th scope="row"><label for="bhg_num"><?php echo esc_html__( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></label></th>
-                  <td><input type="number" min="0" id="bhg_num" name="num_bonuses" value="<?php echo esc_attr( $hunt->num_bonuses ); ?>"></td>
-                </tr>
-                <tr>
-                  <th scope="row"><label for="bhg_prizes"><?php echo esc_html__( 'Prizes', 'bonus-hunt-guesser' ); ?></label></th>
-                  <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"><?php echo esc_textarea( $hunt->prizes ); ?></textarea></td>
-                </tr>
-                <tr>
-                  <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__( 'Affiliate Site', 'bonus-hunt-guesser' ); ?></label></th>
-                  <td>
-                        <select id="bhg_affiliate" name="affiliate_site_id">
-                          <option value="0"><?php echo esc_html__( 'None', 'bonus-hunt-guesser' ); ?></option>
-                          <?php foreach ( $affs as $a ) : ?>
-                                <option value="<?php echo (int) $a->id; ?>" <?php selected( $sel, (int) $a->id ); ?>><?php echo esc_html( $a->name ); ?></option>
-                          <?php endforeach; ?>
-                        </select>
-                  </td>
-                </tr>
-                <tr>
-                  <th scope="row"><label for="bhg_winners"><?php echo esc_html__( 'Number of Winners', 'bonus-hunt-guesser' ); ?></label></th>
-                  <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
-                </tr>
-                <tr>
-                  <th scope="row"><label for="bhg_final"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>
-                  <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '—', 'bonus-hunt-guesser' ) ); ?>"></td>
-                </tr>
-                <tr>
-                  <th scope="row"><label for="bhg_status"><?php echo esc_html__( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
-                  <td>
-                        <select id="bhg_status" name="status">
-                          <option value="open" <?php selected( $hunt->status, 'open' ); ?>><?php echo esc_html__( 'Open', 'bonus-hunt-guesser' ); ?></option>
-                          <option value="closed" <?php selected( $hunt->status, 'closed' ); ?>><?php echo esc_html__( 'Closed', 'bonus-hunt-guesser' ); ?></option>
-                        </select>
-                  </td>
-                </tr>
-          </tbody>
-        </table>
-        <?php submit_button( __( 'Save Hunt', 'bonus-hunt-guesser' ) ); ?>
+		<table class="form-table" role="presentation">
+		  <tbody>
+				<tr>
+				  <th scope="row"><label for="bhg_title"><?php echo esc_html__( 'Title', 'bonus-hunt-guesser' ); ?></label></th>
+				  <td><input required class="regular-text" id="bhg_title" name="title" value="<?php echo esc_attr( $hunt->title ); ?>"></td>
+				</tr>
+				<tr>
+				  <th scope="row"><label for="bhg_starting"><?php echo esc_html__( 'Starting Balance', 'bonus-hunt-guesser' ); ?></label></th>
+				  <td><input type="number" step="0.01" min="0" id="bhg_starting" name="starting_balance" value="<?php echo esc_attr( $hunt->starting_balance ); ?>"></td>
+				</tr>
+				<tr>
+				  <th scope="row"><label for="bhg_num"><?php echo esc_html__( 'Number of Bonuses', 'bonus-hunt-guesser' ); ?></label></th>
+				  <td><input type="number" min="0" id="bhg_num" name="num_bonuses" value="<?php echo esc_attr( $hunt->num_bonuses ); ?>"></td>
+				</tr>
+				<tr>
+				  <th scope="row"><label for="bhg_prizes"><?php echo esc_html__( 'Prizes', 'bonus-hunt-guesser' ); ?></label></th>
+				  <td><textarea class="large-text" rows="3" id="bhg_prizes" name="prizes"><?php echo esc_textarea( $hunt->prizes ); ?></textarea></td>
+				</tr>
+				<tr>
+				  <th scope="row"><label for="bhg_affiliate"><?php echo esc_html__( 'Affiliate Site', 'bonus-hunt-guesser' ); ?></label></th>
+				  <td>
+						<select id="bhg_affiliate" name="affiliate_site_id">
+						  <option value="0"><?php echo esc_html__( 'None', 'bonus-hunt-guesser' ); ?></option>
+						  <?php foreach ( $affs as $a ) : ?>
+								<option value="<?php echo (int) $a->id; ?>" <?php selected( $sel, (int) $a->id ); ?>><?php echo esc_html( $a->name ); ?></option>
+						  <?php endforeach; ?>
+						</select>
+				  </td>
+				</tr>
+				<tr>
+				  <th scope="row"><label for="bhg_winners"><?php echo esc_html__( 'Number of Winners', 'bonus-hunt-guesser' ); ?></label></th>
+				  <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
+				</tr>
+				<tr>
+				  <th scope="row"><label for="bhg_final"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>
+				  <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '—', 'bonus-hunt-guesser' ) ); ?>"></td>
+				</tr>
+				<tr>
+				  <th scope="row"><label for="bhg_status"><?php echo esc_html__( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
+				  <td>
+						<select id="bhg_status" name="status">
+						  <option value="open" <?php selected( $hunt->status, 'open' ); ?>><?php echo esc_html__( 'Open', 'bonus-hunt-guesser' ); ?></option>
+						  <option value="closed" <?php selected( $hunt->status, 'closed' ); ?>><?php echo esc_html__( 'Closed', 'bonus-hunt-guesser' ); ?></option>
+						</select>
+				  </td>
+				</tr>
+		  </tbody>
+		</table>
+		<?php submit_button( __( 'Save Hunt', 'bonus-hunt-guesser' ) ); ?>
   </form>
 
   <h2 class="bhg-margin-top-large"><?php esc_html_e( 'Participants', 'bonus-hunt-guesser' ); ?></h2>
   <p><?php echo esc_html( sprintf( _n( '%s participant', '%s participants', $total, 'bonus-hunt-guesser' ), number_format_i18n( $total ) ) ); ?></p>
 
   <table class="widefat striped">
-        <thead>
-          <tr>
-                <th><?php esc_html_e( 'User', 'bonus-hunt-guesser' ); ?></th>
-                <th><?php esc_html_e( 'Guess', 'bonus-hunt-guesser' ); ?></th>
-                <th><?php esc_html_e( 'Date', 'bonus-hunt-guesser' ); ?></th>
-                <th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th>
-          </tr>
-        </thead>
-        <tbody>
-          <?php if ( empty( $rows ) ) : ?>
-                <tr><td colspan="4"><?php esc_html_e( 'No participants yet.', 'bonus-hunt-guesser' ); ?></td></tr>
-          <?php else : foreach ( $rows as $r ) :
-                $u    = get_userdata( (int) $r->user_id );
-                $name = $u ? $u->display_name : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
-          ?>
-                <tr>
-                  <td><a href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . (int) $r->user_id ) ); ?>"><?php echo esc_html( $name ); ?></a></td>
-                  <td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
-                  <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-                  <td>
-                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( __( 'Delete this guess?', 'bonus-hunt-guesser' ) ); ?>');" class="bhg-inline-form">
-                          <?php wp_nonce_field( 'bhg_delete_guess' ); ?>
-                          <input type="hidden" name="action" value="bhg_delete_guess">
-                          <input type="hidden" name="guess_id" value="<?php echo (int) $r->id; ?>">
-                          <button type="submit" class="button-link-delete"><?php esc_html_e( 'Remove', 'bonus-hunt-guesser' ); ?></button>
-                        </form>
-                  </td>
-                </tr>
-          <?php endforeach; endif; ?>
-        </tbody>
+		<thead>
+		  <tr>
+				<th><?php esc_html_e( 'User', 'bonus-hunt-guesser' ); ?></th>
+				<th><?php esc_html_e( 'Guess', 'bonus-hunt-guesser' ); ?></th>
+				<th><?php esc_html_e( 'Date', 'bonus-hunt-guesser' ); ?></th>
+				<th><?php esc_html_e( 'Actions', 'bonus-hunt-guesser' ); ?></th>
+		  </tr>
+		</thead>
+		<tbody>
+		  <?php if ( empty( $rows ) ) : ?>
+				<tr><td colspan="4"><?php esc_html_e( 'No participants yet.', 'bonus-hunt-guesser' ); ?></td></tr>
+		  <?php else : foreach ( $rows as $r ) :
+				$u    = get_userdata( (int) $r->user_id );
+				$name = $u ? $u->display_name : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
+		  ?>
+				<tr>
+				  <td><a href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . (int) $r->user_id ) ); ?>"><?php echo esc_html( $name ); ?></a></td>
+				  <td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
+				  <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+				  <td>
+						<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( __( 'Delete this guess?', 'bonus-hunt-guesser' ) ); ?>');" class="bhg-inline-form">
+						  <?php wp_nonce_field( 'bhg_delete_guess' ); ?>
+						  <input type="hidden" name="action" value="bhg_delete_guess">
+						  <input type="hidden" name="guess_id" value="<?php echo (int) $r->id; ?>">
+						  <button type="submit" class="button-link-delete"><?php esc_html_e( 'Remove', 'bonus-hunt-guesser' ); ?></button>
+						</form>
+				  </td>
+				</tr>
+		  <?php endforeach; endif; ?>
+		</tbody>
   </table>
 
   <?php if ( $pages > 1 ) : ?>
-        <div class="tablenav">
-          <div class="tablenav-pages">
-                <?php
-                echo paginate_links(
-                        [
-                                'base'      => add_query_arg( 'ppaged', '%#%', $base ),
-                                'format'    => '',
-                                'prev_text' => '&laquo;',
-                                'next_text' => '&raquo;',
-                                'total'     => $pages,
-                                'current'   => $paged,
-                        ]
-                );
-                ?>
-          </div>
-        </div>
+		<div class="tablenav">
+		  <div class="tablenav-pages">
+				<?php
+				echo paginate_links(
+						[
+								'base'      => add_query_arg( 'ppaged', '%#%', $base ),
+								'format'    => '',
+								'prev_text' => '&laquo;',
+								'next_text' => '&raquo;',
+								'total'     => $pages,
+								'current'   => $paged,
+						]
+				);
+				?>
+		  </div>
+		</div>
   <?php endif; ?>
 </div>

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -27,31 +27,31 @@ $guesses_table = esc_sql( $guesses_table );
 $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
 
 if ( 'edit' === $view ) {
-        require __DIR__ . '/bonus-hunts-edit.php';
-        return;
+		require __DIR__ . '/bonus-hunts-edit.php';
+		return;
 }
 
 /** LIST VIEW */
 if ( 'list' === $view ) :
-        $current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
-        $per_page     = 30;
-        $offset       = ( $current_page - 1 ) * $per_page;
+		$current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
+		$per_page     = 30;
+		$offset       = ( $current_page - 1 ) * $per_page;
 
-        $hunts = $wpdb->get_results(
-                $wpdb->prepare(
-                        "SELECT * FROM {$hunts_table} ORDER BY id DESC LIMIT %d OFFSET %d",
-                        $per_page,
-                        $offset
-                )
-        );
+		$hunts = $wpdb->get_results(
+				$wpdb->prepare(
+						"SELECT * FROM {$hunts_table} ORDER BY id DESC LIMIT %d OFFSET %d",
+						$per_page,
+						$offset
+				)
+		);
 
-        $status_labels = [
-                'open'   => __( 'Open', 'bonus-hunt-guesser' ),
-                'closed' => __( 'Closed', 'bonus-hunt-guesser' ),
-        ];
+		$status_labels = [
+				'open'   => __( 'Open', 'bonus-hunt-guesser' ),
+				'closed' => __( 'Closed', 'bonus-hunt-guesser' ),
+		];
 
-        $total    = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$hunts_table}" );
-        $base_url = remove_query_arg( [ 'paged' ] );
+		$total    = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$hunts_table}" );
+		$base_url = remove_query_arg( [ 'paged' ] );
 ?>
 <div class="wrap">
   <h1 class="wp-heading-inline"><?php echo esc_html__('Bonus Hunts', 'bonus-hunt-guesser'); ?></h1>
@@ -81,38 +81,38 @@ if ( 'list' === $view ) :
 		  <td><?php echo (int) $h->id; ?></td>
 		  <td><a href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html( $h->title ); ?></a></td>
 		  <td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-                  <td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+				  <td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  <td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
-                  <td><?php echo esc_html( $status_labels[ $h->status ] ?? $h->status ); ?></td>
+				  <td><?php echo esc_html( $status_labels[ $h->status ] ?? $h->status ); ?></td>
 		  <td>
 			<a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'edit', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Edit', 'bonus-hunt-guesser' ); ?></a>
-                        <?php if ( 'open' === $h->status ) : ?>
-                          <a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'close', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
-                        <?php elseif ( 'closed' === $h->status && null !== $h->final_balance ) : ?>
-                          <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
-                        <?php endif; ?>
+						<?php if ( 'open' === $h->status ) : ?>
+						  <a class="button" href="<?php echo esc_url( add_query_arg( [ 'view' => 'close', 'id' => (int) $h->id ] ) ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
+						<?php elseif ( 'closed' === $h->status && null !== $h->final_balance ) : ?>
+						  <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
+						<?php endif; ?>
 		  </td>
 		</tr>
-          <?php endforeach; endif; ?>
-        </tbody>
+		  <?php endforeach; endif; ?>
+		</tbody>
   </table>
 
   <?php
-        $total_pages = (int) ceil( $total / $per_page );
-        if ( $total_pages > 1 ) {
-                echo '<div class="tablenav"><div class="tablenav-pages">';
-                echo paginate_links(
-                        [
-                                'base'      => add_query_arg( 'paged', '%#%', $base_url ),
-                                'format'    => '',
-                                'prev_text' => '&laquo;',
-                                'next_text' => '&raquo;',
-                                'total'     => $total_pages,
-                                'current'   => $current_page,
-                        ]
-                );
-                echo '</div></div>';
-        }
+		$total_pages = (int) ceil( $total / $per_page );
+		if ( $total_pages > 1 ) {
+				echo '<div class="tablenav"><div class="tablenav-pages">';
+				echo paginate_links(
+						[
+								'base'      => add_query_arg( 'paged', '%#%', $base_url ),
+								'format'    => '',
+								'prev_text' => '&laquo;',
+								'next_text' => '&raquo;',
+								'total'     => $total_pages,
+								'current'   => $current_page,
+						]
+				);
+				echo '</div></div>';
+		}
   ?>
 </div>
 <?php endif; ?>
@@ -120,7 +120,7 @@ if ( 'list' === $view ) :
 <?php
 /** CLOSE VIEW */
 if ( 'close' === $view ) :
-        $id   = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
+		$id   = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
 	$hunt = $wpdb->get_row(
 		$wpdb->prepare( "SELECT * FROM {$hunts_table} WHERE id = %d", $id )
 	);

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -25,7 +25,7 @@ $hunts = bhg_get_latest_closed_hunts( 3 );
   <table class="widefat striped">
 	<thead>
 	  <tr>
-                <th><?php esc_html_e( 'Bonus Hunt', 'bonus-hunt-guesser' ); ?></th>
+				<th><?php esc_html_e( 'Bonus Hunt', 'bonus-hunt-guesser' ); ?></th>
 		<th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
 		<th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
 		<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
@@ -49,14 +49,14 @@ $hunts = bhg_get_latest_closed_hunts( 3 );
 				  foreach ( $winners as $w ) {
 					  $u  = get_userdata( (int) $w->user_id );
 					  $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-                                          $out[] = sprintf(
-                                                  '%s %s %s (%s %s)',
-                                                  esc_html( $nm ),
-                                                  esc_html__( '—', 'bonus-hunt-guesser' ),
-                                                  esc_html( number_format_i18n( (float) $w->guess, 2 ) ),
-                                                  esc_html__( 'diff', 'bonus-hunt-guesser' ),
-                                                  esc_html( number_format_i18n( (float) $w->diff, 2 ) )
-                                          );
+										  $out[] = sprintf(
+												  '%s %s %s (%s %s)',
+												  esc_html( $nm ),
+												  esc_html__( '—', 'bonus-hunt-guesser' ),
+												  esc_html( number_format_i18n( (float) $w->guess, 2 ) ),
+												  esc_html__( 'diff', 'bonus-hunt-guesser' ),
+												  esc_html( number_format_i18n( (float) $w->diff, 2 ) )
+										  );
 				  }
 				  echo esc_html( implode( ' • ', $out ) );
 			  } else {
@@ -65,8 +65,8 @@ $hunts = bhg_get_latest_closed_hunts( 3 );
 			  ?>
 			</td>
 			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-                        <td><?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-                        <td><?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+						<td><?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+						<td><?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  </tr>
 		<?php endforeach; ?>
 	  <?php else : ?>

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -83,7 +83,7 @@ function bhg_insert_demo_data() {
 	$wpdb->insert(
 		$wpdb->prefix . 'bhg_bonus_hunts',
 		array(
-                        'title' => __( 'Demo Bonus Hunt', 'bonus-hunt-guesser' ),
+						'title' => __( 'Demo Bonus Hunt', 'bonus-hunt-guesser' ),
 			'starting_balance' => 2000,
 			'number_of_bonuses' => 10,
 			'status' => 'active',

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -55,7 +55,7 @@ $pages = max(1, (int) ceil($total / $per_page));
 		<tr>
 		  <td><a href="<?php echo esc_url( admin_url('user-edit.php?user_id='.(int)$r->user_id) ); ?>"><?php echo esc_html($name); ?></a></td>
 		  <td><?php echo esc_html(number_format_i18n((float)$r->guess, 2)); ?></td>
-                  <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+				  <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  <td>
 			<form method="post" style="display:inline">
 			  <?php wp_nonce_field('bhg_remove_guess_action','bhg_remove_guess_nonce'); ?>
@@ -77,18 +77,18 @@ $pages = max(1, (int) ceil($total / $per_page));
 	  <div class="tablenav-pages">
 		<?php
 		  $base = remove_query_arg('ppaged');
-                  for ( $i = 1; $i <= $pages; $i++ ) {
-                        $url   = add_query_arg( 'ppaged', $i, $base );
-                        $class = $i === $paged ? 'page-numbers current' : 'page-numbers';
-                        printf(
-                                '<a class="%1$s" href="%2$s">%3$s</a> ',
-                                esc_attr( $class ),
-                                esc_url( $url ),
-                                esc_html( $i )
-                        );
-                  }
-                ?>
-          </div>
-        </div>
+				  for ( $i = 1; $i <= $pages; $i++ ) {
+						$url   = add_query_arg( 'ppaged', $i, $base );
+						$class = $i === $paged ? 'page-numbers current' : 'page-numbers';
+						printf(
+								'<a class="%1$s" href="%2$s">%3$s</a> ',
+								esc_attr( $class ),
+								esc_url( $url ),
+								esc_html( $i )
+						);
+				  }
+				?>
+		  </div>
+		</div>
   <?php endif; ?>
 </div>

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -23,8 +23,8 @@ $total = (int) $wpdb->get_var( "SELECT COUNT(*) FROM $t" );
 $pages = max(1, (int) ceil($total / $per_page));
 
 $status_labels = [
-        'open'   => __( 'Open', 'bonus-hunt-guesser' ),
-        'closed' => __( 'Closed', 'bonus-hunt-guesser' ),
+		'open'   => __( 'Open', 'bonus-hunt-guesser' ),
+		'closed' => __( 'Closed', 'bonus-hunt-guesser' ),
 ];
 
 ?>
@@ -49,10 +49,10 @@ $status_labels = [
 		  <td><?php echo (int)$r->id; ?></td>
 		  <td><strong><a href="<?php echo esc_url( admin_url('admin.php?page=bhg-hunts-edit&id='.(int)$r->id) ); ?>"><?php echo esc_html($r->title); ?></a></strong></td>
 		  <td><?php echo esc_html(number_format_i18n((float)$r->start_balance, 2)); ?></td>
-                  <td><?php echo ($r->final_balance !== null) ? esc_html( number_format_i18n( (float) $r->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-                  <td><?php echo esc_html( $status_labels[ $r->status ] ?? $r->status ); ?></td>
+				  <td><?php echo ($r->final_balance !== null) ? esc_html( number_format_i18n( (float) $r->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+				  <td><?php echo esc_html( $status_labels[ $r->status ] ?? $r->status ); ?></td>
 		  <td><?php echo (int)$r->winners_limit; ?></td>
-                  <td><?php echo $r->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+				  <td><?php echo $r->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
 		  <td>
 			<?php
 			  $results_url = wp_nonce_url( admin_url('admin.php?page=bhg-hunt-results&id='.(int)$r->id), 'bhg_view_results_'.(int)$r->id, 'bhg_nonce' );
@@ -72,19 +72,19 @@ $status_labels = [
 	<div class="tablenav">
 	  <div class="tablenav-pages">
 		<?php
-                  $base = remove_query_arg( 'paged' );
-                  for ( $i = 1; $i <= $pages; $i++ ) {
-                        $url   = add_query_arg( 'paged', $i, $base );
-                        $class = $i === $paged ? 'page-numbers current' : 'page-numbers';
-                        printf(
-                                '<a class="%1$s" href="%2$s">%3$s</a> ',
-                                esc_attr( $class ),
-                                esc_url( $url ),
-                                esc_html( $i )
-                        );
-                  }
-                ?>
-          </div>
-        </div>
+				  $base = remove_query_arg( 'paged' );
+				  for ( $i = 1; $i <= $pages; $i++ ) {
+						$url   = add_query_arg( 'paged', $i, $base );
+						$class = $i === $paged ? 'page-numbers current' : 'page-numbers';
+						printf(
+								'<a class="%1$s" href="%2$s">%3$s</a> ',
+								esc_attr( $class ),
+								esc_url( $url ),
+								esc_html( $i )
+						);
+				  }
+				?>
+		  </div>
+		</div>
   <?php endif; ?>
 </div>

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -23,12 +23,12 @@ $labels = [
 	'monthly'   => __( 'Monthly', 'bonus-hunt-guesser' ),
 	'quarterly' => __( 'Quarterly', 'bonus-hunt-guesser' ),
 	'yearly'    => __( 'Yearly', 'bonus-hunt-guesser' ),
-        'alltime'   => __( 'Alltime', 'bonus-hunt-guesser' ),
+		'alltime'   => __( 'Alltime', 'bonus-hunt-guesser' ),
 ];
 
 $status_labels = [
-        'active'   => __( 'Active', 'bonus-hunt-guesser' ),
-        'archived' => __( 'Archived', 'bonus-hunt-guesser' ),
+		'active'   => __( 'Active', 'bonus-hunt-guesser' ),
+		'archived' => __( 'Archived', 'bonus-hunt-guesser' ),
 ];
 ?>
 <div class="wrap">
@@ -57,7 +57,7 @@ $status_labels = [
 		  <td><?php echo esc_html( $labels[ $r->type ] ?? $r->type ); ?></td>
 		  <td><?php echo esc_html($r->start_date); ?></td>
 		  <td><?php echo esc_html($r->end_date); ?></td>
-                  <td><?php echo esc_html( $status_labels[ $r->status ] ?? $r->status ); ?></td>
+				  <td><?php echo esc_html( $status_labels[ $r->status ] ?? $r->status ); ?></td>
 		  <td>
 			<a class="button" href="<?php echo esc_url(add_query_arg(['edit' => (int)$r->id])); ?>"><?php esc_html_e('Edit','bonus-hunt-guesser'); ?></a>
 		  </td>
@@ -105,15 +105,15 @@ $status_labels = [
 	  <tr>
 		<th><label for="bhg_t_status"><?php esc_html_e('Status','bonus-hunt-guesser'); ?></label></th>
 		<td>
-                  <?php $st = array_keys( $status_labels ); $cur = $row->status ?? 'active'; ?>
-                  <select id="bhg_t_status" name="status">
-                        <?php foreach ( $st as $v ) : ?>
-                          <option value="<?php echo esc_attr( $v ); ?>" <?php selected( $cur, $v ); ?>><?php echo esc_html( $status_labels[ $v ] ); ?></option>
-                        <?php endforeach; ?>
-                  </select>
-                </td>
-          </tr>
-        </table>
+				  <?php $st = array_keys( $status_labels ); $cur = $row->status ?? 'active'; ?>
+				  <select id="bhg_t_status" name="status">
+						<?php foreach ( $st as $v ) : ?>
+						  <option value="<?php echo esc_attr( $v ); ?>" <?php selected( $cur, $v ); ?>><?php echo esc_html( $status_labels[ $v ] ); ?></option>
+						<?php endforeach; ?>
+				  </select>
+				</td>
+		  </tr>
+		</table>
 	<?php submit_button($row ? __('Update Tournament','bonus-hunt-guesser') : __('Create Tournament','bonus-hunt-guesser')); ?>
   </form>
 </div>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -229,51 +229,51 @@ add_action( 'wp_enqueue_scripts', 'bhg_enqueue_public_assets' );
  * @return void
  */
 function bhg_enqueue_public_assets() {
-        $settings  = get_option( 'bhg_plugin_settings', [] );
-        $min_guess = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
-        $max_guess = isset( $settings['max_guess_amount'] ) ? (float) $settings['max_guess_amount'] : 100000;
+		$settings  = get_option( 'bhg_plugin_settings', [] );
+		$min_guess = isset( $settings['min_guess_amount'] ) ? (float) $settings['min_guess_amount'] : 0;
+		$max_guess = isset( $settings['max_guess_amount'] ) ? (float) $settings['max_guess_amount'] : 100000;
 
-        wp_register_style(
-                'bhg-public',
-                BHG_PLUGIN_URL . 'assets/css/public.css',
-                array(),
-                defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-        );
+		wp_register_style(
+				'bhg-public',
+				BHG_PLUGIN_URL . 'assets/css/public.css',
+				array(),
+				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+		);
 
-        wp_register_script(
-                'bhg-public',
-                BHG_PLUGIN_URL . 'assets/js/public.js',
-                array( 'jquery' ),
-                defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
-                true
-        );
+		wp_register_script(
+				'bhg-public',
+				BHG_PLUGIN_URL . 'assets/js/public.js',
+				array( 'jquery' ),
+				defined( 'BHG_VERSION' ) ? BHG_VERSION : null,
+				true
+		);
 
-        $guess_range = sprintf(
-                __( 'Guess must be between %1$s and %2$s.', 'bonus-hunt-guesser' ),
-                bhg_format_currency( $min_guess ),
-                bhg_format_currency( $max_guess )
-        );
+		$guess_range = sprintf(
+				__( 'Guess must be between %1$s and %2$s.', 'bonus-hunt-guesser' ),
+				bhg_format_currency( $min_guess ),
+				bhg_format_currency( $max_guess )
+		);
 
-        wp_localize_script(
-                'bhg-public',
-                'bhg_public_ajax',
-                array(
-                        'ajax_url'         => admin_url( 'admin-ajax.php' ),
-                        'nonce'            => wp_create_nonce( 'bhg_public_nonce' ),
-                        'is_logged_in'     => is_user_logged_in(),
-                        'min_guess_amount' => $min_guess,
-                        'max_guess_amount' => $max_guess,
-                        'i18n'             => array(
-                                'guess_required'     => __( 'Please enter a guess.', 'bonus-hunt-guesser' ),
-                                'guess_numeric'      => __( 'Please enter a valid number.', 'bonus-hunt-guesser' ),
-                                'guess_range'        => $guess_range,
-                                'guess_submitted'    => __( 'Your guess has been submitted!', 'bonus-hunt-guesser' ),
-                                'ajax_error'         => __( 'An error occurred. Please try again.', 'bonus-hunt-guesser' ),
-                                'affiliate_user'     => __( 'Affiliate', 'bonus-hunt-guesser' ),
-                                'non_affiliate_user' => __( 'Non-affiliate', 'bonus-hunt-guesser' ),
-                        ),
-                )
-        );
+		wp_localize_script(
+				'bhg-public',
+				'bhg_public_ajax',
+				array(
+						'ajax_url'         => admin_url( 'admin-ajax.php' ),
+						'nonce'            => wp_create_nonce( 'bhg_public_nonce' ),
+						'is_logged_in'     => is_user_logged_in(),
+						'min_guess_amount' => $min_guess,
+						'max_guess_amount' => $max_guess,
+						'i18n'             => array(
+								'guess_required'     => __( 'Please enter a guess.', 'bonus-hunt-guesser' ),
+								'guess_numeric'      => __( 'Please enter a valid number.', 'bonus-hunt-guesser' ),
+								'guess_range'        => $guess_range,
+								'guess_submitted'    => __( 'Your guess has been submitted!', 'bonus-hunt-guesser' ),
+								'ajax_error'         => __( 'An error occurred. Please try again.', 'bonus-hunt-guesser' ),
+								'affiliate_user'     => __( 'Affiliate', 'bonus-hunt-guesser' ),
+								'non_affiliate_user' => __( 'Non-affiliate', 'bonus-hunt-guesser' ),
+						),
+				)
+		);
 
 	wp_enqueue_style( 'bhg-public' );
 	wp_enqueue_script( 'bhg-public' );
@@ -351,7 +351,7 @@ function bhg_handle_settings_save() {
 	}
 
 	// Verify nonce
-        if ( ! isset( $_POST['bhg_settings_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['bhg_settings_nonce'] ), 'bhg_save_settings_nonce' ) ) {
+		if ( ! isset( $_POST['bhg_settings_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['bhg_settings_nonce'] ), 'bhg_save_settings_nonce' ) ) {
 		wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=bhg_settings&error=nonce_failed' ) ) );
 		exit;
 	}
@@ -359,22 +359,22 @@ function bhg_handle_settings_save() {
 	// Sanitize and validate data
 	$settings = array();
 
-        if ( isset( $_POST['bhg_default_tournament_period'] ) ) {
-                $period = sanitize_text_field( wp_unslash( $_POST['bhg_default_tournament_period'] ) );
+		if ( isset( $_POST['bhg_default_tournament_period'] ) ) {
+				$period = sanitize_text_field( wp_unslash( $_POST['bhg_default_tournament_period'] ) );
 		if ( in_array( $period, array( 'weekly', 'monthly', 'quarterly', 'yearly', 'alltime' ) ) ) {
 			$settings['default_tournament_period'] = $period;
 		}
 	}
 
-        if ( isset( $_POST['bhg_max_guess_amount'] ) ) {
-                $max = floatval( wp_unslash( $_POST['bhg_max_guess_amount'] ) );
+		if ( isset( $_POST['bhg_max_guess_amount'] ) ) {
+				$max = floatval( wp_unslash( $_POST['bhg_max_guess_amount'] ) );
 		if ( $max >= 0 ) {
 			$settings['max_guess_amount'] = $max;
 		}
 	}
 
-        if ( isset( $_POST['bhg_min_guess_amount'] ) ) {
-                $min = floatval( wp_unslash( $_POST['bhg_min_guess_amount'] ) );
+		if ( isset( $_POST['bhg_min_guess_amount'] ) ) {
+				$min = floatval( wp_unslash( $_POST['bhg_min_guess_amount'] ) );
 		if ( $min >= 0 ) {
 			$settings['min_guess_amount'] = $min;
 		}
@@ -387,20 +387,20 @@ function bhg_handle_settings_save() {
 		exit;
 	}
 
-        if ( isset( $_POST['bhg_allow_guess_changes'] ) ) {
-                $allow = sanitize_text_field( wp_unslash( $_POST['bhg_allow_guess_changes'] ) );
+		if ( isset( $_POST['bhg_allow_guess_changes'] ) ) {
+				$allow = sanitize_text_field( wp_unslash( $_POST['bhg_allow_guess_changes'] ) );
 		if ( in_array( $allow, array( 'yes', 'no' ) ) ) {
 			$settings['allow_guess_changes'] = $allow;
 		}
 	}
 
-        if ( isset( $_POST['bhg_ads_enabled'] ) ) {
-                $ads_enabled           = sanitize_text_field( wp_unslash( $_POST['bhg_ads_enabled'] ) );
+		if ( isset( $_POST['bhg_ads_enabled'] ) ) {
+				$ads_enabled           = sanitize_text_field( wp_unslash( $_POST['bhg_ads_enabled'] ) );
 		$settings['ads_enabled'] = $ads_enabled === '1' ? 1 : 0;
 	}
 
-        if ( isset( $_POST['bhg_email_from'] ) ) {
-                $email_from = sanitize_email( wp_unslash( $_POST['bhg_email_from'] ) );
+		if ( isset( $_POST['bhg_email_from'] ) ) {
+				$email_from = sanitize_email( wp_unslash( $_POST['bhg_email_from'] ) );
 		if ( $email_from ) {
 			$settings['email_from'] = $email_from;
 		}
@@ -569,36 +569,36 @@ function bhg_should_show_ad( $visibility ) {
  * @return array List of ad rows.
  */
 function bhg_build_ads_query( $table, $placement = 'footer' ) {
-        global $wpdb;
+		global $wpdb;
 
-        $allowed_tables = array( $wpdb->prefix . 'bhg_ads' );
-        if ( ! in_array( $table, $allowed_tables, true ) ) {
-                return array();
-        }
+		$allowed_tables = array( $wpdb->prefix . 'bhg_ads' );
+		if ( ! in_array( $table, $allowed_tables, true ) ) {
+				return array();
+		}
 
-        $query = $wpdb->prepare(
-                "SELECT * FROM `{$table}` WHERE placement = %s AND active = %d",
-                $placement,
-                1
-        );
+		$query = $wpdb->prepare(
+				"SELECT * FROM `{$table}` WHERE placement = %s AND active = %d",
+				$placement,
+				1
+		);
 
-        $rows = $wpdb->get_results( $query );
-        if ( did_action( 'wp' ) && function_exists( 'get_queried_object_id' ) ) {
-                $pid = (int) get_queried_object_id();
-                if ( $pid && is_array( $rows ) ) {
-                        $rows = array_filter(
-                                $rows,
-                                function( $r ) use ( $pid ) {
-                                        if ( empty( $r->target_pages ) ) {
-                                                return true;
-                                        }
-                                        $ids = array_filter( array_map( 'intval', array_map( 'trim', explode( ',', $r->target_pages ) ) ) );
-                                        return in_array( $pid, $ids, true );
-                                }
-                        );
-                }
-        }
-        return $rows;
+		$rows = $wpdb->get_results( $query );
+		if ( did_action( 'wp' ) && function_exists( 'get_queried_object_id' ) ) {
+				$pid = (int) get_queried_object_id();
+				if ( $pid && is_array( $rows ) ) {
+						$rows = array_filter(
+								$rows,
+								function( $r ) use ( $pid ) {
+										if ( empty( $r->target_pages ) ) {
+												return true;
+										}
+										$ids = array_filter( array_map( 'intval', array_map( 'trim', explode( ',', $r->target_pages ) ) ) );
+										return in_array( $pid, $ids, true );
+								}
+						);
+				}
+		}
+		return $rows;
 }
 
 // AJAX handler for loading leaderboard data
@@ -725,8 +725,8 @@ function bhg_generate_leaderboard_html( $timeframe ) {
 
 	$pos = $offset + 1;
 	foreach ( $rows as $row ) {
-               /* translators: %d: user ID. */
-               $user_label = $row->user_login ? $row->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $row->user_id );
+			   /* translators: %d: user ID. */
+			   $user_label = $row->user_login ? $row->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $row->user_id );
 		echo '<tr>';
 		echo '<td>' . (int) $pos++ . '</td>';
 		echo '<td>' . esc_html( $user_label ) . '</td>';

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -39,44 +39,44 @@ class BHG_Shortcodes {
 			return '';
 		}
 
-                $base     = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
-                $redirect = esc_url_raw( add_query_arg( array(), $base ) );
+				$base     = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
+				$redirect = esc_url_raw( add_query_arg( array(), $base ) );
 
 		return '<p>' . esc_html__( 'Please log in to continue.', 'bonus-hunt-guesser' ) . '</p>'
 			 . '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
 	}
 
 	/** [bhg_active_hunt] — list all open hunts */
-        public function active_hunt_shortcode($atts) {
-                global $wpdb;
-               $hunts = $wpdb->get_results(
-                       $wpdb->prepare(
-                               "SELECT * FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status=%s ORDER BY created_at DESC",
-                               'open'
-                       )
-               );
-                if (!$hunts) {
-                        return '<div class="bhg-active-hunt"><p>' . esc_html__('No active bonus hunts at the moment.', 'bonus-hunt-guesser') . '</p></div>';
-                }
+		public function active_hunt_shortcode($atts) {
+				global $wpdb;
+			   $hunts = $wpdb->get_results(
+					   $wpdb->prepare(
+							   "SELECT * FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status=%s ORDER BY created_at DESC",
+							   'open'
+					   )
+			   );
+				if (!$hunts) {
+						return '<div class="bhg-active-hunt"><p>' . esc_html__('No active bonus hunts at the moment.', 'bonus-hunt-guesser') . '</p></div>';
+				}
 
-               wp_enqueue_style(
-                       'bhg-shortcodes',
-                       BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-                       array(),
-                       defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-               );
+			   wp_enqueue_style(
+					   'bhg-shortcodes',
+					   BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+					   array(),
+					   defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+			   );
 
-               ob_start();
-               echo '<div class="bhg-active-hunts">';
-               foreach ($hunts as $hunt) {
-                       echo '<div class="bhg-hunt-card">';
-                       echo '<h3>' . esc_html($hunt->title) . '</h3>';
-                       echo '<ul class="bhg-hunt-meta">';
-                       echo '<li><strong>' . esc_html__('Starting Balance', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(number_format_i18n((float)$hunt->starting_balance, 2)) . '</li>';
-                       echo '<li><strong>' . esc_html__('Number of Bonuses', 'bonus-hunt-guesser') . ':</strong> ' . (int)$hunt->num_bonuses . '</li>';
-                       if (!empty($hunt->prizes)) {
-                               echo '<li><strong>' . esc_html__('Prizes', 'bonus-hunt-guesser') . ':</strong> ' . wp_kses_post($hunt->prizes) . '</li>';
-                       }
+			   ob_start();
+			   echo '<div class="bhg-active-hunts">';
+			   foreach ($hunts as $hunt) {
+					   echo '<div class="bhg-hunt-card">';
+					   echo '<h3>' . esc_html($hunt->title) . '</h3>';
+					   echo '<ul class="bhg-hunt-meta">';
+					   echo '<li><strong>' . esc_html__('Starting Balance', 'bonus-hunt-guesser') . ':</strong> ' . esc_html(number_format_i18n((float)$hunt->starting_balance, 2)) . '</li>';
+					   echo '<li><strong>' . esc_html__('Number of Bonuses', 'bonus-hunt-guesser') . ':</strong> ' . (int)$hunt->num_bonuses . '</li>';
+					   if (!empty($hunt->prizes)) {
+							   echo '<li><strong>' . esc_html__('Prizes', 'bonus-hunt-guesser') . ':</strong> ' . wp_kses_post($hunt->prizes) . '</li>';
+					   }
 			echo '</ul>';
 			echo '</div>';
 		}
@@ -90,20 +90,20 @@ class BHG_Shortcodes {
 		$hunt_id = (int) $atts['hunt_id'];
 
 		if ( ! is_user_logged_in() ) {
-                        $base     = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
-                        $redirect = esc_url_raw( add_query_arg( array(), $base ) );
+						$base     = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
+						$redirect = esc_url_raw( add_query_arg( array(), $base ) );
 
 			return '<p>' . esc_html__( 'Please log in to submit your guess.', 'bonus-hunt-guesser' ) . '</p>'
 				 . '<p><a class="button button-primary" href="' . esc_url( wp_login_url( $redirect ) ) . '">' . esc_html__( 'Log in', 'bonus-hunt-guesser' ) . '</a></p>';
 		}
 
-               global $wpdb;
-               $open_hunts = $wpdb->get_results(
-                       $wpdb->prepare(
-                               "SELECT id, title FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status=%s ORDER BY created_at DESC",
-                               'open'
-                       )
-               );
+			   global $wpdb;
+			   $open_hunts = $wpdb->get_results(
+					   $wpdb->prepare(
+							   "SELECT id, title FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status=%s ORDER BY created_at DESC",
+							   'open'
+					   )
+			   );
 
 		if ($hunt_id <= 0) {
 			if (!$open_hunts) {
@@ -119,19 +119,19 @@ class BHG_Shortcodes {
 		$existing_id = $hunt_id > 0 ? (int)$wpdb->get_var($wpdb->prepare("SELECT id FROM {$table} WHERE user_id=%d AND hunt_id=%d", $user_id, $hunt_id)) : 0;
 		$existing_guess = $existing_id ? (float) $wpdb->get_var($wpdb->prepare("SELECT guess FROM {$table} WHERE id=%d", $existing_id)) : '';
 
-               $settings = get_option('bhg_plugin_settings');
-               $min = isset($settings['min_guess_amount']) ? (float)$settings['min_guess_amount'] : 0;
-               $max = isset($settings['max_guess_amount']) ? (float)$settings['max_guess_amount'] : 100000;
+			   $settings = get_option('bhg_plugin_settings');
+			   $min = isset($settings['min_guess_amount']) ? (float)$settings['min_guess_amount'] : 0;
+			   $max = isset($settings['max_guess_amount']) ? (float)$settings['max_guess_amount'] : 100000;
 
-               wp_enqueue_style(
-                       'bhg-shortcodes',
-                       BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-                       array(),
-                       defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-               );
+			   wp_enqueue_style(
+					   'bhg-shortcodes',
+					   BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+					   array(),
+					   defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+			   );
 
-               ob_start(); ?>
-               <form class="bhg-guess-form" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+			   ob_start(); ?>
+			   <form class="bhg-guess-form" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
 			<input type="hidden" name="action" value="bhg_submit_guess">
 			<?php wp_nonce_field('bhg_submit_guess', 'bhg_nonce'); ?>
 
@@ -172,17 +172,17 @@ class BHG_Shortcodes {
 
 		global $wpdb;
 		$hunt_id = (int)$a['hunt_id'];
-               if ($hunt_id <= 0) {
-                       $hunt_id = (int) $wpdb->get_var(
-                               $wpdb->prepare(
-                                       "SELECT id FROM {$wpdb->prefix}bhg_bonus_hunts ORDER BY created_at DESC LIMIT %d",
-                                       1
-                               )
-                       );
-                       if ($hunt_id <= 0) {
-                               return '<p>' . esc_html__('No hunts found.', 'bonus-hunt-guesser') . '</p>';
-                       }
-               }
+			   if ($hunt_id <= 0) {
+					   $hunt_id = (int) $wpdb->get_var(
+							   $wpdb->prepare(
+									   "SELECT id FROM {$wpdb->prefix}bhg_bonus_hunts ORDER BY created_at DESC LIMIT %d",
+									   1
+							   )
+					   );
+					   if ($hunt_id <= 0) {
+							   return '<p>' . esc_html__('No hunts found.', 'bonus-hunt-guesser') . '</p>';
+					   }
+			   }
 
 		$g = $wpdb->prefix . 'bhg_guesses';
 		$u = $wpdb->users;
@@ -236,8 +236,8 @@ class BHG_Shortcodes {
 				? (int)get_user_meta((int)$r->user_id, 'bhg_affiliate_website_' . $site_id, true)
 				: (int)get_user_meta((int)$r->user_id, 'bhg_is_affiliate', true);
 			$aff = $is_aff ? 'green' : 'red';
-                       /* translators: %d: user ID. */
-                       $user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
+					   /* translators: %d: user ID. */
+					   $user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
 
 			echo '<tr>';
 			echo '<td data-column="position">' . (int)$pos++ . '</td>';
@@ -249,20 +249,20 @@ class BHG_Shortcodes {
 
 		$pages = (int) ceil( $total / $per );
 		if ( $pages > 1 ) {
-                        $base = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
-                        $base = esc_url_raw( remove_query_arg( 'page', $base ) );
-                        echo '<div class="bhg-pagination">';
-                        for ( $p = 1; $p <= $pages; $p++ ) {
-                                $class = $p == $page ? 'bhg-current-page' : '';
-                                printf(
-                                        '<a class="%1$s" href="%2$s">%3$s</a> ',
-                                        esc_attr( $class ),
-                                        esc_url( add_query_arg( array( 'page' => $p ), $base ) ),
-                                        esc_html( $p )
-                                );
-                        }
-                        echo '</div>';
-                }
+						$base = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
+						$base = esc_url_raw( remove_query_arg( 'page', $base ) );
+						echo '<div class="bhg-pagination">';
+						for ( $p = 1; $p <= $pages; $p++ ) {
+								$class = $p == $page ? 'bhg-current-page' : '';
+								printf(
+										'<a class="%1$s" href="%2$s">%3$s</a> ',
+										esc_attr( $class ),
+										esc_url( add_query_arg( array( 'page' => $p ), $base ) ),
+										esc_html( $p )
+								);
+						}
+						echo '</div>';
+				}
 
 			   return ob_get_clean();
 	   }
@@ -352,11 +352,11 @@ class BHG_Shortcodes {
 					   echo '<td>' . esc_html( $row->title ) . '</td>';
 					   $guess_cell = esc_html( number_format_i18n( (float) $row->guess, 2 ) );
 					   if ( $show_aff ) {
-                                           $guess_cell = bhg_render_affiliate_dot( $user_id, (int) $row->affiliate_site_id ) . $guess_cell;
-                                           }
-                                           echo '<td>' . wp_kses_post( $guess_cell ) . '</td>';
+										   $guess_cell = bhg_render_affiliate_dot( $user_id, (int) $row->affiliate_site_id ) . $guess_cell;
+										   }
+										   echo '<td>' . wp_kses_post( $guess_cell ) . '</td>';
 					   echo '<td>';
-                                           echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html__( '&mdash;', 'bonus-hunt-guesser' );
+										   echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html__( '&mdash;', 'bonus-hunt-guesser' );
 					   echo '</td>';
 					   echo '</tr>';
 			   }
@@ -442,12 +442,12 @@ class BHG_Shortcodes {
 					   echo '<td>' . esc_html( $row->title ) . '</td>';
 					   echo '<td>' . esc_html( number_format_i18n( (float) $row->starting_balance, 2 ) ) . '</td>';
 					   echo '<td>';
-                                           echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html__( '&mdash;', 'bonus-hunt-guesser' );
-                                           echo '</td>';
-                                           echo '<td>' . esc_html( $row->status ) . '</td>';
-                                           if ( $show_aff ) {
-                                                           echo '<td>' . ( $row->aff_name ? esc_html( $row->aff_name ) : esc_html__( '—', 'bonus-hunt-guesser' ) ) . '</td>';
-                                           }
+										   echo isset( $row->final_balance ) ? esc_html( number_format_i18n( (float) $row->final_balance, 2 ) ) : esc_html__( '&mdash;', 'bonus-hunt-guesser' );
+										   echo '</td>';
+										   echo '<td>' . esc_html( $row->status ) . '</td>';
+										   if ( $show_aff ) {
+														   echo '<td>' . ( $row->aff_name ? esc_html( $row->aff_name ) : esc_html__( '—', 'bonus-hunt-guesser' ) ) . '</td>';
+										   }
 					   echo '</tr>';
 			   }
 			   echo '</tbody></table>';
@@ -517,13 +517,13 @@ class BHG_Shortcodes {
 			   foreach ( $hunts as $hunt ) {
 					   echo '<div class="bhg-leaderboard-wrap">';
 					   echo '<h3>' . esc_html( $hunt->title ) . '</h3>';
-                                           $html = $this->leaderboard_shortcode( array( 'hunt_id' => (int) $hunt->id ) );
-                                           if ( ! $show_aff ) {
-                                                           $html = preg_replace( '/<span class="bhg-aff-dot[^>]*><\/span>/', '', $html );
-                                           }
-                                           echo wp_kses_post( $html );
-                                           echo '</div>';
-                           }
+										   $html = $this->leaderboard_shortcode( array( 'hunt_id' => (int) $hunt->id ) );
+										   if ( ! $show_aff ) {
+														   $html = preg_replace( '/<span class="bhg-aff-dot[^>]*><\/span>/', '', $html );
+										   }
+										   echo wp_kses_post( $html );
+										   echo '</div>';
+						   }
 			   return ob_get_clean();
 	   }
 
@@ -541,15 +541,15 @@ class BHG_Shortcodes {
 		* @param array $atts Shortcode attributes.
 		* @return string HTML output.
 		*/
-       public function tournaments_shortcode($atts) {
-                          global $wpdb;
+	   public function tournaments_shortcode($atts) {
+						  global $wpdb;
 
-               wp_enqueue_style(
-                       'bhg-shortcodes',
-                       BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-                       array(),
-                       defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-               );
+			   wp_enqueue_style(
+					   'bhg-shortcodes',
+					   BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+					   array(),
+					   defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+			   );
 
 		// If a specific tournament ID is requested, render details
 		$details_id = isset($_GET['bhg_tournament_id']) ? absint($_GET['bhg_tournament_id']) : 0;
@@ -621,10 +621,10 @@ foreach ($rows as $row) {
 echo '<tr>';
 echo '<td>' . (int)$pos++ . '</td>';
 echo '<td>' . esc_html( $row->user_login ?: sprintf(
-                                       /* translators: %d: user ID. */
-                                       __( 'user#%d', 'bonus-hunt-guesser' ),
-                                       (int) $row->user_id
-                               ) ) . '</td>';
+									   /* translators: %d: user ID. */
+									   __( 'user#%d', 'bonus-hunt-guesser' ),
+									   (int) $row->user_id
+							   ) ) . '</td>';
 echo '<td>' . (int)$row->wins . '</td>';
 echo '<td>' . ( $row->last_win_date ? esc_html( mysql2date( get_option( 'date_format' ), $row->last_win_date ) ) : esc_html__( '—', 'bonus-hunt-guesser' ) ) . '</td>';
 				echo '</tr>';
@@ -682,9 +682,9 @@ echo '<td>' . ( $row->last_win_date ? esc_html( mysql2date( get_option( 'date_fo
 			   if (!$rows) {
 					   return '<p>' . esc_html__('No tournaments found.', 'bonus-hunt-guesser') . '</p>';
 			   }
-                               $current_url = isset( $_SERVER['REQUEST_URI'] )
-                                       ? esc_url_raw( wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) ) )
-                                       : home_url( '/' );
+							   $current_url = isset( $_SERVER['REQUEST_URI'] )
+									   ? esc_url_raw( wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) ) )
+									   : home_url( '/' );
 
 				ob_start();
 echo '<form method="get" class="bhg-tournament-filters">';
@@ -757,25 +757,25 @@ echo '<td><a href="' . esc_url( $detail_url ) . '">' . esc_html__( 'Show details
 			)
 		);
 
-               if ( ! $hunts ) {
-                       return '<p>' . esc_html__( 'No closed hunts yet.', 'bonus-hunt-guesser' ) . '</p>';
-               }
+			   if ( ! $hunts ) {
+					   return '<p>' . esc_html__( 'No closed hunts yet.', 'bonus-hunt-guesser' ) . '</p>';
+			   }
 
-               wp_enqueue_style(
-                       'bhg-shortcodes',
-                       BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-                       array(),
-                       defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-               );
+			   wp_enqueue_style(
+					   'bhg-shortcodes',
+					   BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+					   array(),
+					   defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+			   );
 
-               ob_start();
-               echo '<div class="bhg-winner-notifications">';
-               foreach ( $hunts as $hunt ) {
-                        $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
-                                ? bhg_get_top_winners_for_hunt( $hunt->id, (int) $hunt->winners_count )
-                                : array();
+			   ob_start();
+			   echo '<div class="bhg-winner-notifications">';
+			   foreach ( $hunts as $hunt ) {
+						$winners = function_exists( 'bhg_get_top_winners_for_hunt' )
+								? bhg_get_top_winners_for_hunt( $hunt->id, (int) $hunt->winners_count )
+								: array();
 
-                       echo '<div class="bhg-winner">';
+					   echo '<div class="bhg-winner">';
 			echo '<p><strong>' . esc_html( $hunt->title ) . '</strong></p>';
 			if ( $hunt->final_balance !== null ) {
 				echo '<p><em>' . esc_html__( 'Final', 'bonus-hunt-guesser' ) . ':</em> ' . esc_html( number_format_i18n( (float) $hunt->final_balance, 2 ) ) . '</p>';
@@ -786,7 +786,7 @@ echo '<td><a href="' . esc_url( $detail_url ) . '">' . esc_html__( 'Show details
 				foreach ( $winners as $w ) {
 					$u  = get_userdata( (int) $w->user_id );
 					$nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-                                        echo '<li>' . esc_html( $nm ) . ' ' . esc_html__( '—', 'bonus-hunt-guesser' ) . ' ' . esc_html( number_format_i18n( (float) $w->guess, 2 ) ) . ' (' . esc_html( number_format_i18n( (float) $w->diff, 2 ) ) . ')</li>';
+										echo '<li>' . esc_html( $nm ) . ' ' . esc_html__( '—', 'bonus-hunt-guesser' ) . ' ' . esc_html( number_format_i18n( (float) $w->guess, 2 ) ) . ' (' . esc_html( number_format_i18n( (float) $w->diff, 2 ) ) . ')</li>';
 				}
 				echo '</ul>';
 			}
@@ -879,18 +879,18 @@ echo '<td><a href="' . esc_url( $detail_url ) . '">' . esc_html__( 'Show details
 						GROUP BY u.ID, u.user_login
 						ORDER BY total_wins DESC, u.user_login ASC
 						LIMIT %d";
-                                $results[$key] = $wpdb->get_results( $wpdb->prepare( $sql, 50 ) );
+								$results[$key] = $wpdb->get_results( $wpdb->prepare( $sql, 50 ) );
 			}
 		}
 
-               $hunts_tbl = $wpdb->prefix . 'bhg_bonus_hunts';
-               $hunts = $wpdb->get_results(
-                       $wpdb->prepare(
-                               "SELECT id, title FROM {$hunts_tbl} WHERE status=%s ORDER BY created_at DESC LIMIT %d",
-                               'closed',
-                               50
-                       )
-               );
+			   $hunts_tbl = $wpdb->prefix . 'bhg_bonus_hunts';
+			   $hunts = $wpdb->get_results(
+					   $wpdb->prepare(
+							   "SELECT id, title FROM {$hunts_tbl} WHERE status=%s ORDER BY created_at DESC LIMIT %d",
+							   'closed',
+							   50
+					   )
+			   );
 
 		wp_enqueue_style(
 			'bhg-shortcodes',
@@ -907,46 +907,46 @@ echo '<td><a href="' . esc_url( $detail_url ) . '">' . esc_html__( 'Show details
 		);
 
 		ob_start();
-                echo '<ul class="bhg-tabs">';
-                $first = true;
-                foreach ( $periods as $key => $info ) {
-                        echo '<li' . ( $first ? ' class="active"' : '' ) . '><a href="#bhg-tab-' . esc_attr( $key ) . '">' . esc_html( $info['label'] ) . '</a></li>';
-                        $first = false;
-                }
-                if ($hunts) {
+				echo '<ul class="bhg-tabs">';
+				$first = true;
+				foreach ( $periods as $key => $info ) {
+						echo '<li' . ( $first ? ' class="active"' : '' ) . '><a href="#bhg-tab-' . esc_attr( $key ) . '">' . esc_html( $info['label'] ) . '</a></li>';
+						$first = false;
+				}
+				if ($hunts) {
 			echo '<li><a href="#bhg-tab-hunts">' . esc_html__('Bonus Hunts', 'bonus-hunt-guesser') . '</a></li>';
 		}
 		echo '</ul>';
 
-                $first = true;
-                foreach ( $periods as $key => $info ) {
-                        echo '<div id="bhg-tab-' . esc_attr( $key ) . '" class="bhg-tab-pane' . ( $first ? ' active' : '' ) . '">';
-                        $rows = isset( $results[ $key ] ) ? $results[ $key ] : array();
-                        if ( ! $rows ) {
-                                echo '<p>' . esc_html__( 'No data yet.', 'bonus-hunt-guesser' ) . '</p>';
-                        } else {
-                                echo '<table class="bhg-leaderboard"><thead><tr><th>#</th><th>' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th><th>' . esc_html__( 'Wins', 'bonus-hunt-guesser' ) . '</th></tr></thead><tbody>';
-                                $pos = 1;
-                                foreach ( $rows as $r ) {
-                                       /* translators: %d: user ID. */
-                                       $user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
-                                        echo '<tr><td>' . (int) $pos++ . '</td><td>' . esc_html( $user_label ) . '</td><td>' . (int) $r->total_wins . '</td></tr>';
-                                }
-                                echo '</tbody></table>';
-                        }
-                        echo '</div>';
-                        $first = false;
-                }
+				$first = true;
+				foreach ( $periods as $key => $info ) {
+						echo '<div id="bhg-tab-' . esc_attr( $key ) . '" class="bhg-tab-pane' . ( $first ? ' active' : '' ) . '">';
+						$rows = isset( $results[ $key ] ) ? $results[ $key ] : array();
+						if ( ! $rows ) {
+								echo '<p>' . esc_html__( 'No data yet.', 'bonus-hunt-guesser' ) . '</p>';
+						} else {
+								echo '<table class="bhg-leaderboard"><thead><tr><th>#</th><th>' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th><th>' . esc_html__( 'Wins', 'bonus-hunt-guesser' ) . '</th></tr></thead><tbody>';
+								$pos = 1;
+								foreach ( $rows as $r ) {
+									   /* translators: %d: user ID. */
+									   $user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
+										echo '<tr><td>' . (int) $pos++ . '</td><td>' . esc_html( $user_label ) . '</td><td>' . (int) $r->total_wins . '</td></tr>';
+								}
+								echo '</tbody></table>';
+						}
+						echo '</div>';
+						$first = false;
+				}
 
 		if ( $hunts ) {
-                       $base = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
-                       $base = esc_url_raw( remove_query_arg( 'hunt_id', $base ) );
+					   $base = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
+					   $base = esc_url_raw( remove_query_arg( 'hunt_id', $base ) );
 			echo '<div id="bhg-tab-hunts" class="bhg-tab-pane">';
 			echo '<ul class="bhg-hunt-history">';
 			foreach ( $hunts as $hunt ) {
-                                $url = add_query_arg( 'hunt_id', (int) $hunt->id, $base );
-                                echo '<li><a href="' . esc_url( $url ) . '">' . esc_html( $hunt->title ) . '</a></li>';
-                        }
+								$url = add_query_arg( 'hunt_id', (int) $hunt->id, $base );
+								echo '<li><a href="' . esc_url( $url ) . '">' . esc_html( $hunt->title ) . '</a></li>';
+						}
 			echo '</ul>';
 			echo '</div>';
 		}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -207,16 +207,16 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 			'label_user_number'           => 'User #%d',
 			'label_diff'                  => 'diff',
 			'notice_login_view_content'   => 'Please log in to view this content.',
-                        'label_latest_hunts'          => 'Latest Hunts',
-                        'label_bonushunt'             => 'Bonushunt',
-                        'label_all_winners'           => 'All Winners',
-                        'label_closed_at'             => 'Closed At',
-                        'label_hunt'                  => 'Hunt',
-                        'label_title'                 => 'Title',
-                        'notice_no_user_specified'    => 'No user specified.',
-                        'notice_no_guesses_found'     => 'No guesses found.',
-                        'msg_no_ads_yet'              => 'No ads yet.',
-                        'notice_no_winners_yet'       => 'No winners yet.',
+						'label_latest_hunts'          => 'Latest Hunts',
+						'label_bonushunt'             => 'Bonushunt',
+						'label_all_winners'           => 'All Winners',
+						'label_closed_at'             => 'Closed At',
+						'label_hunt'                  => 'Hunt',
+						'label_title'                 => 'Title',
+						'notice_no_user_specified'    => 'No user specified.',
+						'notice_no_guesses_found'     => 'No guesses found.',
+						'msg_no_ads_yet'              => 'No ads yet.',
+						'notice_no_winners_yet'       => 'No winners yet.',
 				// Shortcode labels for public views.
 				'sc_hunt'                     => 'Hunt',
 				'sc_guess'                    => 'Guess',
@@ -228,8 +228,8 @@ if ( ! function_exists( 'bhg_get_default_translations' ) ) {
 				'sc_affiliate'                => 'Affiliate',
 				'sc_position'                 => 'Position',
 				'sc_user'                     => 'User',
-                );
-        }
+				);
+		}
 }
 
 if ( ! function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
@@ -517,12 +517,12 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 				'num_bonuses' => 10,
 				'prizes' => __('Gift card + swag', 'bonus-hunt-guesser'),
 				'status' => 'open',
-                               'affiliate_site_id' => (int) $wpdb->get_var(
-                                       $wpdb->prepare(
-                                               "SELECT id FROM {$p}bhg_affiliate_websites ORDER BY id ASC LIMIT %d",
-                                               1
-                                       )
-                               ),
+							   'affiliate_site_id' => (int) $wpdb->get_var(
+									   $wpdb->prepare(
+											   "SELECT id FROM {$p}bhg_affiliate_websites ORDER BY id ASC LIMIT %d",
+											   1
+									   )
+							   ),
 				'created_at' => $now,
 				'updated_at' => $now,
 			), array('%s','%f','%d','%s','%s','%d','%s','%s'));
@@ -569,12 +569,12 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 			if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $r_tbl)) === $r_tbl) {
 				$wpdb->query( "DELETE FROM `{$r_tbl}`" );
 			}
-                       $closed = $wpdb->get_results(
-                               $wpdb->prepare(
-                                       "SELECT winner_user_id, closed_at FROM {$hunts_tbl} WHERE status=%s AND winner_user_id IS NOT NULL",
-                                       'closed'
-                               )
-                       );
+					   $closed = $wpdb->get_results(
+							   $wpdb->prepare(
+									   "SELECT winner_user_id, closed_at FROM {$hunts_tbl} WHERE status=%s AND winner_user_id IS NOT NULL",
+									   'closed'
+							   )
+					   );
 			foreach ($closed as $row) {
 				$ts = $row->closed_at ? strtotime($row->closed_at) : time();
 				$isoYear = date('o', $ts);


### PR DESCRIPTION
## Summary
- Replaced leading spaces with tabs in admin and other PHP files to align with WordPress Coding Standards.
- Verified coding style using PHP_CodeSniffer.

## Testing
- `~/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs admin/class-bhg-admin.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb301f1a4c8333a344dc1efcbc7066