### PR TITLE
Improve SQL preparation and placeholder handling

### DIFF
--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -123,7 +123,8 @@ class BHG_Users_Table extends WP_List_Table {
 			// Guesses per user
 			$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
 			$sql_g        = "SELECT user_id, COUNT(*) c FROM `$g_table` WHERE user_id IN ($placeholders) GROUP BY user_id";
-			$g_counts     = $wpdb->get_results( $wpdb->prepare( $sql_g, $ids ) );
+			$prepared     = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql_g ), $ids ) );
+			$g_counts     = $wpdb->get_results( $prepared );
 			foreach ( (array) $g_counts as $row ) {
 				$uid = (int) $row->user_id;
 				if ( isset( $items[ $uid ] ) ) {
@@ -136,7 +137,8 @@ class BHG_Users_Table extends WP_List_Table {
 			if ( $exists ) {
 				$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
 				$sql_w        = "SELECT user_id, SUM(wins) c FROM `$w_table` WHERE user_id IN ($placeholders) GROUP BY user_id";
-				$w_counts     = $wpdb->get_results( $wpdb->prepare( $sql_w, $ids ) );
+				$prepared_w   = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql_w ), $ids ) );
+				$w_counts     = $wpdb->get_results( $prepared_w );
 				foreach ( (array) $w_counts as $row ) {
 					$uid = (int) $row->user_id;
 					if ( isset( $items[ $uid ] ) ) {

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -51,7 +51,7 @@ if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'
 }
 
 // Fetch rows.
-$rows = $wpdb->get_results( $wpdb->prepare( "SELECT tkey, tvalue FROM {$wpdb->prefix}bhg_translations ORDER BY tkey ASC" ) );
+$rows = $wpdb->get_results( "SELECT tkey, tvalue FROM {$wpdb->prefix}bhg_translations ORDER BY tkey ASC" );
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Translations', 'bonus-hunt-guesser' ); ?></h1>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -704,11 +704,12 @@ function bhg_generate_leaderboard_html( $timeframe ) {
 			GROUP BY g.user_id
 		) t";
 
-	if ( $args ) {
-		$total = (int) $wpdb->get_var( $wpdb->prepare( $sql_total, $args ) );
-	} else {
-		$total = (int) $wpdb->get_var( $sql_total );
-	}
+        if ( $args ) {
+                $prepared = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql_total ), $args ) );
+                $total    = (int) $wpdb->get_var( $prepared );
+        } else {
+                $total = (int) $wpdb->get_var( $sql_total );
+        }
 
 	$sql = "
 		SELECT g.user_id, u.user_login, COUNT(*) AS wins
@@ -724,10 +725,11 @@ function bhg_generate_leaderboard_html( $timeframe ) {
 		ORDER BY wins DESC, u.user_login ASC
 		LIMIT %d OFFSET %d";
 
-	$args_query   = $args;
-	$args_query[] = $per_page;
-	$args_query[] = $offset;
-	$rows         = $wpdb->get_results( $wpdb->prepare( $sql, $args_query ) );
+        $args_query   = $args;
+        $args_query[] = $per_page;
+        $args_query[] = $offset;
+        $prepared     = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $args_query ) );
+        $rows         = $wpdb->get_results( $prepared );
 
 	if ( ! $rows ) {
 		return '<p>' . esc_html__( 'No data available.', 'bonus-hunt-guesser' ) . '</p>';

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -347,7 +347,8 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					   WHERE " . implode( ' AND ', $where ) . "
 					   ORDER BY {$orderby} {$order}{$limit_sql}";
 
-			$rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
+                        $prepared = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $params ) );
+                        $rows     = $wpdb->get_results( $prepared );
 			if ( ! $rows ) {
 					return '<p>' . esc_html__( 'No guesses found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -433,7 +434,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					$sql .= ' LIMIT 10';
 			}
 
-				$rows = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ) ) : $wpdb->get_results( $sql );
+                        if ( $params ) {
+                                $prepared = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $params ) );
+                                $rows     = $wpdb->get_results( $prepared );
+                        } else {
+                                $rows = $wpdb->get_results( $sql );
+                        }
 			if ( ! $rows ) {
 					return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -520,7 +526,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					$sql .= ' LIMIT 5';
 			}
 
-				$hunts = $params ? $wpdb->get_results( $wpdb->prepare( $sql, $params ) ) : $wpdb->get_results( $sql );
+                                if ( $params ) {
+                                        $prepared = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $params ) );
+                                        $hunts    = $wpdb->get_results( $prepared );
+                                } else {
+                                        $hunts = $wpdb->get_results( $sql );
+                                }
 			if ( ! $hunts ) {
 					return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
 			}
@@ -708,7 +719,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			}
 				$sql .= ' ORDER BY start_date DESC, id DESC';
 
-				$rows = $args ? $wpdb->get_results( $wpdb->prepare( $sql, $args ) ) : $wpdb->get_results( $sql );
+                                if ( $args ) {
+                                        $prepared = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $args ) );
+                                        $rows     = $wpdb->get_results( $prepared );
+                                } else {
+                                        $rows = $wpdb->get_results( $sql );
+                                }
 			if ( ! $rows ) {
 					return '<p>' . esc_html__( 'No tournaments found.', 'bonus-hunt-guesser' ) . '</p>';
 			}


### PR DESCRIPTION
## Summary
- remove unnecessary prepare() call in translations view
- ensure dynamic queries use call_user_func_array with matching placeholders

## Testing
- `composer install`
- `composer run phpcs` *(fails: phpcs --standard=phpcs.xml: phpcs: not found / internal errors)*
- `vendor/bin/phpcs admin/views/translations.php bonus-hunt-guesser.php includes/class-bhg-shortcodes.php admin/class-bhg-users-table.php` *(errors: WPCS sniff deprecation and missing file doc comment)*
- `php -l admin/views/translations.php bonus-hunt-guesser.php includes/class-bhg-shortcodes.php admin/class-bhg-users-table.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb89cccd0c8333ae1bcf766ced589c