### PR TITLE
Normalize indentation to tabs in key plugin files

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -475,7 +475,7 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
-               check_admin_referer( 'bhg_save_settings', 'bhg_nonce' );
+			   check_admin_referer( 'bhg_save_settings', 'bhg_nonce' );
 		$opts = array(
 			'allow_guess_edit_until_close' => isset( $_POST['allow_guess_edit_until_close'] ) ? 'yes' : 'no',
 			'guesses_max'                  => isset( $_POST['guesses_max'] ) ? max( 1, absint( wp_unslash( $_POST['guesses_max'] ) ) ) : 1,

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -477,13 +477,13 @@ function bhg_handle_submit_guess() {
 	$max        = isset( $settings['max_guesses'] ) ? (int) $settings['max_guesses'] : 1;
 	$allow_edit = isset( $settings['allow_guess_changes'] ) && $settings['allow_guess_changes'] === 'yes';
 
-        if ( $guess < $min_guess || $guess > $max_guess ) {
-                bhg_log( 'invalid guess after parse: raw=' . print_r( $raw_guess, true ) . ' parsed=' . print_r( $guess, true ) );
-                if ( wp_doing_ajax() ) {
-                        wp_send_json_error( __( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
-                }
-                wp_die( esc_html__( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
-        }
+	if ( $guess < $min_guess || $guess > $max_guess ) {
+			bhg_log( 'invalid guess after parse: raw=' . print_r( $raw_guess, true ) . ' parsed=' . print_r( $guess, true ) );
+		if ( wp_doing_ajax() ) {
+				wp_send_json_error( __( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
+		}
+			wp_die( esc_html__( 'Invalid guess amount.', 'bonus-hunt-guesser' ) );
+	}
 
 	global $wpdb;
 	$hunts = $wpdb->prefix . 'bhg_bonus_hunts';
@@ -593,9 +593,9 @@ function bhg_build_ads_query( $table, $placement = 'footer' ) {
 	}
 
 				$query = $wpdb->prepare(
-						"SELECT id, title, content, link_url, placement, visible_to, target_pages, active FROM `{$table}` WHERE placement = %s AND active = %d",
-						$placement,
-						1
+					"SELECT id, title, content, link_url, placement, visible_to, target_pages, active FROM `{$table}` WHERE placement = %s AND active = %d",
+					$placement,
+					1
 				);
 
 		$rows = $wpdb->get_results( $query );
@@ -843,15 +843,15 @@ if ( ! function_exists( 'bhg_self_heal_db' ) ) {
 		if ( ! class_exists( 'BHG_DB' ) ) {
 			require_once __DIR__ . '/includes/class-bhg-db.php';
 		}
-               try {
-                       $db = new BHG_DB();
-                       $db->create_tables();
-               } catch ( Throwable $e ) {
-                       bhg_log( 'DB self-heal failed: ' . $e->getMessage() );
-               }
-        }
-        add_action( 'admin_init', 'bhg_self_heal_db' );
-        register_activation_hook( __FILE__, 'bhg_self_heal_db' );
+		try {
+				$db = new BHG_DB();
+				$db->create_tables();
+		} catch ( Throwable $e ) {
+				bhg_log( 'DB self-heal failed: ' . $e->getMessage() );
+		}
+	}
+		add_action( 'admin_init', 'bhg_self_heal_db' );
+		register_activation_hook( __FILE__, 'bhg_self_heal_db' );
 }
 
 

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -51,10 +51,10 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 		public function active_hunt_shortcode( $atts ) {
 				global $wpdb;
 								$hunts = $wpdb->get_results(
-										$wpdb->prepare(
-												"SELECT id, title, starting_balance, num_bonuses, prizes FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status=%s ORDER BY created_at DESC",
-												'open'
-										)
+									$wpdb->prepare(
+										"SELECT id, title, starting_balance, num_bonuses, prizes FROM {$wpdb->prefix}bhg_bonus_hunts WHERE status=%s ORDER BY created_at DESC",
+										'open'
+									)
 								);
 			if ( ! $hunts ) {
 					return '<div class="bhg-active-hunt"><p>' . esc_html__( 'No active bonus hunts at the moment.', 'bonus-hunt-guesser' ) . '</p></div>';
@@ -166,148 +166,148 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 			return ob_get_clean();
 		}
 
-	/** [bhg_leaderboard] */
-	public function leaderboard_shortcode( $atts ) {
-	$a = shortcode_atts(
-	array(
-	'hunt_id'   => 0,
-	'orderby'   => 'guess',
-	'order'     => 'ASC',
-	'page'      => 1,
-	'per_page'  => 20,
-	'tournament'=> 0,
-	'ranking'   => '',
-	'fields'    => 'position,user,guess',
-	'bonushunt' => 0,
-	),
-	$atts,
-	'bhg_leaderboard'
-	);
-	
-	global $wpdb;
-	
-	$hunt_id = $a['bonushunt'] ? (int) $a['bonushunt'] : (int) $a['hunt_id'];
-	if ( $hunt_id <= 0 ) {
-	$hunt_id = (int) $wpdb->get_var(
-	$wpdb->prepare(
-	"SELECT id FROM {$wpdb->prefix}bhg_bonus_hunts ORDER BY created_at DESC LIMIT %d",
-	1
-	)
-	);
-	if ( $hunt_id <= 0 ) {
-	return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
-	}
-	}
-	
-	$g         = $wpdb->prefix . 'bhg_guesses';
-	$u         = $wpdb->users;
-	$results   = $wpdb->prefix . 'bhg_tournament_results';
-	$fields    = array_map( 'trim', explode( ',', $a['fields'] ) );
-	$show_wins = in_array( 'wins', $fields, true );
-	
-	$order       = strtoupper( $a['order'] ) === 'DESC' ? 'DESC' : 'ASC';
-	$map         = array(
-	'guess'    => 'g.guess',
-	'user'     => 'u.user_login',
-	'position' => 'g.id', // stable proxy
-	'wins'     => 'tr.wins',
-	);
-	$rank_key    = $a['ranking'] ? $a['ranking'] : $a['orderby'];
-	$orderby_key = array_key_exists( $rank_key, $map ) ? $rank_key : 'guess';
-	$orderby     = $map[ $orderby_key ];
-	
-	$page   = max( 1, (int) $a['page'] );
-	$per    = max( 1, (int) $a['per_page'] );
-	$offset = ( $page - 1 ) * $per;
-	
-	$total = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$g} WHERE hunt_id=%d", $hunt_id ) );
-	if ( $total < 1 ) {
-	return '<p>' . esc_html__( 'No guesses yet.', 'bonus-hunt-guesser' ) . '</p>';
-	}
-	
-	$select = 'g.id, g.user_id, g.guess, g.created_at, u.user_login, h.affiliate_site_id';
-	$joins  = " FROM {$g} g LEFT JOIN {$u} u ON u.ID = g.user_id LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id";
-	$where  = $wpdb->prepare( ' WHERE g.hunt_id=%d', $hunt_id );
-	if ( $show_wins || (int) $a['tournament'] > 0 || 'wins' === $orderby_key ) {
-	$joins .= " LEFT JOIN {$results} tr ON tr.user_id = g.user_id";
-	if ( (int) $a['tournament'] > 0 ) {
-	$where .= $wpdb->prepare( ' AND tr.tournament_id=%d', (int) $a['tournament'] );
-	}
-	$select .= ', tr.wins';
-	}
-	$sql  = $select . $joins . $where . " ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
-	$rows = $wpdb->get_results( $wpdb->prepare( $sql, $per, $offset ) );
-	
-	wp_enqueue_style(
-	'bhg-shortcodes',
-	BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
-	array(),
-	defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-	);
-	
-	ob_start();
-	echo '<table class="bhg-leaderboard">';
-	echo '<thead><tr>';
-	if ( in_array( 'position', $fields, true ) ) {
-	echo '<th class="sortable" data-column="position">' . esc_html__( 'Position', 'bonus-hunt-guesser' ) . '</th>';
-	}
-	if ( in_array( 'user', $fields, true ) ) {
-	echo '<th class="sortable" data-column="user">' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th>';
-	}
-	if ( in_array( 'guess', $fields, true ) ) {
-	echo '<th class="sortable" data-column="guess">' . esc_html__( 'Guess', 'bonus-hunt-guesser' ) . '</th>';
-	}
-	if ( $show_wins ) {
-	echo '<th class="sortable" data-column="wins">' . esc_html__( 'Wins', 'bonus-hunt-guesser' ) . '</th>';
-	}
-	echo '</tr></thead><tbody>';
-	
-	$pos = $offset + 1;
-	foreach ( $rows as $r ) {
-	$site_id = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
-	$is_aff  = $site_id > 0
-	? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
-	: (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
-	$aff     = $is_aff ? 'green' : 'red';
-	/* translators: %d: user ID. */
-	$user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
-	
-	echo '<tr>';
-	if ( in_array( 'position', $fields, true ) ) {
-	echo '<td data-column="position">' . (int) $pos++ . '</td>';
-	}
-	if ( in_array( 'user', $fields, true ) ) {
-	echo '<td data-column="user">' . esc_html( $user_label ) . ' <span class="bhg-aff-dot bhg-aff-' . esc_attr( $aff ) . '" aria-hidden="true"></span></td>';
-	}
-	if ( in_array( 'guess', $fields, true ) ) {
-	echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
-	}
-	if ( $show_wins ) {
-	echo '<td data-column="wins">' . ( isset( $r->wins ) ? (int) $r->wins : 0 ) . '</td>';
-	}
-	echo '</tr>';
-	}
-	echo '</tbody></table>';
-	
-	$pages = (int) ceil( $total / $per );
-	if ( $pages > 1 ) {
-	$base = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
-	$base = esc_url_raw( remove_query_arg( 'page', $base ) );
-	echo '<div class="bhg-pagination">';
-	for ( $p = 1; $p <= $pages; $p++ ) {
-	$class = $p == $page ? 'bhg-current-page' : '';
-	printf(
-	'<a class="%1$s" href="%2$s">%3$s</a> ',
-	esc_attr( $class ),
-	esc_url( add_query_arg( array( 'page' => $p ), $base ) ),
-	esc_html( $p )
-	);
-	}
-	echo '</div>';
-	}
-	
-	return ob_get_clean();
-	}
+		/** [bhg_leaderboard] */
+		public function leaderboard_shortcode( $atts ) {
+			$a = shortcode_atts(
+				array(
+					'hunt_id'    => 0,
+					'orderby'    => 'guess',
+					'order'      => 'ASC',
+					'page'       => 1,
+					'per_page'   => 20,
+					'tournament' => 0,
+					'ranking'    => '',
+					'fields'     => 'position,user,guess',
+					'bonushunt'  => 0,
+				),
+				$atts,
+				'bhg_leaderboard'
+			);
+
+			global $wpdb;
+
+			$hunt_id = $a['bonushunt'] ? (int) $a['bonushunt'] : (int) $a['hunt_id'];
+			if ( $hunt_id <= 0 ) {
+				$hunt_id = (int) $wpdb->get_var(
+					$wpdb->prepare(
+						"SELECT id FROM {$wpdb->prefix}bhg_bonus_hunts ORDER BY created_at DESC LIMIT %d",
+						1
+					)
+				);
+				if ( $hunt_id <= 0 ) {
+						return '<p>' . esc_html__( 'No hunts found.', 'bonus-hunt-guesser' ) . '</p>';
+				}
+			}
+
+			$g         = $wpdb->prefix . 'bhg_guesses';
+			$u         = $wpdb->users;
+			$results   = $wpdb->prefix . 'bhg_tournament_results';
+			$fields    = array_map( 'trim', explode( ',', $a['fields'] ) );
+			$show_wins = in_array( 'wins', $fields, true );
+
+			$order       = strtoupper( $a['order'] ) === 'DESC' ? 'DESC' : 'ASC';
+			$map         = array(
+				'guess'    => 'g.guess',
+				'user'     => 'u.user_login',
+				'position' => 'g.id', // stable proxy
+				'wins'     => 'tr.wins',
+			);
+			$rank_key    = $a['ranking'] ? $a['ranking'] : $a['orderby'];
+			$orderby_key = array_key_exists( $rank_key, $map ) ? $rank_key : 'guess';
+			$orderby     = $map[ $orderby_key ];
+
+			$page   = max( 1, (int) $a['page'] );
+			$per    = max( 1, (int) $a['per_page'] );
+			$offset = ( $page - 1 ) * $per;
+
+			$total = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$g} WHERE hunt_id=%d", $hunt_id ) );
+			if ( $total < 1 ) {
+				return '<p>' . esc_html__( 'No guesses yet.', 'bonus-hunt-guesser' ) . '</p>';
+			}
+
+			$select = 'g.id, g.user_id, g.guess, g.created_at, u.user_login, h.affiliate_site_id';
+			$joins  = " FROM {$g} g LEFT JOIN {$u} u ON u.ID = g.user_id LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id";
+			$where  = $wpdb->prepare( ' WHERE g.hunt_id=%d', $hunt_id );
+			if ( $show_wins || (int) $a['tournament'] > 0 || 'wins' === $orderby_key ) {
+				$joins .= " LEFT JOIN {$results} tr ON tr.user_id = g.user_id";
+				if ( (int) $a['tournament'] > 0 ) {
+					$where .= $wpdb->prepare( ' AND tr.tournament_id=%d', (int) $a['tournament'] );
+				}
+				$select .= ', tr.wins';
+			}
+			$sql  = $select . $joins . $where . " ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
+			$rows = $wpdb->get_results( $wpdb->prepare( $sql, $per, $offset ) );
+
+			wp_enqueue_style(
+				'bhg-shortcodes',
+				BHG_PLUGIN_URL . 'assets/css/bhg-shortcodes.css',
+				array(),
+				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+			);
+
+			ob_start();
+			echo '<table class="bhg-leaderboard">';
+			echo '<thead><tr>';
+			if ( in_array( 'position', $fields, true ) ) {
+				echo '<th class="sortable" data-column="position">' . esc_html__( 'Position', 'bonus-hunt-guesser' ) . '</th>';
+			}
+			if ( in_array( 'user', $fields, true ) ) {
+				echo '<th class="sortable" data-column="user">' . esc_html__( 'User', 'bonus-hunt-guesser' ) . '</th>';
+			}
+			if ( in_array( 'guess', $fields, true ) ) {
+				echo '<th class="sortable" data-column="guess">' . esc_html__( 'Guess', 'bonus-hunt-guesser' ) . '</th>';
+			}
+			if ( $show_wins ) {
+				echo '<th class="sortable" data-column="wins">' . esc_html__( 'Wins', 'bonus-hunt-guesser' ) . '</th>';
+			}
+			echo '</tr></thead><tbody>';
+
+			$pos = $offset + 1;
+			foreach ( $rows as $r ) {
+				$site_id = isset( $r->affiliate_site_id ) ? (int) $r->affiliate_site_id : 0;
+				$is_aff  = $site_id > 0
+				? (int) get_user_meta( (int) $r->user_id, 'bhg_affiliate_website_' . $site_id, true )
+				: (int) get_user_meta( (int) $r->user_id, 'bhg_is_affiliate', true );
+				$aff     = $is_aff ? 'green' : 'red';
+				/* translators: %d: user ID. */
+				$user_label = $r->user_login ? $r->user_login : sprintf( __( 'user#%d', 'bonus-hunt-guesser' ), (int) $r->user_id );
+
+				echo '<tr>';
+				if ( in_array( 'position', $fields, true ) ) {
+					echo '<td data-column="position">' . (int) $pos++ . '</td>';
+				}
+				if ( in_array( 'user', $fields, true ) ) {
+					echo '<td data-column="user">' . esc_html( $user_label ) . ' <span class="bhg-aff-dot bhg-aff-' . esc_attr( $aff ) . '" aria-hidden="true"></span></td>';
+				}
+				if ( in_array( 'guess', $fields, true ) ) {
+					echo '<td data-column="guess">' . esc_html( number_format_i18n( (float) $r->guess, 2 ) ) . '</td>';
+				}
+				if ( $show_wins ) {
+					echo '<td data-column="wins">' . ( isset( $r->wins ) ? (int) $r->wins : 0 ) . '</td>';
+				}
+				echo '</tr>';
+			}
+			echo '</tbody></table>';
+
+			$pages = (int) ceil( $total / $per );
+			if ( $pages > 1 ) {
+				$base = wp_validate_redirect( wp_unslash( $_SERVER['REQUEST_URI'] ), home_url( '/' ) );
+				$base = esc_url_raw( remove_query_arg( 'page', $base ) );
+				echo '<div class="bhg-pagination">';
+				for ( $p = 1; $p <= $pages; $p++ ) {
+					$class = $p == $page ? 'bhg-current-page' : '';
+					printf(
+						'<a class="%1$s" href="%2$s">%3$s</a> ',
+						esc_attr( $class ),
+						esc_url( add_query_arg( array( 'page' => $p ), $base ) ),
+						esc_html( $p )
+					);
+				}
+				echo '</div>';
+			}
+
+			return ob_get_clean();
+		}
 
 		/**
 		 * Display guesses for a specific hunt.
@@ -385,7 +385,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				$limit_sql = ' LIMIT 10';
 			}
 
-			$sql = "SELECT g.guess, g.user_id, u.user_login, h.final_balance, h.affiliate_site_id"
+			$sql = 'SELECT g.guess, g.user_id, u.user_login, h.final_balance, h.affiliate_site_id'
 			. " FROM {$g} g"
 			. " LEFT JOIN {$u} u ON u.ID = g.user_id"
 			. " INNER JOIN {$h} h ON h.id = g.hunt_id"
@@ -413,7 +413,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				echo '<td>' . esc_html( $user_label ) . '</td>';
 				$guess_cell = esc_html( number_format_i18n( (float) $row->guess, 2 ) );
 				if ( $show_aff ) {
-				$guess_cell = bhg_render_affiliate_dot( (int) $row->user_id, (int) $row->affiliate_site_id ) . $guess_cell;
+					$guess_cell = bhg_render_affiliate_dot( (int) $row->user_id, (int) $row->affiliate_site_id ) . $guess_cell;
 				}
 				echo '<td>' . wp_kses_post( $guess_cell ) . '</td>';
 				echo '<td>';
@@ -973,27 +973,27 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 						$params[] = $info['start'];
 						$params[] = $info['end'];
 					}
-                                       $sql = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
-                                               FROM {$wins_tbl} r
-                                               INNER JOIN {$users_tbl} u ON u.ID = r.user_id
-                                               INNER JOIN {$tours_tbl} t ON t.id = r.tournament_id
-                                               WHERE {$where}
-                                               GROUP BY u.ID, u.user_login
-                                               ORDER BY total_wins DESC, u.user_login ASC
-                                               LIMIT %d";
-                                       $prepared = call_user_func_array(
-                                               array( $wpdb, 'prepare' ),
-                                               array_merge( array( $sql ), $params, array( 50 ) )
-                                       );
-                                       $results[ $key ] = $wpdb->get_results( $prepared );
-                               } else {
-					$sql                         = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
+									   $sql             = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
+											   FROM {$wins_tbl} r
+											   INNER JOIN {$users_tbl} u ON u.ID = r.user_id
+											   INNER JOIN {$tours_tbl} t ON t.id = r.tournament_id
+											   WHERE {$where}
+											   GROUP BY u.ID, u.user_login
+											   ORDER BY total_wins DESC, u.user_login ASC
+											   LIMIT %d";
+									$prepared           = call_user_func_array(
+										array( $wpdb, 'prepare' ),
+										array_merge( array( $sql ), $params, array( 50 ) )
+									);
+									   $results[ $key ] = $wpdb->get_results( $prepared );
+				} else {
+					$sql             = "SELECT u.ID as user_id, u.user_login, SUM(r.wins) as total_wins
 						FROM {$wins_tbl} r
 						INNER JOIN {$users_tbl} u ON u.ID = r.user_id
 						GROUP BY u.ID, u.user_login
 						ORDER BY total_wins DESC, u.user_login ASC
 						LIMIT %d";
-								$results[ $key ] = $wpdb->get_results( $wpdb->prepare( $sql, 50 ) );
+					$results[ $key ] = $wpdb->get_results( $wpdb->prepare( $sql, 50 ) );
 				}
 			}
 


### PR DESCRIPTION
## Summary
- Replace leading spaces with tabs in `bonus-hunt-guesser.php`
- Apply tab-based indentation for `admin/class-bhg-admin.php`
- Convert leading spaces to tabs in `includes/class-bhg-shortcodes.php`

## Testing
- `php -d error_reporting="E_ALL & ~E_DEPRECATED" vendor/bin/phpcbf --standard=phpcs.xml bonus-hunt-guesser.php admin/class-bhg-admin.php includes/class-bhg-shortcodes.php`
- `php -d error_reporting="E_ALL & ~E_DEPRECATED" vendor/bin/phpcs --standard=phpcs.xml bonus-hunt-guesser.php admin/class-bhg-admin.php includes/class-bhg-shortcodes.php` (fails: 89 errors, 22 warnings)

------
https://chatgpt.com/codex/tasks/task_e_68bbac945f8883339e2a11339d195d2c