### PR TITLE
Use prepared query for demo hunt winner calculation

### DIFF
--- a/includes/demo.php
+++ b/includes/demo.php
@@ -124,11 +124,16 @@ function bhg_seed_demo_on_activation() {
 		}
 	}
 
-	// Compute winner for the closed hunt (closest)
-	$rows        = $wpdb->get_results( "SELECT * FROM `{$closed_id}`" );
-	$final       = 2420.00;
-	$winner_id   = 0;
-	$winner_diff = null;
+        // Compute winner for the closed hunt (closest)
+        $rows        = $wpdb->get_results(
+                $wpdb->prepare(
+                        "SELECT * FROM {$guesses} WHERE hunt_id = %d",
+                        $closed_id
+                )
+        );
+        $final       = 2420.00;
+        $winner_id   = 0;
+        $winner_diff = null;
 	foreach ( $rows as $row ) {
 		$diff = abs( floatval( $row->guess_amount ) - $final );
 		if ( $winner_diff === null || $diff < $winner_diff ) {


### PR DESCRIPTION
## Summary
- fetch guesses for closed demo hunt using `$wpdb->prepare` and `hunt_id` filter

## Testing
- `php -l includes/demo.php`
- `composer phpcs` *(fails: Missing file doc comment in includes/class-bhg-login-redirect.php)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8cfe9490833393f7e220f44cd1cb