### PR TITLE
Improve order sanitization in user listing

### DIFF
--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -68,8 +68,8 @@ class BHG_Users_Table extends WP_List_Table {
 	public function prepare_items() {
 $paged       = isset( $_GET['paged'] ) ? max( 1, absint( wp_unslash( $_GET['paged'] ) ) ) : 1;
 $orderby     = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'username';
-$order_raw   = isset( $_GET['order'] ) ? sanitize_text_field( wp_unslash( $_GET['order'] ) ) : '';
-$order       = in_array( strtolower( $order_raw ), array( 'asc', 'desc' ), true ) ? strtoupper( $order_raw ) : 'ASC';
+$order_raw   = isset( $_GET['order'] ) ? sanitize_key( wp_unslash( $_GET['order'] ) ) : '';
+$order       = in_array( $order_raw, array( 'asc', 'desc' ), true ) ? strtoupper( $order_raw ) : 'ASC';
 $search      = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
 
 		// Whitelist orderby


### PR DESCRIPTION
## Summary
- sanitize `order` parameter using `sanitize_key`

## Testing
- `composer run phpcs admin/class-bhg-users-table.php` *(fails: WordPressCS\WordPress\PHPCSHelper::ignore_annotations() deprecated nullable parameter)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9ad96e888333830d7311015e406a