### PR TITLE
Guard debug logging behind WP_DEBUG

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -409,7 +409,7 @@ class BHG_Admin {
 			wp_safe_redirect( add_query_arg( 'bhg_msg', 't_saved', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 		} catch ( Throwable $e ) {
-			if ( function_exists( 'error_log' ) ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
 				error_log( '[BHG] tournament save error: ' . $e->getMessage() );
 			}
 			wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', admin_url( 'admin.php?page=bhg-tournaments' ) ) );

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -478,7 +478,7 @@ function bhg_handle_submit_guess() {
 	$allow_edit = isset( $settings['allow_guess_changes'] ) && $settings['allow_guess_changes'] === 'yes';
 
 	if ( $guess < $min_guess || $guess > $max_guess ) {
-		if ( function_exists( 'error_log' ) ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
 			error_log( '[BHG] invalid guess after parse: raw=' . print_r( $raw_guess, true ) . ' parsed=' . print_r( $guess, true ) );
 		}
 		if ( wp_doing_ajax() ) {
@@ -849,7 +849,7 @@ if ( ! function_exists( 'bhg_self_heal_db' ) ) {
 			$db = new BHG_DB();
 			$db->create_tables();
 		} catch ( Throwable $e ) {
-			if ( function_exists( 'error_log' ) ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
 				error_log( '[BHG] DB self-heal failed: ' . $e->getMessage() );
 			}
 		}

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -244,7 +244,7 @@ class BHG_DB {
                                                                 dbDelta( "ALTER TABLE `{$aff_table}` ADD UNIQUE KEY name_unique (name)" );
                                                 }
 		} catch ( Throwable $e ) {
-			if ( function_exists( 'error_log' ) ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
 				error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
 			}
 		}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -15,7 +15,9 @@ function bhg_log( $message ) {
 	if ( is_array( $message ) || is_object( $message ) ) {
 		$message = print_r( $message, true );
 	}
-	error_log( '[BHG] ' . $message );
+	if ( function_exists( 'error_log' ) ) {
+		error_log( '[BHG] ' . $message );
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary
- wrap raw `error_log` calls with `defined( 'WP_DEBUG' ) && WP_DEBUG`
- ensure helper logging uses `function_exists` check

## Testing
- `composer install`
- `vendor/bin/phpcs --standard=phpcs.xml bonus-hunt-guesser.php admin/class-bhg-admin.php includes/helpers.php includes/class-bhg-db.php` *(fails: numerous coding standard violations in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8f7c950083339aeac03e3426dbc5