### PR TITLE
Fix demo query to use guesses table

### DIFF
--- a/includes/demo.php
+++ b/includes/demo.php
@@ -124,13 +124,13 @@ function bhg_seed_demo_on_activation() {
 		}
 	}
 
-		// Compute winner for the closed hunt (closest)
-		$rows        = $wpdb->get_results(
-				$wpdb->prepare(
-						"SELECT id, hunt_id, user_id, guess_amount, created_at FROM {$guesses} WHERE hunt_id = %d",
-						$closed_id
-				)
-		);
+               // Compute winner for the closed hunt (closest)
+               $rows = $wpdb->get_results(
+                       $wpdb->prepare(
+                               "SELECT * FROM {$guesses} WHERE hunt_id = %d",
+                               $closed_id
+                       )
+               );
 		$final       = 2420.00;
 		$winner_id   = 0;
 		$winner_diff = null;


### PR DESCRIPTION
## Summary
- Correct demo winner calculation to query bhg_guesses table filtered by hunt_id

## Testing
- `composer phpcs` *(fails: Line indented incorrectly and other sniff errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb163b1e48333850af9ec384cb2df