### PR TITLE
Docs: update minimum WordPress version

### DIFF
--- a/README-Stage-A.txt
+++ b/README-Stage-A.txt
@@ -1,6 +1,6 @@
 Bonus Hunt Guesser — Stage A Patch
 Generated: 2025-09-05T03:13:45.120802
-Requires at least: 5.5.5
+Requires at least: 6.3.5
 
 WHAT THIS PATCH DELIVERS
 - Fixes parse error in admin/views/translations.php

--- a/README-Stage-B.txt
+++ b/README-Stage-B.txt
@@ -1,6 +1,6 @@
 Bonus Hunt Guesser — Stage B Patch
 Generated: 2025-09-05T03:18:38.706805
-Requires at least: 5.5.5
+Requires at least: 6.3.5
 
 WHAT THIS PATCH DELIVERS
 - Adds "Results" button to the hunts list (Admin → Bonus Hunts).


### PR DESCRIPTION
## Summary
- align README stage notes with the plugin's minimum WordPress version (6.3.5)
- confirm CHANGELOG notes WordPress 6.3.5 compatibility

## Testing
- `php -l bonus-hunt-guesser.php`
- `phpcs bonus-hunt-guesser.php` *(fails: numerous WordPress coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7e6e61388333b13bde7497d4374c