### PR TITLE
Align settings nonce fields

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -475,7 +475,7 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
-		check_admin_referer( 'bhg_save_settings' );
+               check_admin_referer( 'bhg_save_settings', 'bhg_nonce' );
 		$opts = array(
 			'allow_guess_edit_until_close' => isset( $_POST['allow_guess_edit_until_close'] ) ? 'yes' : 'no',
 			'guesses_max'                  => isset( $_POST['guesses_max'] ) ? max( 1, absint( wp_unslash( $_POST['guesses_max'] ) ) ) : 1,

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -53,7 +53,7 @@ if ( ! empty( $error ) ) {
 	
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 		<input type="hidden" name="action" value="bhg_save_settings">
-		<?php wp_nonce_field( 'bhg_save_settings_nonce', 'bhg_settings_nonce' ); ?>
+               <?php wp_nonce_field( 'bhg_save_settings', 'bhg_nonce' ); ?>
 
 		<table class="form-table">
 			<tr>


### PR DESCRIPTION
## Summary
- Replace settings nonce field names with `bhg_save_settings`/`bhg_nonce`
- Match nonce verification in `handle_save_settings`

## Testing
- `php -l admin/views/settings.php`
- `php -l admin/class-bhg-admin.php`
- `composer phpcs` *(fails: Missing file doc comment in includes/class-bhg-settings.php)*

------
https://chatgpt.com/codex/tasks/task_e_68bbabd9cbac8333b281a826f5faafa1