### PR TITLE
Specify columns in SQL queries

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -29,7 +29,7 @@ if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
 
 // Fetch ads
 $ads = $wpdb->get_results(
-	"SELECT * FROM {$table} ORDER BY id DESC"
+        "SELECT id, title, content, placement, visible_to, active FROM {$table} ORDER BY id DESC"
 );
 
 $placement_labels = array(
@@ -116,9 +116,9 @@ endif;
 	<?php
 		$ad = null;
 	if ( $edit_id ) {
-			$ad = $wpdb->get_row(
-				$wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id )
-			);
+                        $ad = $wpdb->get_row(
+                                $wpdb->prepare( "SELECT id, title, content, link_url, placement, visible_to, target_pages, active FROM {$table} WHERE id = %d", $edit_id )
+                        );
 	}
 	?>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="max-width:800px">

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -9,10 +9,10 @@ $table = $wpdb->prefix . 'bhg_affiliates';
 
 // Load for edit
 $edit_id = isset( $_GET['edit'] ) ? (int) $_GET['edit'] : 0;
-$row     = $edit_id ? $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$table` WHERE id=%d", $edit_id ) ) : null;
+$row     = $edit_id ? $wpdb->get_row( $wpdb->prepare( "SELECT id, name, url, status FROM `$table` WHERE id=%d", $edit_id ) ) : null;
 
 // List
-$rows = $wpdb->get_results( "SELECT * FROM `$table` ORDER BY id DESC" );
+$rows = $wpdb->get_results( "SELECT id, name, url, status FROM `$table` ORDER BY id DESC" );
 
 $status_labels = array(
 	'active'   => __( 'Active', 'bonus-hunt-guesser' ),

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -8,13 +8,13 @@ global $wpdb;
 $hunt_id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
 $hunts   = $wpdb->prefix . 'bhg_bonus_hunts';
 $guesses = $wpdb->prefix . 'bhg_guesses';
-$hunt    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$hunts` WHERE id=%d", $hunt_id ) );
+$hunt    = $wpdb->get_row( $wpdb->prepare( "SELECT id, title, final_balance, winners_count FROM `$hunts` WHERE id=%d", $hunt_id ) );
 if ( ! $hunt ) {
 	echo '<div class="wrap"><h1>' . esc_html__( 'Hunt not found', 'bonus-hunt-guesser' ) . '</h1></div>';
 	return; }
 $rows = $wpdb->get_results(
 	$wpdb->prepare(
-		"SELECT g.*, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
+                "SELECT g.id, g.user_id, g.guess, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
 		(float) $hunt->final_balance,
 		$hunt_id
 	)

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -38,13 +38,13 @@ if ( 'list' === $view ) :
 		$per_page     = 30;
 		$offset       = ( $current_page - 1 ) * $per_page;
 
-		$hunts = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT * FROM {$hunts_table} ORDER BY id DESC LIMIT %d OFFSET %d",
-				$per_page,
-				$offset
-			)
-		);
+                $hunts = $wpdb->get_results(
+                        $wpdb->prepare(
+                                "SELECT id, title, starting_balance, final_balance, winners_count, status FROM {$hunts_table} ORDER BY id DESC LIMIT %d OFFSET %d",
+                                $per_page,
+                                $offset
+                        )
+                );
 
 		$status_labels = array(
 			'open'   => __( 'Open', 'bonus-hunt-guesser' ),
@@ -161,9 +161,9 @@ endif;
 /** CLOSE VIEW */
 if ( 'close' === $view ) :
 		$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
-	$hunt   = $wpdb->get_row(
-		$wpdb->prepare( "SELECT * FROM {$hunts_table} WHERE id = %d", $id )
-	);
+        $hunt   = $wpdb->get_row(
+                $wpdb->prepare( "SELECT id, title, status FROM {$hunts_table} WHERE id = %d", $id )
+        );
 	if ( ! $hunt || 'open' !== $hunt->status ) :
 		echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) . '</p></div>';
 	else :

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -14,10 +14,10 @@ $table = esc_sql( $table );
 
 $edit_id = isset( $_GET['edit'] ) ? (int) wp_unslash( $_GET['edit'] ) : 0;
 $row     = $edit_id
-	? $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $edit_id ) )
-	: null;
+        ? $wpdb->get_row( $wpdb->prepare( "SELECT id, title, description, type, start_date, end_date, status FROM {$table} WHERE id = %d", $edit_id ) )
+        : null;
 
