### PR TITLE
Harden request handling and add nonce checks

### DIFF
--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -66,10 +66,11 @@ class BHG_Users_Table extends WP_List_Table {
 	}
 
 	public function prepare_items() {
-		$paged   = isset( $_REQUEST['paged'] ) ? max( 1, (int) $_REQUEST['paged'] ) : 1;
-		$orderby = isset( $_REQUEST['orderby'] ) ? sanitize_key( $_REQUEST['orderby'] ) : 'username';
-		$order   = isset( $_REQUEST['order'] ) && in_array( strtolower( $_REQUEST['order'] ), array( 'asc', 'desc' ), true ) ? strtoupper( $_REQUEST['order'] ) : 'ASC';
-		$search  = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) : '';
+$paged       = isset( $_GET['paged'] ) ? max( 1, absint( wp_unslash( $_GET['paged'] ) ) ) : 1;
+$orderby     = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'username';
+$order_raw   = isset( $_GET['order'] ) ? sanitize_text_field( wp_unslash( $_GET['order'] ) ) : '';
+$order       = in_array( strtolower( $order_raw ), array( 'asc', 'desc' ), true ) ? strtoupper( $order_raw ) : 'ASC';
+$search      = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
 
 		// Whitelist orderby
 		$allowed = array( 'username', 'email', 'role', 'guesses', 'wins' );

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -110,22 +110,23 @@ if ( 'list' === $view ) :
 				);
 				?>
 									"><?php echo esc_html__( 'Edit', 'bonus-hunt-guesser' ); ?></a>
-						<?php if ( 'open' === $h->status ) : ?>
-							<a class="button" href="
-							<?php
-							echo esc_url(
-								add_query_arg(
-									array(
-										'view' => 'close',
-										'id'   => (int) $h->id,
-									)
-								)
-							);
-							?>
-													"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
-						<?php elseif ( 'closed' === $h->status && null !== $h->final_balance ) : ?>
-							<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
-						<?php endif; ?>
+                                                <?php if ( 'open' === $h->status ) : ?>
+                                                        <?php
+                                                        $close_url = wp_nonce_url(
+                                                                add_query_arg(
+                                                                        array(
+                                                                                'view' => 'close',
+                                                                                'id'   => (int) $h->id,
+                                                                        )
+                                                                ),
+                                                                'bhg_close_hunt_' . (int) $h->id,
+                                                                'bhg_nonce'
+                                                        );
+                                                        ?>
+                                                        <a class="button" href="<?php echo esc_url( $close_url ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
+                                                <?php elseif ( 'closed' === $h->status && null !== $h->final_balance ) : ?>
+                                                        <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
+                                                <?php endif; ?>
 			</td>
 		</tr>
 				<?php
@@ -158,14 +159,18 @@ endif;
 <?php
 /** CLOSE VIEW */
 if ( 'close' === $view ) :
