### PR TITLE
Use tabs for indentation

### DIFF
--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -29,7 +29,7 @@ if ( 'delete' === $action && $ad_id && isset( $_GET['_wpnonce'] ) ) {
 
 // Fetch ads
 $ads = $wpdb->get_results(
-        "SELECT id, title, content, placement, visible_to, active FROM {$table} ORDER BY id DESC"
+		"SELECT id, title, content, placement, visible_to, active FROM {$table} ORDER BY id DESC"
 );
 
 $placement_labels = array(
@@ -116,9 +116,9 @@ endif;
 	<?php
 		$ad = null;
 	if ( $edit_id ) {
-                        $ad = $wpdb->get_row(
-                                $wpdb->prepare( "SELECT id, title, content, link_url, placement, visible_to, target_pages, active FROM {$table} WHERE id = %d", $edit_id )
-                        );
+						$ad = $wpdb->get_row(
+								$wpdb->prepare( "SELECT id, title, content, link_url, placement, visible_to, target_pages, active FROM {$table} WHERE id = %d", $edit_id )
+						);
 	}
 	?>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="max-width:800px">

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -14,7 +14,7 @@ if ( ! $hunt ) {
 	return; }
 $rows = $wpdb->get_results(
 	$wpdb->prepare(
-                "SELECT g.id, g.user_id, g.guess, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
+				"SELECT g.id, g.user_id, g.guess, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
 		(float) $hunt->final_balance,
 		$hunt_id
 	)

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -20,7 +20,7 @@ $allowed_tables = array(
 	$wpdb->users,
 );
 if ( ! in_array( $hunts_table, $allowed_tables, true ) || ! in_array( $guesses_table, $allowed_tables, true ) ) {
-        wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+		wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
 
 $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
@@ -36,13 +36,13 @@ if ( 'list' === $view ) :
 		$per_page     = 30;
 		$offset       = ( $current_page - 1 ) * $per_page;
 
-                $hunts = $wpdb->get_results(
-                        $wpdb->prepare(
-                                "SELECT id, title, starting_balance, final_balance, winners_count, status FROM {$hunts_table} ORDER BY id DESC LIMIT %d OFFSET %d",
-                                $per_page,
-                                $offset
-                        )
-                );
+				$hunts = $wpdb->get_results(
+						$wpdb->prepare(
+								"SELECT id, title, starting_balance, final_balance, winners_count, status FROM {$hunts_table} ORDER BY id DESC LIMIT %d OFFSET %d",
+								$per_page,
+								$offset
+						)
+				);
 
 		$status_labels = array(
 			'open'   => __( 'Open', 'bonus-hunt-guesser' ),
@@ -110,23 +110,23 @@ if ( 'list' === $view ) :
 				);
 				?>
 									"><?php echo esc_html__( 'Edit', 'bonus-hunt-guesser' ); ?></a>
-                                                <?php if ( 'open' === $h->status ) : ?>
-                                                        <?php
-                                                        $close_url = wp_nonce_url(
-                                                                add_query_arg(
-                                                                        array(
-                                                                                'view' => 'close',
-                                                                                'id'   => (int) $h->id,
-                                                                        )
-                                                                ),
-                                                                'bhg_close_hunt_' . (int) $h->id,
-                                                                'bhg_nonce'
-                                                        );
-                                                        ?>
-                                                        <a class="button" href="<?php echo esc_url( $close_url ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
-                                                <?php elseif ( 'closed' === $h->status && null !== $h->final_balance ) : ?>
-                                                        <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
-                                                <?php endif; ?>
+												<?php if ( 'open' === $h->status ) : ?>
+														<?php
+														$close_url = wp_nonce_url(
+																add_query_arg(
+																		array(
+																				'view' => 'close',
+																				'id'   => (int) $h->id,
+																		)
+																),
+																'bhg_close_hunt_' . (int) $h->id,
+																'bhg_nonce'
+														);
+														?>
+														<a class="button" href="<?php echo esc_url( $close_url ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
+												<?php elseif ( 'closed' === $h->status && null !== $h->final_balance ) : ?>
+														<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
+												<?php endif; ?>
 			</td>
 		</tr>
 				<?php
@@ -159,18 +159,18 @@ endif;
 <?php
 /** CLOSE VIEW */
 if ( 'close' === $view ) :
-                $id    = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
-                $nonce = isset( $_GET['bhg_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['bhg_nonce'] ) ) : '';
-        if ( ! $id || ! $nonce || ! wp_verify_nonce( $nonce, 'bhg_close_hunt_' . $id ) ) :
-                echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid request.', 'bonus-hunt-guesser' ) . '</p></div>';
-        else :
-                $hunt = $wpdb->get_row(
-                        $wpdb->prepare( "SELECT id, title, status FROM {$hunts_table} WHERE id = %d", $id )
-                );
-                if ( ! $hunt || 'open' !== $hunt->status ) :
-                        echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) . '</p></div>';
-                else :
-                ?>
+				$id    = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
+				$nonce = isset( $_GET['bhg_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['bhg_nonce'] ) ) : '';
+		if ( ! $id || ! $nonce || ! wp_verify_nonce( $nonce, 'bhg_close_hunt_' . $id ) ) :
+				echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid request.', 'bonus-hunt-guesser' ) . '</p></div>';
+		else :
+				$hunt = $wpdb->get_row(
+						$wpdb->prepare( "SELECT id, title, status FROM {$hunts_table} WHERE id = %d", $id )
+				);
+				if ( ! $hunt || 'open' !== $hunt->status ) :
+						echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt.', 'bonus-hunt-guesser' ) . '</p></div>';
+				else :
+				?>
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php echo esc_html__( 'Close Bonus Hunt', 'bonus-hunt-guesser' ); ?> <?php echo esc_html__( '—', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( $hunt->title ); ?></h1>
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="bhg-max-width-400 bhg-margin-top-small">
@@ -188,9 +188,9 @@ if ( 'close' === $view ) :
 		<?php submit_button( __( 'Close Hunt', 'bonus-hunt-guesser' ) ); ?>
 	</form>
 </div>
-                <?php
-        endif;
-        endif;
+				<?php
+		endif;
+		endif;
 endif;
 ?>
 

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -1,63 +1,63 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-        exit;
+		exit;
 }
 
 if ( ! current_user_can( 'manage_options' ) ) {
-        wp_die(
-                __( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' )
-        );
+		wp_die(
+				__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' )
+		);
 }
 
 if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {
-        wp_die(
-                __(
-                        'Helper function bhg_get_latest_closed_hunts() missing. Please include class-bhg-bonus-hunts.php helpers.',
-                        'bonus-hunt-guesser'
-                )
-        );
+		wp_die(
+				__(
+						'Helper function bhg_get_latest_closed_hunts() missing. Please include class-bhg-bonus-hunts.php helpers.',
+						'bonus-hunt-guesser'
+				)
+		);
 }
 
 $hunts = bhg_get_latest_closed_hunts( 3 );
 ?>
 <div class="wrap bhg-wrap bhg-admin">
-        <h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
-        <div class="bhg-dashboard-grid">
-                <?php if ( $hunts ) : ?>
-                        <?php foreach ( $hunts as $h ) : ?>
-                                <?php
-                                $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
-                                ? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
-                                : array();
-                                ?>
-                                <div class="bhg-hunt-card">
-                                        <h2 class="bhg-hunt-title"><span class="dashicons dashicons-calendar-alt"></span> <?php echo esc_html( $h->title ); ?></h2>
-                                        <ul class="bhg-winners">
-                                                <?php if ( $winners ) : ?>
-                                                        <?php foreach ( $winners as $i => $w ) : ?>
-                                                                <?php
-                                                                $u  = get_userdata( (int) $w->user_id );
-                                                                $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-                                                                ?>
-                                                                <li class="bhg-winner winner-<?php echo (int) $i + 1; ?>">
-                                                                        <span class="dashicons dashicons-awards"></span>
-                                                                        <?php echo esc_html( $nm ); ?>
-                                                                        <?php esc_html_e( '—', 'bonus-hunt-guesser' ); ?>
-                                                                        <?php echo esc_html( number_format_i18n( (float) $w->guess, 2 ) ); ?>
-                                                                        <span class="bhg-diff">(<?php esc_html_e( 'diff', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( number_format_i18n( (float) $w->diff, 2 ) ); ?>)</span>
-                                                                </li>
-                                                        <?php endforeach; ?>
-                                                <?php else : ?>
-                                                        <li class="bhg-winner none"><span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'No winners yet', 'bonus-hunt-guesser' ); ?></li>
-                                                <?php endif; ?>
-                                        </ul>
-                                        <div class="bhg-balance bhg-start"><span class="dashicons dashicons-money-alt"></span> <?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?>: <?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></div>
-                                        <div class="bhg-balance bhg-final"><span class="dashicons dashicons-chart-bar"></span> <?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?>: <?php echo ( null !== $h->final_balance ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></div>
-                                        <div class="bhg-closed"><span class="dashicons dashicons-clock"></span> <?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?>: <?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></div>
-                                </div>
-                        <?php endforeach; ?>
-                <?php else : ?>
-                        <p><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></p>
-                <?php endif; ?>
-        </div>
+		<h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
+		<div class="bhg-dashboard-grid">
+				<?php if ( $hunts ) : ?>
+						<?php foreach ( $hunts as $h ) : ?>
+								<?php
+								$winners = function_exists( 'bhg_get_top_winners_for_hunt' )
+								? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
+								: array();
+								?>
+								<div class="bhg-hunt-card">
+										<h2 class="bhg-hunt-title"><span class="dashicons dashicons-calendar-alt"></span> <?php echo esc_html( $h->title ); ?></h2>
+										<ul class="bhg-winners">
+												<?php if ( $winners ) : ?>
+														<?php foreach ( $winners as $i => $w ) : ?>
+																<?php
+																$u  = get_userdata( (int) $w->user_id );
+																$nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
+																?>
+																<li class="bhg-winner winner-<?php echo (int) $i + 1; ?>">
+																		<span class="dashicons dashicons-awards"></span>
+																		<?php echo esc_html( $nm ); ?>
+																		<?php esc_html_e( '—', 'bonus-hunt-guesser' ); ?>
+																		<?php echo esc_html( number_format_i18n( (float) $w->guess, 2 ) ); ?>
+																		<span class="bhg-diff">(<?php esc_html_e( 'diff', 'bonus-hunt-guesser' ); ?> <?php echo esc_html( number_format_i18n( (float) $w->diff, 2 ) ); ?>)</span>
+																</li>
+														<?php endforeach; ?>
+												<?php else : ?>
+														<li class="bhg-winner none"><span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'No winners yet', 'bonus-hunt-guesser' ); ?></li>
+												<?php endif; ?>
+										</ul>
+										<div class="bhg-balance bhg-start"><span class="dashicons dashicons-money-alt"></span> <?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?>: <?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></div>
+										<div class="bhg-balance bhg-final"><span class="dashicons dashicons-chart-bar"></span> <?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?>: <?php echo ( null !== $h->final_balance ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></div>
+										<div class="bhg-closed"><span class="dashicons dashicons-clock"></span> <?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?>: <?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></div>
+								</div>
+						<?php endforeach; ?>
+				<?php else : ?>
+						<p><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></p>
+				<?php endif; ?>
+		</div>
 </div>

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -14,8 +14,8 @@ $table = esc_sql( $table );
 
 $edit_id = isset( $_GET['edit'] ) ? (int) wp_unslash( $_GET['edit'] ) : 0;
 $row     = $edit_id
-        ? $wpdb->get_row( $wpdb->prepare( "SELECT id, title, description, type, start_date, end_date, status FROM {$table} WHERE id = %d", $edit_id ) )
-        : null;
+		? $wpdb->get_row( $wpdb->prepare( "SELECT id, title, description, type, start_date, end_date, status FROM {$table} WHERE id = %d", $edit_id ) )
+		: null;
 
 $rows = $wpdb->get_results( "SELECT id, title, type, start_date, end_date, status FROM {$table} ORDER BY id DESC" );
 

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -594,11 +594,11 @@ function bhg_build_ads_query( $table, $placement = 'footer' ) {
 			return array();
 	}
 
-                $query = $wpdb->prepare(
-                        "SELECT id, title, content, link_url, placement, visible_to, target_pages, active FROM `{$table}` WHERE placement = %s AND active = %d",
-                        $placement,
-                        1
-                );
+				$query = $wpdb->prepare(
+						"SELECT id, title, content, link_url, placement, visible_to, target_pages, active FROM `{$table}` WHERE placement = %s AND active = %d",
+						$placement,
+						1
+				);
 
 		$rows = $wpdb->get_results( $query );
 	if ( did_action( 'wp' ) && function_exists( 'get_queried_object_id' ) ) {

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -12,9 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! function_exists( 'bhg_get_hunt' ) ) {
 	function bhg_get_hunt( $hunt_id ) {
 		global $wpdb;
-                $t = $wpdb->prefix . 'bhg_bonus_hunts';
-                return $wpdb->get_row( $wpdb->prepare( "SELECT id, title, starting_balance, final_balance, winners_count, status, closed_at FROM $t WHERE id=%d", (int) $hunt_id ) );
-        }
+				$t = $wpdb->prefix . 'bhg_bonus_hunts';
+				return $wpdb->get_row( $wpdb->prepare( "SELECT id, title, starting_balance, final_balance, winners_count, status, closed_at FROM $t WHERE id=%d", (int) $hunt_id ) );
+		}
 }
 
 if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {

--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -69,7 +69,7 @@ class BHG_Bonus_Hunts {
 		global $wpdb;
 		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
 
-                return $wpdb->get_row( $wpdb->prepare( "SELECT id, title, starting_balance, num_bonuses, prizes, affiliate_site_id, winners_count, final_balance, status, created_at, updated_at, closed_at FROM `$hunts_table` WHERE id=%d", (int) $hunt_id ) );
+				return $wpdb->get_row( $wpdb->prepare( "SELECT id, title, starting_balance, num_bonuses, prizes, affiliate_site_id, winners_count, final_balance, status, created_at, updated_at, closed_at FROM `$hunts_table` WHERE id=%d", (int) $hunt_id ) );
 	}
 
 	/**
@@ -87,29 +87,29 @@ class BHG_Bonus_Hunts {
 		if ( ! $hunt ) {
 			return array(); }
 
-                if ( null !== $hunt->final_balance ) {
-                        return $wpdb->get_results(
-                                $wpdb->prepare(
-                                        "SELECT g.id, g.user_id, g.guess, g.created_at, u.display_name, ABS(g.guess - %f) AS diff
-                                         FROM `$guesses_table` g
-                                         LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
-                                         WHERE g.hunt_id = %d
-                                         ORDER BY diff ASC, g.id ASC",
-                                        $hunt->final_balance,
-                                        $hunt_id
-                                )
-                        );
-                }
+				if ( null !== $hunt->final_balance ) {
+						return $wpdb->get_results(
+								$wpdb->prepare(
+										"SELECT g.id, g.user_id, g.guess, g.created_at, u.display_name, ABS(g.guess - %f) AS diff
+										 FROM `$guesses_table` g
+										 LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
+										 WHERE g.hunt_id = %d
+										 ORDER BY diff ASC, g.id ASC",
+										$hunt->final_balance,
+										$hunt_id
+								)
+						);
+				}
 
-                return $wpdb->get_results(
-                        $wpdb->prepare(
-                                "SELECT g.id, g.user_id, g.guess, g.created_at, u.display_name, NULL AS diff
-                                 FROM `$guesses_table` g
-                                 LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
-                                 WHERE g.hunt_id = %d
-                                 ORDER BY g.id ASC",
-                                $hunt_id
-                        )
-                );
-        }
+				return $wpdb->get_results(
+						$wpdb->prepare(
+								"SELECT g.id, g.user_id, g.guess, g.created_at, u.display_name, NULL AS diff
+								 FROM `$guesses_table` g
+								 LEFT JOIN `$wpdb->users` u ON u.ID = g.user_id
+								 WHERE g.hunt_id = %d
+								 ORDER BY g.id ASC",
+								$hunt_id
+						)
+				);
+		}
 }

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -6,26 +6,26 @@ class BHG_DB {
 
 	// Static wrapper to support legacy static calls.
 	public static function migrate() {
-                $db = new self();
-                $db->create_tables();
+				$db = new self();
+				$db->create_tables();
 
-                               global $wpdb;
-                               $tours_table    = $wpdb->prefix . 'bhg_tournaments';
-                               $allowed_tables = array( $wpdb->prefix . 'bhg_tournaments' );
-                               if ( ! in_array( $tours_table, $allowed_tables, true ) ) {
-                                       wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
-                               }
+							   global $wpdb;
+							   $tours_table    = $wpdb->prefix . 'bhg_tournaments';
+							   $allowed_tables = array( $wpdb->prefix . 'bhg_tournaments' );
+							   if ( ! in_array( $tours_table, $allowed_tables, true ) ) {
+									   wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+							   }
 
-                // Drop legacy "period" column and related index if they exist.
-                if ( $db->column_exists( $tours_table, 'period' ) ) {
-                        // Remove unique index first if present.
-                        if ( $db->index_exists( $tours_table, 'type_period' ) ) {
-                                                                dbDelta( "ALTER TABLE `{$tours_table}` DROP INDEX type_period" );
-                        }
+				// Drop legacy "period" column and related index if they exist.
+				if ( $db->column_exists( $tours_table, 'period' ) ) {
+						// Remove unique index first if present.
+						if ( $db->index_exists( $tours_table, 'type_period' ) ) {
+																dbDelta( "ALTER TABLE `{$tours_table}` DROP INDEX type_period" );
+						}
 
-                                                dbDelta( "ALTER TABLE `{$tours_table}` DROP COLUMN period" );
-                }
-        }
+												dbDelta( "ALTER TABLE `{$tours_table}` DROP COLUMN period" );
+				}
+		}
 
 	public function create_tables() {
 		global $wpdb;
@@ -33,13 +33,13 @@ class BHG_DB {
 
 		$charset_collate = $wpdb->get_charset_collate();
 
-                               $hunts_table  = $wpdb->prefix . 'bhg_bonus_hunts';
-                               $guesses_table = $wpdb->prefix . 'bhg_guesses';
-                               $tours_table  = $wpdb->prefix . 'bhg_tournaments';
-                               $tres_table   = $wpdb->prefix . 'bhg_tournament_results';
-                               $ads_table    = $wpdb->prefix . 'bhg_ads';
-                               $trans_table  = $wpdb->prefix . 'bhg_translations';
-                               $aff_table    = $wpdb->prefix . 'bhg_affiliates';
+							   $hunts_table  = $wpdb->prefix . 'bhg_bonus_hunts';
+							   $guesses_table = $wpdb->prefix . 'bhg_guesses';
+							   $tours_table  = $wpdb->prefix . 'bhg_tournaments';
+							   $tres_table   = $wpdb->prefix . 'bhg_tournament_results';
+							   $ads_table    = $wpdb->prefix . 'bhg_ads';
+							   $trans_table  = $wpdb->prefix . 'bhg_translations';
+							   $aff_table    = $wpdb->prefix . 'bhg_affiliates';
 
 		$sql = array();
 
@@ -149,17 +149,17 @@ class BHG_DB {
 		// Idempotent ensure for columns/indexes
 		try {
 			// Hunts: winners_count, affiliate_site_id
-                        $need = array(
-                                'winners_count'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
-                                'affiliate_site_id' => "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
-                                'final_balance'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
-                                'status'            => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
-                        );
-                        foreach ( $need as $c => $alter ) {
-                                if ( ! $this->column_exists( $hunts_table, $c ) ) {
-                                                                                dbDelta( $alter );
-                                }
-                        }
+						$need = array(
+								'winners_count'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
+								'affiliate_site_id' => "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
+								'final_balance'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
+								'status'            => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
+						);
+						foreach ( $need as $c => $alter ) {
+								if ( ! $this->column_exists( $hunts_table, $c ) ) {
+																				dbDelta( $alter );
+								}
+						}
 
 			// Tournaments: make sure common columns exist
 			$tneed = array(
@@ -169,31 +169,31 @@ class BHG_DB {
 				'start_date'  => "ALTER TABLE `{$tours_table}` ADD COLUMN start_date DATE NULL",
 				'end_date'    => "ALTER TABLE `{$tours_table}` ADD COLUMN end_date DATE NULL",
 				'status'      => "ALTER TABLE `{$tours_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
-                        );
-                        foreach ( $tneed as $c => $alter ) {
-                                if ( ! $this->column_exists( $tours_table, $c ) ) {
-                                        dbDelta( $alter );
-                                }
-                        }
+						);
+						foreach ( $tneed as $c => $alter ) {
+								if ( ! $this->column_exists( $tours_table, $c ) ) {
+										dbDelta( $alter );
+								}
+						}
 
 						// Tournament results columns
-                                                $trrneed = array(
-                                                        'tournament_id' => "ALTER TABLE `{$tres_table}` ADD COLUMN tournament_id BIGINT UNSIGNED NOT NULL",
-                                                        'user_id'       => "ALTER TABLE `{$tres_table}` ADD COLUMN user_id BIGINT UNSIGNED NOT NULL",
-                                                        'wins'          => "ALTER TABLE `{$tres_table}` ADD COLUMN wins INT UNSIGNED NOT NULL DEFAULT 0",
-                                                        'last_win_date' => "ALTER TABLE `{$tres_table}` ADD COLUMN last_win_date DATETIME NULL",
-                                                );
-                                                foreach ( $trrneed as $c => $alter ) {
-                                                        if ( ! $this->column_exists( $tres_table, $c ) ) {
-                                                                dbDelta( $alter );
-                                                        }
-                                                }
-                                                if ( ! $this->index_exists( $tres_table, 'tournament_id' ) ) {
-                                                        dbDelta( "ALTER TABLE `{$tres_table}` ADD KEY tournament_id (tournament_id)" );
-                                                }
-                                                if ( ! $this->index_exists( $tres_table, 'user_id' ) ) {
-                                                        dbDelta( "ALTER TABLE `{$tres_table}` ADD KEY user_id (user_id)" );
-                                                }
+												$trrneed = array(
+														'tournament_id' => "ALTER TABLE `{$tres_table}` ADD COLUMN tournament_id BIGINT UNSIGNED NOT NULL",
+														'user_id'       => "ALTER TABLE `{$tres_table}` ADD COLUMN user_id BIGINT UNSIGNED NOT NULL",
+														'wins'          => "ALTER TABLE `{$tres_table}` ADD COLUMN wins INT UNSIGNED NOT NULL DEFAULT 0",
+														'last_win_date' => "ALTER TABLE `{$tres_table}` ADD COLUMN last_win_date DATETIME NULL",
+												);
+												foreach ( $trrneed as $c => $alter ) {
+														if ( ! $this->column_exists( $tres_table, $c ) ) {
+																dbDelta( $alter );
+														}
+												}
+												if ( ! $this->index_exists( $tres_table, 'tournament_id' ) ) {
+														dbDelta( "ALTER TABLE `{$tres_table}` ADD KEY tournament_id (tournament_id)" );
+												}
+												if ( ! $this->index_exists( $tres_table, 'user_id' ) ) {
+														dbDelta( "ALTER TABLE `{$tres_table}` ADD KEY user_id (user_id)" );
+												}
 
 						// Ads columns
 						$aneed = array(
@@ -206,12 +206,12 @@ class BHG_DB {
 							'active'       => "ALTER TABLE `{$ads_table}` ADD COLUMN active TINYINT(1) NOT NULL DEFAULT 1",
 							'created_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN created_at DATETIME NULL",
 							'updated_at'   => "ALTER TABLE `{$ads_table}` ADD COLUMN updated_at DATETIME NULL",
-                                                );
-                                                foreach ( $aneed as $c => $alter ) {
-                                                        if ( ! $this->column_exists( $ads_table, $c ) ) {
-                                                                                dbDelta( $alter );
-                                                        }
-                                                }
+												);
+												foreach ( $aneed as $c => $alter ) {
+														if ( ! $this->column_exists( $ads_table, $c ) ) {
+																				dbDelta( $alter );
+														}
+												}
 
 						// Translations columns
 						$trneed = array(
@@ -220,16 +220,16 @@ class BHG_DB {
 							'locale'     => "ALTER TABLE `{$trans_table}` ADD COLUMN locale VARCHAR(20) NOT NULL DEFAULT 'en_US'",
 							'created_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN created_at DATETIME NULL",
 							'updated_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN updated_at DATETIME NULL",
-                                                );
-                                                foreach ( $trneed as $c => $alter ) {
-                                                        if ( ! $this->column_exists( $trans_table, $c ) ) {
-                                                                                dbDelta( $alter );
-                                                        }
-                                                }
-                                                // Ensure unique index
-                                                if ( ! $this->index_exists( $trans_table, 'tkey_locale' ) ) {
-                                                                dbDelta( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY tkey_locale (tkey, locale)" );
-                                                }
+												);
+												foreach ( $trneed as $c => $alter ) {
+														if ( ! $this->column_exists( $trans_table, $c ) ) {
+																				dbDelta( $alter );
+														}
+												}
+												// Ensure unique index
+												if ( ! $this->index_exists( $trans_table, 'tkey_locale' ) ) {
+																dbDelta( "ALTER TABLE `{$trans_table}` ADD UNIQUE KEY tkey_locale (tkey, locale)" );
+												}
 
 						// Affiliates columns / unique index
 						$afneed = array(
@@ -238,15 +238,15 @@ class BHG_DB {
 							'status'     => "ALTER TABLE `{$aff_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
 							'created_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN created_at DATETIME NULL",
 							'updated_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN updated_at DATETIME NULL",
-                                                );
-                                                foreach ( $afneed as $c => $alter ) {
-                                                        if ( ! $this->column_exists( $aff_table, $c ) ) {
-                                                                                dbDelta( $alter );
-                                                        }
-                                                }
-                                                if ( ! $this->index_exists( $aff_table, 'name_unique' ) ) {
-                                                                dbDelta( "ALTER TABLE `{$aff_table}` ADD UNIQUE KEY name_unique (name)" );
-                                                }
+												);
+												foreach ( $afneed as $c => $alter ) {
+														if ( ! $this->column_exists( $aff_table, $c ) ) {
+																				dbDelta( $alter );
+														}
+												}
+												if ( ! $this->index_exists( $aff_table, 'name_unique' ) ) {
+																dbDelta( "ALTER TABLE `{$aff_table}` ADD UNIQUE KEY name_unique (name)" );
+												}
 		} catch ( Throwable $e ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
 				error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
@@ -264,8 +264,8 @@ class BHG_DB {
 	private function column_exists( $table, $column ) {
 		global $wpdb;
 
-                $table  = esc_sql( $table );
-                $column = esc_sql( $column );
+				$table  = esc_sql( $table );
+				$column = esc_sql( $column );
 
 				$wpdb->last_error = '';
 				$exists           = $wpdb->get_var(
@@ -277,11 +277,11 @@ class BHG_DB {
 					)
 				);
 
-                if ( $wpdb->last_error ) {
-                                                $wpdb->last_error = '';
-                                                $sql              = sprintf( 'SHOW COLUMNS FROM `%s` LIKE %%s', $table );
-                                                $exists           = $wpdb->get_var( $wpdb->prepare( $sql, $column ) );
-                }
+				if ( $wpdb->last_error ) {
+												$wpdb->last_error = '';
+												$sql              = sprintf( 'SHOW COLUMNS FROM `%s` LIKE %%s', $table );
+												$exists           = $wpdb->get_var( $wpdb->prepare( $sql, $column ) );
+				}
 
 		return ! empty( $exists );
 	}
@@ -296,8 +296,8 @@ class BHG_DB {
 	private function index_exists( $table, $index ) {
 		global $wpdb;
 
-                $table = esc_sql( $table );
-                $index = esc_sql( $index );
+				$table = esc_sql( $table );
+				$index = esc_sql( $index );
 
 				$wpdb->last_error = '';
 				$exists           = $wpdb->get_var(
@@ -309,11 +309,11 @@ class BHG_DB {
 					)
 				);
 
-                if ( $wpdb->last_error ) {
-                                                $wpdb->last_error = '';
-                                                $sql              = sprintf( 'SHOW INDEX FROM `%s` WHERE Key_name=%%s', $table );
-                                                $exists           = $wpdb->get_var( $wpdb->prepare( $sql, $index ) );
-                }
+				if ( $wpdb->last_error ) {
+												$wpdb->last_error = '';
+												$sql              = sprintf( 'SHOW INDEX FROM `%s` WHERE Key_name=%%s', $table );
+												$exists           = $wpdb->get_var( $wpdb->prepare( $sql, $index ) );
+				}
 
 		return ! empty( $exists );
 	}

--- a/includes/class-bhg-login-redirect.php
+++ b/includes/class-bhg-login-redirect.php
@@ -16,16 +16,16 @@ if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
 		}
 
 		public function core_login_redirect( $redirect_to, $requested, $user ) {
-                        $requested_redirect = '';
-                        if ( isset( $_POST['redirect_to'] ) ) {
-                                $requested_redirect = sanitize_text_field( wp_unslash( $_POST['redirect_to'] ) );
-                        } elseif ( isset( $_GET['redirect_to'] ) ) {
-                                $requested_redirect = sanitize_text_field( wp_unslash( $_GET['redirect_to'] ) );
-                        }
-                        if ( $requested_redirect ) {
-                                $validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
-                                return esc_url_raw( $validated_redirect );
-                        }
+						$requested_redirect = '';
+						if ( isset( $_POST['redirect_to'] ) ) {
+								$requested_redirect = sanitize_text_field( wp_unslash( $_POST['redirect_to'] ) );
+						} elseif ( isset( $_GET['redirect_to'] ) ) {
+								$requested_redirect = sanitize_text_field( wp_unslash( $_GET['redirect_to'] ) );
+						}
+						if ( $requested_redirect ) {
+								$validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
+								return esc_url_raw( $validated_redirect );
+						}
 
 			// Fall back to referer if safe.
 			$ref = wp_get_referer();
@@ -39,16 +39,16 @@ if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
 		}
 
 		public function nextend_redirect( $redirect_to, $user, $provider ) {
-                        $requested_redirect = '';
-                        if ( isset( $_POST['redirect_to'] ) ) {
-                                $requested_redirect = sanitize_text_field( wp_unslash( $_POST['redirect_to'] ) );
-                        } elseif ( isset( $_GET['redirect_to'] ) ) {
-                                $requested_redirect = sanitize_text_field( wp_unslash( $_GET['redirect_to'] ) );
-                        }
-                        if ( $requested_redirect ) {
-                                $validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
-                                return esc_url_raw( $validated_redirect );
-                        }
+						$requested_redirect = '';
+						if ( isset( $_POST['redirect_to'] ) ) {
+								$requested_redirect = sanitize_text_field( wp_unslash( $_POST['redirect_to'] ) );
+						} elseif ( isset( $_GET['redirect_to'] ) ) {
+								$requested_redirect = sanitize_text_field( wp_unslash( $_GET['redirect_to'] ) );
+						}
+						if ( $requested_redirect ) {
+								$validated_redirect = wp_validate_redirect( $requested_redirect, home_url( '/' ) );
+								return esc_url_raw( $validated_redirect );
+						}
 
 			$ref = wp_get_referer();
 			if ( $ref ) {

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -50,12 +50,12 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 		/** [bhg_active_hunt] — list all open hunts */
 		public function active_hunt_shortcode( $atts ) {
 				global $wpdb;
-                                $hunts = $wpdb->get_results(
-                                        $wpdb->prepare(
-                                                "SELECT id, title, starting_balance, num_bonuses, prizes FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status=%s ORDER BY created_at DESC",
-                                                'open'
-                                        )
-                                );
+								$hunts = $wpdb->get_results(
+										$wpdb->prepare(
+												"SELECT id, title, starting_balance, num_bonuses, prizes FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status=%s ORDER BY created_at DESC",
+												'open'
+										)
+								);
 			if ( ! $hunts ) {
 					return '<div class="bhg-active-hunt"><p>' . esc_html__( 'No active bonus hunts at the moment.', 'bonus-hunt-guesser' ) . '</p></div>';
 			}
@@ -215,18 +215,18 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			}
 
 			$rows = $wpdb->get_results(
-                                $wpdb->prepare(
-                                        "SELECT g.id, g.user_id, g.guess, g.created_at, u.user_login, h.affiliate_site_id
-                         FROM {$g} g
-                         LEFT JOIN {$u} u ON u.ID = g.user_id
-                         LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id
-                         WHERE g.hunt_id=%d
-                         ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
-                                        $hunt_id,
-                                        $per,
-                                        $offset
-                                )
-                        );
+								$wpdb->prepare(
+										"SELECT g.id, g.user_id, g.guess, g.created_at, u.user_login, h.affiliate_site_id
+						 FROM {$g} g
+						 LEFT JOIN {$u} u ON u.ID = g.user_id
+						 LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id
+						 WHERE g.hunt_id=%d
+						 ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
+										$hunt_id,
+										$per,
+										$offset
+								)
+						);
 
 			wp_enqueue_style(
 				'bhg-shortcodes',
@@ -713,7 +713,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					$args[]  = $website;
 			}
 
-                                $sql = "SELECT id, type, start_date, end_date, status FROM {$t}";
+								$sql = "SELECT id, type, start_date, end_date, status FROM {$t}";
 			if ( $where ) {
 					$sql .= ' WHERE ' . implode( ' AND ', $where );
 			}

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -124,16 +124,16 @@ function bhg_seed_demo_on_activation() {
 		}
 	}
 
-        // Compute winner for the closed hunt (closest)
-        $rows        = $wpdb->get_results(
-                $wpdb->prepare(
-                        "SELECT id, hunt_id, user_id, guess_amount, created_at FROM {$guesses} WHERE hunt_id = %d",
-                        $closed_id
-                )
-        );
-        $final       = 2420.00;
-        $winner_id   = 0;
-        $winner_diff = null;
+		// Compute winner for the closed hunt (closest)
+		$rows        = $wpdb->get_results(
+				$wpdb->prepare(
+						"SELECT id, hunt_id, user_id, guess_amount, created_at FROM {$guesses} WHERE hunt_id = %d",
+						$closed_id
+				)
+		);
+		$final       = 2420.00;
+		$winner_id   = 0;
+		$winner_diff = null;
 	foreach ( $rows as $row ) {
 		$diff = abs( floatval( $row->guess_amount ) - $final );
 		if ( $winner_diff === null || $diff < $winner_diff ) {


### PR DESCRIPTION
## Summary
- Replace leading spaces with tabs across PHP sources to better align with WordPress coding conventions.

## Testing
- `vendor/bin/phpcbf --standard=phpcs.xml --exclude=WordPress.WP.I18n` *(failed: trim(): Passing null to parameter #1 of type string is deprecated)*
- `vendor/bin/phpcs --standard=phpcs.xml` *(errors: WordPressCS\WordPress\PHPCSHelper::ignore_annotations(), trim(): Passing null to parameter #1 of type string is deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9eeef1748333b6220ec48f831e33