### PR TITLE
Style latest hunts dashboard with grid and icons

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -1,77 +1,63 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+        exit;
 }
 
 if ( ! current_user_can( 'manage_options' ) ) {
-	wp_die(
-		__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' )
-	);
+        wp_die(
+                __( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' )
+        );
 }
 
 if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {
-	wp_die(
-		__(
-			'Helper function bhg_get_latest_closed_hunts() missing. Please include class-bhg-bonus-hunts.php helpers.',
-			'bonus-hunt-guesser'
-		)
-	);
+        wp_die(
+                __(
+                        'Helper function bhg_get_latest_closed_hunts() missing. Please include class-bhg-bonus-hunts.php helpers.',
+                        'bonus-hunt-guesser'
+                )
+        );
 }
 
 $hunts = bhg_get_latest_closed_hunts( 3 );
 ?>
-<div class="wrap">
-	<h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
-	<table class="widefat striped">
-	<thead>
-		<tr>
-				<th><?php esc_html_e( 'Bonus Hunt', 'bonus-hunt-guesser' ); ?></th>
-		<th><?php esc_html_e( 'All Winners', 'bonus-hunt-guesser' ); ?></th>
-		<th><?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?></th>
-		<th><?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?></th>
-		<th><?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?></th>
-		</tr>
-	</thead>
-	<tbody>
-		<?php if ( $hunts ) : ?>
-			<?php foreach ( $hunts as $h ) : ?>
-				<?php
-				$winners = function_exists( 'bhg_get_top_winners_for_hunt' )
-				? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
-				: array();
-				?>
-			<tr>
-			<td><?php echo esc_html( $h->title ); ?></td>
-			<td>
-				<?php
-				if ( $winners ) {
-					$out = array();
-					foreach ( $winners as $w ) {
-						$u                         = get_userdata( (int) $w->user_id );
-						$nm                        = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-											$out[] = sprintf(
-												'%s %s %s (%s %s)',
-												esc_html( $nm ),
-												esc_html__( '—', 'bonus-hunt-guesser' ),
-												esc_html( number_format_i18n( (float) $w->guess, 2 ) ),
-												esc_html__( 'diff', 'bonus-hunt-guesser' ),
-												esc_html( number_format_i18n( (float) $w->diff, 2 ) )
-											);
-					}
-					echo esc_html( implode( ' • ', $out ) );
-				} else {
-					esc_html_e( 'No winners yet', 'bonus-hunt-guesser' );
-				}
-				?>
-			</td>
-			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-						<td><?php echo ( $h->final_balance !== null ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-						<td><?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-			</tr>
-		<?php endforeach; ?>
-		<?php else : ?>
-		<tr><td colspan="5"><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></td></tr>
-		<?php endif; ?>
-	</tbody>
-	</table>
+<div class="wrap bhg-wrap bhg-admin">
+        <h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
+        <div class="bhg-dashboard-grid">
+                <?php if ( $hunts ) : ?>
+                        <?php foreach ( $hunts as $h ) : ?>
+                                <?php
+                                $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
+                                ? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
+                                : array();
+                                ?>
+                                <div class="bhg-hunt-card">
+                                        <h2 class="bhg-hunt-title"><span class="dashicons dashicons-calendar-alt"></span> <?php echo esc_html( $h->title ); ?></h2>
+                                        <ul class="bhg-winners">
+                                                <?php if ( $winners ) : ?>
+                                                        <?php foreach ( $winners as $i => $w ) : ?>
+                                                                <?php
+                                                                $u  = get_userdata( (int) $w->user_id );
+                                                                $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
+                                                                ?>
+                                                                <li class="bhg-winner winner-<?php echo (int) $i + 1; ?>">
+                                                                        <span class="dashicons dashicons-awards"></span>
+                                                                        <?php echo esc_html( $nm ); ?>
+                                                                        <?php esc_html_e( '—', 'bonus-hunt-guesser' ); ?>
+                                                                        <?php echo esc_html( number_format_i18n( (float) $w->guess, 2 ) ); ?>
+                                                                        <span class="bhg-diff">(<?php esc_html_e( 'diff', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( number_format_i18n( (float) $w->diff, 2 ) ); ?>)</span>
+                                                                </li>
+                                                        <?php endforeach; ?>
+                                                <?php else : ?>
+                                                        <li class="bhg-winner none"><span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'No winners yet', 'bonus-hunt-guesser' ); ?></li>
+                                                <?php endif; ?>
+                                        </ul>
+                                        <div class="bhg-balance bhg-start"><span class="dashicons dashicons-money-alt"></span> <?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?>: <?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></div>
+                                        <div class="bhg-balance bhg-final"><span class="dashicons dashicons-chart-bar"></span> <?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?>: <?php echo ( null !== $h->final_balance ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></div>
+                                        <div class="bhg-closed"><span class="dashicons dashicons-clock"></span> <?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?>: <?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></div>
+                                </div>
+                        <?php endforeach; ?>
+                <?php else : ?>
+                        <p><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></p>
+                <?php endif; ?>
+        </div>
 </div>

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -32,3 +32,59 @@ body.wp-admin .bhg-admin {
     outline: none;
     box-shadow: 0 0 3px rgba(200,92,142,0.4);
 }
+
+/* Dashboard layout */
+.bhg-dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.bhg-hunt-card {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 16px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+}
+
+.bhg-hunt-title {
+    margin: 0 0 8px;
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.bhg-winners {
+    list-style: none;
+    margin: 0 0 8px;
+    padding: 0;
+}
+
+.bhg-winner {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.bhg-winner .bhg-diff {
+    color: #6b7280;
+    font-size: 12px;
+}
+
+.bhg-winner.winner-1 { color: #d4af37; }
+.bhg-winner.winner-2 { color: #c0c0c0; }
+.bhg-winner.winner-3 { color: #cd7f32; }
+
+.bhg-balance, .bhg-closed {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 4px;
+}
+
+.bhg-balance.bhg-start { color: #3b82f6; }
+.bhg-balance.bhg-final { color: #16a34a; }
+.bhg-closed { color: #6b7280; }

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -48,3 +48,51 @@
 .bhg-text-center {
     text-align: center;
 }
+
+/* Dashboard layout */
+.bhg-dashboard-grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fill,minmax(300px,1fr));
+    gap:20px;
+    margin-top:20px;
+}
+.bhg-hunt-card{
+    background:#fff;
+    border:1px solid #e5e7eb;
+    border-radius:8px;
+    padding:16px;
+    box-shadow:0 1px 2px rgba(0,0,0,.04);
+}
+.bhg-hunt-title{
+    margin:0 0 8px;
+    font-size:16px;
+    display:flex;
+    align-items:center;
+    gap:4px;
+}
+.bhg-winners{
+    list-style:none;
+    margin:0 0 8px;
+    padding:0;
+}
+.bhg-winner{
+    display:flex;
+    align-items:center;
+    gap:4px;
+}
+.bhg-winner .bhg-diff{
+    color:#6b7280;
+    font-size:12px;
+}
+.bhg-winner.winner-1{color:#d4af37}
+.bhg-winner.winner-2{color:#c0c0c0}
+.bhg-winner.winner-3{color:#cd7f32}
+.bhg-balance,.bhg-closed{
+    display:flex;
+    align-items:center;
+    gap:4px;
+    margin-top:4px;
+}
+.bhg-balance.bhg-start{color:#3b82f6}
+.bhg-balance.bhg-final{color:#16a34a}
+.bhg-closed{color:#6b7280}


### PR DESCRIPTION
## Summary
- overhaul latest hunts dashboard into card-based grid
- highlight winners with trophy icons and color-coded balances
- add dashboard styling rules to admin stylesheet

## Testing
- `composer phpcs admin/views/dashboard.php` *(fails: WordPressCS\WordPress\PHPCSHelper::ignore_annotations(): Implicitly marking parameter $phpcsFile as nullable is deprecated)*


------
https://chatgpt.com/codex/tasks/task_e_68bb9b6626288333931f080c6f5ef83d