### PR TITLE
Fix best guessers query placeholder count

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -927,18 +927,20 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 						$params[] = $info['start'];
 						$params[] = $info['end'];
 					}
-					$sql = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
-						FROM {$wins_tbl} r
-						INNER JOIN {$users_tbl} u ON u.ID = r.user_id
-						INNER JOIN {$tours_tbl} t ON t.id = r.tournament_id
-						WHERE {$where}
-						GROUP BY u.ID, u.user_login
-						ORDER BY total_wins DESC, u.user_login ASC
-						LIMIT %d";
-					array_unshift( $params, $sql );
-					$prepared        = call_user_func_array( array( $wpdb, 'prepare' ), $params );
-					$results[ $key ] = $wpdb->get_results( $prepared );
-				} else {
+                                       $sql = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
+                                               FROM {$wins_tbl} r
+                                               INNER JOIN {$users_tbl} u ON u.ID = r.user_id
+                                               INNER JOIN {$tours_tbl} t ON t.id = r.tournament_id
+                                               WHERE {$where}
+                                               GROUP BY u.ID, u.user_login
+                                               ORDER BY total_wins DESC, u.user_login ASC
+                                               LIMIT %d";
+                                       $prepared = call_user_func_array(
+                                               array( $wpdb, 'prepare' ),
+                                               array_merge( array( $sql ), $params, array( 50 ) )
+                                       );
+                                       $results[ $key ] = $wpdb->get_results( $prepared );
+                               } else {
 					$sql                         = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
 						FROM {$wins_tbl} r
 						INNER JOIN {$users_tbl} u ON u.ID = r.user_id


### PR DESCRIPTION
## Summary
- ensure LIMIT placeholder in best guessers query has a matching argument
- use `array_merge` with explicit limit value when preparing dynamic query

## Testing
- `php -l includes/class-bhg-shortcodes.php`
- `composer phpcs` *(fails: trim(): Passing null to parameter #1 in WordPress sniff)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9ff001008333844a63eb314dfdca