-$rows = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY id DESC" );
+$rows = $wpdb->get_results( "SELECT id, title, type, start_date, end_date, status FROM {$table} ORDER BY id DESC" );
 
 $labels = array(
 	'weekly'    => __( 'Weekly', 'bonus-hunt-guesser' ),

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -594,11 +594,11 @@ function bhg_build_ads_query( $table, $placement = 'footer' ) {
 			return array();
 	}
 
-		$query = $wpdb->prepare(
-			"SELECT * FROM `{$table}` WHERE placement = %s AND active = %d",
-			$placement,
-			1
-		);
+                $query = $wpdb->prepare(
+                        "SELECT id, title, content, link_url, placement, visible_to, target_pages, active FROM `{$table}` WHERE placement = %s AND active = %d",
+                        $placement,
+                        1
+                );
 
 		$rows = $wpdb->get_results( $query );
 	if ( did_action( 'wp' ) && function_exists( 'get_queried_object_id' ) ) {

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -12,9 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! function_exists( 'bhg_get_hunt' ) ) {
 	function bhg_get_hunt( $hunt_id ) {
 		global $wpdb;
-		$t = $wpdb->prefix . 'bhg_bonus_hunts';
-		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $t WHERE id=%d", (int) $hunt_id ) );
-	}
+                $t = $wpdb->prefix . 'bhg_bonus_hunts';
+                return $wpdb->get_row( $wpdb->prepare( "SELECT id, title, starting_balance, final_balance, winners_count, status, closed_at FROM $t WHERE id=%d", (int) $hunt_id ) );
+        }
 }
 
 if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {

--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -69,7 +69,7 @@ class BHG_Bonus_Hunts {
 		global $wpdb;
 		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 
-		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `$hunts_table` WHERE id=%d", (int) $hunt_id ) );
+                return $wpdb->get_row( $wpdb->prepare( "SELECT id, title, starting_balance, num_bonuses, prizes, affiliate_site_id, winners_count, final_balance, status, created_at, updated_at, closed_at FROM `$hunts_table` WHERE id=%d", (int) $hunt_id ) );
 	}
 
 	/**
@@ -87,29 +87,29 @@ class BHG_Bonus_Hunts {
 		if ( ! $hunt ) {
 			return array(); }
 
-		if ( null !== $hunt->final_balance ) {
-			return $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT g.*, u.display_name, ABS(g.guess - %f) AS diff
-					 FROM `$guesses_table` g
-					 LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
-					 WHERE g.hunt_id = %d
-					 ORDER BY diff ASC, g.id ASC",
-					$hunt->final_balance,
-					$hunt_id
-				)
-			);
-		}
+                if ( null !== $hunt->final_balance ) {
+                        return $wpdb->get_results(
+                                $wpdb->prepare(
+                                        "SELECT g.id, g.user_id, g.guess, g.created_at, u.display_name, ABS(g.guess - %f) AS diff
+                                         FROM `$guesses_table` g
+                                         LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
+                                         WHERE g.hunt_id = %d
+                                         ORDER BY diff ASC, g.id ASC",
+                                        $hunt->final_balance,
+                                        $hunt_id
+                                )
+                        );
+                }
 
-		return $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT g.*, u.display_name, NULL AS diff
-				 FROM `$guesses_table` g
-				 LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
-				 WHERE g.hunt_id = %d
-				 ORDER BY g.id ASC",
-				$hunt_id
-			)
-		);
-	}
+                return $wpdb->get_results(
+                        $wpdb->prepare(
+                                "SELECT g.id, g.user_id, g.guess, g.created_at, u.display_name, NULL AS diff
+                                 FROM `$guesses_table` g
+                                 LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
+                                 WHERE g.hunt_id = %d
+                                 ORDER BY g.id ASC",
+                                $hunt_id
+                        )
+                );
+        }
 }

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -50,12 +50,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 		/** [bhg_active_hunt] — list all open hunts */
 		public function active_hunt_shortcode( $atts ) {
 				global $wpdb;
-				$hunts = $wpdb->get_results(
-					$wpdb->prepare(
-						"SELECT * FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status=%s ORDER BY created_at DESC",
-						'open'
-					)
-				);
+                                $hunts = $wpdb->get_results(
+                                        $wpdb->prepare(
+                                                "SELECT id, title, starting_balance, num_bonuses, prizes FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status=%s ORDER BY created_at DESC",
+                                                'open'
+                                        )
+                                );
 			if ( ! $hunts ) {
 					return '<div class="bhg-active-hunt"><p>' . esc_html__( 'No active bonus hunts at the moment.', 'bonus-hunt-guesser' ) . '</p></div>';
 			}
@@ -215,18 +215,18 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			}
 
 			$rows = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT g.*, u.user_login, h.affiliate_site_id
-			 FROM {$g} g
-			 LEFT JOIN {$u} u ON u.ID = g.user_id
-			 LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id
-			 WHERE g.hunt_id=%d
-			 ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
-					$hunt_id,
-					$per,
-					$offset
-				)
-			);
+                                $wpdb->prepare(
+                                        "SELECT g.id, g.user_id, g.guess, g.created_at, u.user_login, h.affiliate_site_id
+                         FROM {$g} g
+                         LEFT JOIN {$u} u ON u.ID = g.user_id
+                         LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id
+                         WHERE g.hunt_id=%d
+                         ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
+                                        $hunt_id,
+                                        $per,
+                                        $offset
+                                )
+                        );
 
 			wp_enqueue_style(
 				'bhg-shortcodes',
@@ -713,7 +713,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					$args[]  = $website;
 			}
 
-				$sql = "SELECT * FROM {$t}";
+                                $sql = "SELECT id, type, start_date, end_date, status FROM {$t}";
 			if ( $where ) {
 					$sql .= ' WHERE ' . implode( ' AND ', $where );
 			}

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -127,7 +127,7 @@ function bhg_seed_demo_on_activation() {
         // Compute winner for the closed hunt (closest)
         $rows        = $wpdb->get_results(
                 $wpdb->prepare(
-                        "SELECT * FROM {$guesses} WHERE hunt_id = %d",
+                        "SELECT id, hunt_id, user_id, guess_amount, created_at FROM {$guesses} WHERE hunt_id = %d",
                         $closed_id
                 )
         );


### PR DESCRIPTION
## Summary
- Avoid `SELECT *` by listing needed columns for affiliate sites, bonus hunts, ads, tournaments, and front-end shortcodes
- Ensure queries only retrieve required fields, improving clarity and compatibility

## Testing
- `composer install`
- `vendor/bin/phpcs --standard=phpcs.xml admin/views/advertising.php admin/views/affiliate-websites.php admin/views/bonus-hunts-results.php admin/views/bonus-hunts.php admin/views/tournaments.php bonus-hunt-guesser.php includes/class-bhg-bonus-hunts-helpers.php includes/class-bhg-bonus-hunts.php includes/class-bhg-shortcodes.php includes/demo.php` *(fails: file comment and naming convention issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9139b77c833399534fdc60e8ea65