### PR TITLE
Use printf for results heading

### DIFF
--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -16,7 +16,7 @@ $rows = $wpdb->get_results(
 );
 ?>
 <div class="wrap">
-  <h1><?php echo esc_html__('Results for ','bonus-hunt-guesser').esc_html($hunt->title); ?></h1>
+  <h1><?php printf( esc_html__( 'Results for %s', 'bonus-hunt-guesser' ), esc_html( $hunt->title ) ); ?></h1>
   <table class="widefat striped">
 	<thead><tr>
 	  <th><?php esc_html_e('Position','bonus-hunt-guesser'); ?></th>


### PR DESCRIPTION
## Summary
- switch bonus hunt results heading to `printf` for safer translation-friendly output

## Testing
- `/root/.local/share/mise/installs/php/8.4.12/.composer/vendor/bin/phpcs --standard=phpcs.xml admin/views/bonus-hunts-results.php` *(fails: referenced file contains 91 errors and 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bb310858cc833395ce55987f9d6b84