### PR TITLE
Use bhg_log for internal logging

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -477,15 +477,13 @@ function bhg_handle_submit_guess() {
 	$max        = isset( $settings['max_guesses'] ) ? (int) $settings['max_guesses'] : 1;
 	$allow_edit = isset( $settings['allow_guess_changes'] ) && $settings['allow_guess_changes'] === 'yes';
 
-	if ( $guess < $min_guess || $guess > $max_guess ) {
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
-			error_log( '[BHG] invalid guess after parse: raw=' . print_r( $raw_guess, true ) . ' parsed=' . print_r( $guess, true ) );
-		}
-		if ( wp_doing_ajax() ) {
-			wp_send_json_error( __( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
-		}
-		wp_die( esc_html__( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
-	}
+        if ( $guess < $min_guess || $guess > $max_guess ) {
+                bhg_log( 'invalid guess after parse: raw=' . print_r( $raw_guess, true ) . ' parsed=' . print_r( $guess, true ) );
+                if ( wp_doing_ajax() ) {
+                        wp_send_json_error( __( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
+                }
+                wp_die( esc_html__( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
+        }
 
 	global $wpdb;
 	$hunts = $wpdb->prefix . 'bhg_bonus_hunts';
@@ -845,17 +843,15 @@ if ( ! function_exists( 'bhg_self_heal_db' ) ) {
 		if ( ! class_exists( 'BHG_DB' ) ) {
 			require_once __DIR__ . '/includes/class-bhg-db.php';
 		}
-		try {
-			$db = new BHG_DB();
-			$db->create_tables();
-		} catch ( Throwable $e ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
-				error_log( '[BHG] DB self-heal failed: ' . $e->getMessage() );
-			}
-		}
-	}
-	add_action( 'admin_init', 'bhg_self_heal_db' );
-	register_activation_hook( __FILE__, 'bhg_self_heal_db' );
+               try {
+                       $db = new BHG_DB();
+                       $db->create_tables();
+               } catch ( Throwable $e ) {
+                       bhg_log( 'DB self-heal failed: ' . $e->getMessage() );
+               }
+        }
+        add_action( 'admin_init', 'bhg_self_heal_db' );
+        register_activation_hook( __FILE__, 'bhg_self_heal_db' );
 }
 
 


### PR DESCRIPTION
## Summary
- route plugin logging through bhg_log to avoid accidental production error_log calls

## Testing
- `php -l bonus-hunt-guesser.php`
- `composer phpcs` *(fails: WordPressCS\WordPress\PHPCSHelper::ignore_annotations(): Implicitly marking parameter $phpcsFile as nullable is deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_68bba75564b88333abb71ccd42c4b781