### PR TITLE
Use prepared query for translations lookup

### DIFF
--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -51,7 +51,7 @@ if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'
 }
 
 // Fetch rows.
-$rows = $wpdb->get_results( "SELECT tkey, tvalue FROM {$table} ORDER BY tkey ASC" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+$rows = $wpdb->get_results( $wpdb->prepare( "SELECT tkey, tvalue FROM {$wpdb->prefix}bhg_translations ORDER BY tkey ASC" ) );
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Translations', 'bonus-hunt-guesser' ); ?></h1>


### PR DESCRIPTION
## Summary
- sanitize translations query and use `$wpdb->prepare()` with `$wpdb->get_results()`

## Testing
- `phpcs admin/views/translations.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb31afec9c8333b98616af48e92417