-		$id = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
-        $hunt   = $wpdb->get_row(
-                $wpdb->prepare( "SELECT id, title, status FROM {$hunts_table} WHERE id = %d", $id )
-        );
-	if ( ! $hunt || 'open' !== $hunt->status ) :
-		echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) . '</p></div>';
-	else :
-		?>
+                $id    = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
+                $nonce = isset( $_GET['bhg_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['bhg_nonce'] ) ) : '';
+        if ( ! $id || ! $nonce || ! wp_verify_nonce( $nonce, 'bhg_close_hunt_' . $id ) ) :
+                echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid request.', 'bonus-hunt-guesser' ) . '</p></div>';
+        else :
+                $hunt = $wpdb->get_row(
+                        $wpdb->prepare( "SELECT id, title, status FROM {$hunts_table} WHERE id = %d", $id )
+                );
+                if ( ! $hunt || 'open' !== $hunt->status ) :
+                        echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) . '</p></div>';
+                else :
+                ?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Close Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-400 bhg-margin-top-small">
@@ -183,8 +188,9 @@ if ( 'close' === $view ) :
 		<?php submit_button( __( 'Close Hunt', 'bonus-hunt-guesser' ) ); ?>
 	</form>
 </div>
-		<?php
-	endif;
+                <?php
+        endif;
+        endif;
 endif;
 ?>
 

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -7,7 +7,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 global $wpdb;
 $t = $wpdb->prefix . 'bhg_hunts';
 
-$paged    = max( 1, isset( $_GET['paged'] ) ? (int) $_GET['paged'] : 1 );
+$paged    = max( 1, isset( $_GET['paged'] ) ? absint( wp_unslash( $_GET['paged'] ) ) : 1 );
 $per_page = 20;
 $offset   = ( $paged - 1 ) * $per_page;
 

--- a/includes/class-bhg-login-redirect.php
+++ b/includes/class-bhg-login-redirect.php
@@ -16,11 +16,16 @@ if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
 		}
 
 		public function core_login_redirect( $redirect_to, $requested, $user ) {
-			if ( ! empty( $_REQUEST['redirect_to'] ) ) {
-				$requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );
-				$validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
-				return esc_url_raw( $validated_redirect );
-			}
+                        $requested_redirect = '';
+                        if ( isset( $_POST['redirect_to'] ) ) {
+                                $requested_redirect = sanitize_text_field( wp_unslash( $_POST['redirect_to'] ) );
+                        } elseif ( isset( $_GET['redirect_to'] ) ) {
+                                $requested_redirect = sanitize_text_field( wp_unslash( $_GET['redirect_to'] ) );
+                        }
+                        if ( $requested_redirect ) {
+                                $validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
+                                return esc_url_raw( $validated_redirect );
+                        }
 
 			// Fall back to referer if safe.
 			$ref = wp_get_referer();
@@ -34,11 +39,16 @@ if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
 		}
 
 		public function nextend_redirect( $redirect_to, $user, $provider ) {
-			if ( ! empty( $_REQUEST['redirect_to'] ) ) {
-				$requested_redirect = sanitize_text_field( wp_unslash( $_REQUEST['redirect_to'] ) );
-				$validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
-				return esc_url_raw( $validated_redirect );
-			}
+                        $requested_redirect = '';
+                        if ( isset( $_POST['redirect_to'] ) ) {
+                                $requested_redirect = sanitize_text_field( wp_unslash( $_POST['redirect_to'] ) );
+                        } elseif ( isset( $_GET['redirect_to'] ) ) {
+                                $requested_redirect = sanitize_text_field( wp_unslash( $_GET['redirect_to'] ) );
+                        }
+                        if ( $requested_redirect ) {
+                                $validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
+                                return esc_url_raw( $validated_redirect );
+                        }
 
 			$ref = wp_get_referer();
 			if ( $ref ) {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -57,7 +57,7 @@ function bhg_admin_cap() {
 add_filter(
 	'login_redirect',
 	function ( $redirect_to, $requested_redirect_to, $user ) {
-		$r = isset( $_REQUEST['bhg_redirect'] ) ? wp_unslash( $_REQUEST['bhg_redirect'] ) : '';
+$r = isset( $_GET['bhg_redirect'] ) ? wp_unslash( $_GET['bhg_redirect'] ) : '';
 		if ( ! empty( $r ) ) {
 			$safe      = esc_url_raw( $r );
 			$home_host = wp_parse_url( home_url(), PHP_URL_HOST );


### PR DESCRIPTION
## Summary
- sanitize paging parameter in hunts list
- secure bonus hunt closing with nonces
- replace $_REQUEST with sanitized $_GET/$_POST in helpers, login redirect, and users table

## Testing
- `composer install`
- `composer phpcs` *(fails: Missing file doc comment, precision alignment, tabs must be used)*

------
https://chatgpt.com/codex/tasks/task_e_68bb96ae0de483338624bf87ab69b5d8