### PR TITLE
Harden table name handling with prefix whitelisting

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -11,8 +11,8 @@ if ( ! current_user_can( 'manage_options' ) ) {
 }
 
 global $wpdb;
-$hunts_table    = $wpdb->prefix . 'bhg_bonus_hunts';
-$guesses_table  = $wpdb->prefix . 'bhg_guesses';
+$hunts_table	= $wpdb->prefix . 'bhg_bonus_hunts';
+$guesses_table	= $wpdb->prefix . 'bhg_guesses';
 $allowed_tables = array(
 	$wpdb->prefix . 'bhg_bonus_hunts',
 	$wpdb->prefix . 'bhg_guesses',
@@ -34,7 +34,7 @@ if ( 'edit' === $view ) {
 if ( 'list' === $view ) :
 		$current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
 		$per_page     = 30;
-		$offset       = ( $current_page - 1 ) * $per_page;
+		$offset	      = ( $current_page - 1 ) * $per_page;
 
 				$hunts = $wpdb->get_results(
 						$wpdb->prepare(
@@ -45,11 +45,11 @@ if ( 'list' === $view ) :
 				);
 
 		$status_labels = array(
-			'open'   => __( 'Open', 'bonus-hunt-guesser' ),
+			'open'	 => __( 'Open', 'bonus-hunt-guesser' ),
 			'closed' => __( 'Closed', 'bonus-hunt-guesser' ),
 		);
 
-		$total    = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$hunts_table}" );
+		$total	  = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$hunts_table}" );
 		$base_url = remove_query_arg( array( 'paged' ) );
 		?>
 <div class="wrap">
@@ -142,11 +142,11 @@ endif;
 			echo '<div class="tablenav"><div class="tablenav-pages">';
 			echo paginate_links(
 				array(
-					'base'      => add_query_arg( 'paged', '%#%', $base_url ),
+					'base'	    => add_query_arg( 'paged', '%#%', $base_url ),
 					'format'    => '',
 					'prev_text' => '&laquo;',
 					'next_text' => '&raquo;',
-					'total'     => $total_pages,
+					'total'	    => $total_pages,
 					'current'   => $current_page,
 				)
 			);
@@ -230,11 +230,10 @@ if ( $view === 'add' ) :
 			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
 				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 			}
-			$aff_table = esc_sql( $aff_table );
-			$affs      = $wpdb->get_results(
+			$affs = $wpdb->get_results(
 				"SELECT id, name FROM {$aff_table} ORDER BY name ASC"
 			);
-			$sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
+			$sel  = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 			?>
 			<select id="bhg_affiliate" name="affiliate_site_id">
 				<option value="0"><?php echo esc_html__( 'None', 'bonus-hunt-guesser' ); ?></option>

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -5,27 +5,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 class BHG_DB {
 
 	// Static wrapper to support legacy static calls.
-        public static function migrate() {
-                $db = new self();
-                $db->create_tables();
+	public static function migrate() {
+		$db = new self();
+		$db->create_tables();
 
-                global $wpdb;
-                $tours_table    = esc_sql( $wpdb->prefix . 'bhg_tournaments' );
-                $allowed_tables = array( esc_sql( $wpdb->prefix . 'bhg_tournaments' ) );
-                if ( ! in_array( $tours_table, $allowed_tables, true ) ) {
-                        wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
-                }
+	global $wpdb;
+	$tours_table	= $wpdb->prefix . 'bhg_tournaments';
+	$allowed_tables = array( $wpdb->prefix . 'bhg_tournaments' );
+	if ( ! in_array( $tours_table, $allowed_tables, true ) ) {
+			wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+		}
 
-                // Drop legacy "period" column and related index if they exist.
-                if ( $db->column_exists( $tours_table, 'period' ) ) {
-                        // Remove unique index first if present.
-                        if ( $db->index_exists( $tours_table, 'type_period' ) ) {
-                                dbDelta( sprintf( 'ALTER TABLE `%s` DROP INDEX type_period', $tours_table ) );
-                        }
+		// Drop legacy "period" column and related index if they exist.
+		if ( $db->column_exists( $tours_table, 'period' ) ) {
+			// Remove unique index first if present.
+			if ( $db->index_exists( $tours_table, 'type_period' ) ) {
+				dbDelta( sprintf( 'ALTER TABLE `%s` DROP INDEX type_period', $tours_table ) );
+			}
 
-                        dbDelta( sprintf( 'ALTER TABLE `%s` DROP COLUMN period', $tours_table ) );
-                }
-        }
+			dbDelta( sprintf( 'ALTER TABLE `%s` DROP COLUMN period', $tours_table ) );
+		}
+	}
 
 	public function create_tables() {
 		global $wpdb;
@@ -33,18 +33,18 @@ class BHG_DB {
 
 		$charset_collate = $wpdb->get_charset_collate();
 
-                $hunts_table   = esc_sql( $wpdb->prefix . 'bhg_bonus_hunts' );
-                $guesses_table = esc_sql( $wpdb->prefix . 'bhg_guesses' );
-                $tours_table   = esc_sql( $wpdb->prefix . 'bhg_tournaments' );
-                $tres_table    = esc_sql( $wpdb->prefix . 'bhg_tournament_results' );
-                $ads_table     = esc_sql( $wpdb->prefix . 'bhg_ads' );
-                $trans_table   = esc_sql( $wpdb->prefix . 'bhg_translations' );
-                $aff_table     = esc_sql( $wpdb->prefix . 'bhg_affiliates' );
+	$hunts_table   = $wpdb->prefix . 'bhg_bonus_hunts';
+	$guesses_table = $wpdb->prefix . 'bhg_guesses';
+	$tours_table   = $wpdb->prefix . 'bhg_tournaments';
+	$tres_table    = $wpdb->prefix . 'bhg_tournament_results';
+	$ads_table     = $wpdb->prefix . 'bhg_ads';
+	$trans_table   = $wpdb->prefix . 'bhg_translations';
+	$aff_table     = $wpdb->prefix . 'bhg_affiliates';
 
 		$sql = array();
 
 		// Bonus Hunts
-                $sql[] = "CREATE TABLE `{$hunts_table}` (
+		$sql[] = "CREATE TABLE `{$hunts_table}` (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			title VARCHAR(190) NOT NULL,
 			starting_balance DECIMAL(12,2) NOT NULL DEFAULT 0.00,
@@ -62,7 +62,7 @@ class BHG_DB {
 		) {$charset_collate};";
 
 		// Guesses
-                $sql[] = "CREATE TABLE `{$guesses_table}` (
+		$sql[] = "CREATE TABLE `{$guesses_table}` (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			hunt_id BIGINT UNSIGNED NOT NULL,
 			user_id BIGINT UNSIGNED NOT NULL,
@@ -74,7 +74,7 @@ class BHG_DB {
 		) {$charset_collate};";
 
 				// Tournaments
-                                $sql[] = "CREATE TABLE `{$tours_table}` (
+				$sql[] = "CREATE TABLE `{$tours_table}` (
 						id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 						title VARCHAR(190) NOT NULL,
 						description TEXT NULL,
@@ -90,7 +90,7 @@ class BHG_DB {
 				) {$charset_collate};";
 
 				// Tournament Results
-                                $sql[] = "CREATE TABLE `{$tres_table}` (
+				$sql[] = "CREATE TABLE `{$tres_table}` (
 						id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 						tournament_id BIGINT UNSIGNED NOT NULL,
 						user_id BIGINT UNSIGNED NOT NULL,
@@ -102,7 +102,7 @@ class BHG_DB {
 				) {$charset_collate};";
 
 				// Ads
-                                $sql[] = "CREATE TABLE `{$ads_table}` (
+				$sql[] = "CREATE TABLE `{$ads_table}` (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			title VARCHAR(190) NOT NULL,
 			content TEXT NULL,
@@ -119,7 +119,7 @@ class BHG_DB {
 		) {$charset_collate};";
 
 		// Translations
-                $sql[] = "CREATE TABLE `{$trans_table}` (
+		$sql[] = "CREATE TABLE `{$trans_table}` (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			tkey VARCHAR(190) NOT NULL,
 			tvalue LONGTEXT NULL,
@@ -131,7 +131,7 @@ class BHG_DB {
 		) {$charset_collate};";
 
 		// Affiliates
-                $sql[] = "CREATE TABLE `{$aff_table}` (
+		$sql[] = "CREATE TABLE `{$aff_table}` (
 			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
 			name VARCHAR(190) NOT NULL,
 			url VARCHAR(255) NULL,
@@ -150,10 +150,10 @@ class BHG_DB {
 		try {
 			// Hunts: winners_count, affiliate_site_id
 						$need = array(
-								'winners_count'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
+								'winners_count'	    => "ALTER TABLE `{$hunts_table}` ADD COLUMN winners_count INT UNSIGNED NOT NULL DEFAULT 3",
 								'affiliate_site_id' => "ALTER TABLE `{$hunts_table}` ADD COLUMN affiliate_site_id BIGINT UNSIGNED NULL",
-								'final_balance'     => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
-								'status'            => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
+								'final_balance'	    => "ALTER TABLE `{$hunts_table}` ADD COLUMN final_balance DECIMAL(12,2) NULL",
+								'status'	    => "ALTER TABLE `{$hunts_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'open'",
 						);
 						foreach ( $need as $c => $alter ) {
 								if ( ! $this->column_exists( $hunts_table, $c ) ) {
@@ -163,9 +163,9 @@ class BHG_DB {
 
 			// Tournaments: make sure common columns exist
 			$tneed = array(
-				'title'       => "ALTER TABLE `{$tours_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
+				'title'	      => "ALTER TABLE `{$tours_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
 				'description' => "ALTER TABLE `{$tours_table}` ADD COLUMN description TEXT NULL",
-				'type'        => "ALTER TABLE `{$tours_table}` ADD COLUMN type VARCHAR(20) NOT NULL",
+				'type'	      => "ALTER TABLE `{$tours_table}` ADD COLUMN type VARCHAR(20) NOT NULL",
 				'start_date'  => "ALTER TABLE `{$tours_table}` ADD COLUMN start_date DATE NULL",
 				'end_date'    => "ALTER TABLE `{$tours_table}` ADD COLUMN end_date DATE NULL",
 				'status'      => "ALTER TABLE `{$tours_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
@@ -179,8 +179,8 @@ class BHG_DB {
 						// Tournament results columns
 												$trrneed = array(
 														'tournament_id' => "ALTER TABLE `{$tres_table}` ADD COLUMN tournament_id BIGINT UNSIGNED NOT NULL",
-														'user_id'       => "ALTER TABLE `{$tres_table}` ADD COLUMN user_id BIGINT UNSIGNED NOT NULL",
-														'wins'          => "ALTER TABLE `{$tres_table}` ADD COLUMN wins INT UNSIGNED NOT NULL DEFAULT 0",
+														'user_id'	=> "ALTER TABLE `{$tres_table}` ADD COLUMN user_id BIGINT UNSIGNED NOT NULL",
+														'wins'		=> "ALTER TABLE `{$tres_table}` ADD COLUMN wins INT UNSIGNED NOT NULL DEFAULT 0",
 														'last_win_date' => "ALTER TABLE `{$tres_table}` ADD COLUMN last_win_date DATETIME NULL",
 												);
 												foreach ( $trrneed as $c => $alter ) {
@@ -188,16 +188,16 @@ class BHG_DB {
 																dbDelta( $alter );
 														}
 												}
-                                                                                                if ( ! $this->index_exists( $tres_table, 'tournament_id' ) ) {
-                                                                                                                dbDelta( sprintf( 'ALTER TABLE `%s` ADD KEY tournament_id (tournament_id)', $tres_table ) );
-                                                                                                }
-                                                                                                if ( ! $this->index_exists( $tres_table, 'user_id' ) ) {
-                                                                                                                dbDelta( sprintf( 'ALTER TABLE `%s` ADD KEY user_id (user_id)', $tres_table ) );
-                                                                                                }
+												if ( ! $this->index_exists( $tres_table, 'tournament_id' ) ) {
+														dbDelta( sprintf( 'ALTER TABLE `%s` ADD KEY tournament_id (tournament_id)', $tres_table ) );
+												}
+												if ( ! $this->index_exists( $tres_table, 'user_id' ) ) {
+														dbDelta( sprintf( 'ALTER TABLE `%s` ADD KEY user_id (user_id)', $tres_table ) );
+												}
 
 						// Ads columns
 						$aneed = array(
-							'title'        => "ALTER TABLE `{$ads_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
+							'title'	       => "ALTER TABLE `{$ads_table}` ADD COLUMN title VARCHAR(190) NOT NULL",
 							'content'      => "ALTER TABLE `{$ads_table}` ADD COLUMN content TEXT NULL",
 							'link_url'     => "ALTER TABLE `{$ads_table}` ADD COLUMN link_url VARCHAR(255) NULL",
 							'placement'    => "ALTER TABLE `{$ads_table}` ADD COLUMN placement VARCHAR(50) NOT NULL DEFAULT 'none'",
@@ -215,7 +215,7 @@ class BHG_DB {
 
 						// Translations columns
 						$trneed = array(
-							'tkey'       => "ALTER TABLE `{$trans_table}` ADD COLUMN tkey VARCHAR(190) NOT NULL",
+							'tkey'	     => "ALTER TABLE `{$trans_table}` ADD COLUMN tkey VARCHAR(190) NOT NULL",
 							'tvalue'     => "ALTER TABLE `{$trans_table}` ADD COLUMN tvalue LONGTEXT NULL",
 							'locale'     => "ALTER TABLE `{$trans_table}` ADD COLUMN locale VARCHAR(20) NOT NULL DEFAULT 'en_US'",
 							'created_at' => "ALTER TABLE `{$trans_table}` ADD COLUMN created_at DATETIME NULL",
@@ -227,14 +227,14 @@ class BHG_DB {
 														}
 												}
 												// Ensure unique index
-                                                                                                if ( ! $this->index_exists( $trans_table, 'tkey_locale' ) ) {
-                                                                                                                               dbDelta( sprintf( 'ALTER TABLE `%s` ADD UNIQUE KEY tkey_locale (tkey, locale)', $trans_table ) );
-                                                                                                }
+												if ( ! $this->index_exists( $trans_table, 'tkey_locale' ) ) {
+															       dbDelta( sprintf( 'ALTER TABLE `%s` ADD UNIQUE KEY tkey_locale (tkey, locale)', $trans_table ) );
+												}
 
 						// Affiliates columns / unique index
 						$afneed = array(
-							'name'       => "ALTER TABLE `{$aff_table}` ADD COLUMN name VARCHAR(190) NOT NULL",
-							'url'        => "ALTER TABLE `{$aff_table}` ADD COLUMN url VARCHAR(255) NULL",
+							'name'	     => "ALTER TABLE `{$aff_table}` ADD COLUMN name VARCHAR(190) NOT NULL",
+							'url'	     => "ALTER TABLE `{$aff_table}` ADD COLUMN url VARCHAR(255) NULL",
 							'status'     => "ALTER TABLE `{$aff_table}` ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active'",
 							'created_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN created_at DATETIME NULL",
 							'updated_at' => "ALTER TABLE `{$aff_table}` ADD COLUMN updated_at DATETIME NULL",
@@ -244,45 +244,67 @@ class BHG_DB {
 																				dbDelta( $alter );
 														}
 												}
-                                                                                                if ( ! $this->index_exists( $aff_table, 'name_unique' ) ) {
-                                                                                                                               dbDelta( sprintf( 'ALTER TABLE `%s` ADD UNIQUE KEY name_unique (name)', $aff_table ) );
-                                                                                                }
+												if ( ! $this->index_exists( $aff_table, 'name_unique' ) ) {
+															       dbDelta( sprintf( 'ALTER TABLE `%s` ADD UNIQUE KEY name_unique (name)', $aff_table ) );
+												}
 		} catch ( Throwable $e ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
 				error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
 			}
 		}
+}
+
+	/**
+	 * Get list of allowed plugin tables.
+	 *
+	 * @return array
+	 */
+	private function get_allowed_tables() {
+		global $wpdb;
+		
+		return array(
+		$wpdb->prefix . 'bhg_bonus_hunts',
+		$wpdb->prefix . 'bhg_guesses',
+		$wpdb->prefix . 'bhg_tournaments',
+		$wpdb->prefix . 'bhg_tournament_results',
+		$wpdb->prefix . 'bhg_ads',
+		$wpdb->prefix . 'bhg_translations',
+		$wpdb->prefix . 'bhg_affiliates',
+		);
 	}
 
 	/**
 	 * Check if a column exists, falling back when information_schema is not accessible.
 	 *
-	 * @param string $table  Table name.
+	 * @param string $table	 Table name.
 	 * @param string $column Column to check.
 	 * @return bool
-	 */
+ */
 	private function column_exists( $table, $column ) {
 		global $wpdb;
-
-				$table  = esc_sql( $table );
-				$column = esc_sql( $column );
-
-				$wpdb->last_error = '';
-				$exists           = $wpdb->get_var(
-					$wpdb->prepare(
-						'SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND COLUMN_NAME=%s',
-						DB_NAME,
-						$table,
-						$column
-					)
-				);
-
-				if ( $wpdb->last_error ) {
-												$wpdb->last_error = '';
-												$sql              = sprintf( 'SHOW COLUMNS FROM `%s` LIKE %%s', $table );
-												$exists           = $wpdb->get_var( $wpdb->prepare( $sql, $column ) );
-				}
-
+		
+		$allowed_tables = $this->get_allowed_tables();
+		if ( ! in_array( $table, $allowed_tables, true ) ) {
+		return false;
+		}
+		$column = esc_sql( $column );
+		
+		$wpdb->last_error = '';
+		$exists		  = $wpdb->get_var(
+		$wpdb->prepare(
+		'SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND COLUMN_NAME=%s',
+		DB_NAME,
+		$table,
+		$column
+		)
+		);
+		
+		if ( $wpdb->last_error ) {
+		$wpdb->last_error = '';
+		$sql		  = sprintf( 'SHOW COLUMNS FROM `%s` LIKE %%s', $table );
+		$exists		  = $wpdb->get_var( $wpdb->prepare( $sql, $column ) );
+		}
+		
 		return ! empty( $exists );
 	}
 
@@ -292,29 +314,32 @@ class BHG_DB {
 	 * @param string $table Table name.
 	 * @param string $index Index to check.
 	 * @return bool
-	 */
+ */
 	private function index_exists( $table, $index ) {
 		global $wpdb;
-
-				$table = esc_sql( $table );
-				$index = esc_sql( $index );
-
-				$wpdb->last_error = '';
-				$exists           = $wpdb->get_var(
-					$wpdb->prepare(
-						'SELECT INDEX_NAME FROM information_schema.STATISTICS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND INDEX_NAME=%s',
-						DB_NAME,
-						$table,
-						$index
-					)
-				);
-
-				if ( $wpdb->last_error ) {
-												$wpdb->last_error = '';
-												$sql              = sprintf( 'SHOW INDEX FROM `%s` WHERE Key_name=%%s', $table );
-												$exists           = $wpdb->get_var( $wpdb->prepare( $sql, $index ) );
-				}
-
+		
+		$allowed_tables = $this->get_allowed_tables();
+		if ( ! in_array( $table, $allowed_tables, true ) ) {
+		return false;
+		}
+		$index = esc_sql( $index );
+		
+		$wpdb->last_error = '';
+		$exists		  = $wpdb->get_var(
+		$wpdb->prepare(
+		'SELECT INDEX_NAME FROM information_schema.STATISTICS WHERE TABLE_SCHEMA=%s AND TABLE_NAME=%s AND INDEX_NAME=%s',
+		DB_NAME,
+		$table,
+		$index
+		)
+		);
+		
+		if ( $wpdb->last_error ) {
+		$wpdb->last_error = '';
+		$sql		  = sprintf( 'SHOW INDEX FROM `%s` WHERE Key_name=%%s', $table );
+		$exists		  = $wpdb->get_var( $wpdb->prepare( $sql, $index ) );
+		}
+		
 		return ! empty( $exists );
 	}
 }


### PR DESCRIPTION
## Summary
- Replace esc_sql() usage in admin bonus-hunt view with trusted $wpdb->prefix table name
- Drop esc_sql() for table names in DB class and introduce a whitelist via get_allowed_tables()
- Validate table names in column_exists() and index_exists() using the whitelist

## Testing
- `composer run phpcs -- admin/views/bonus-hunts.php includes/class-bhg-db.php` *(fails: WordPressCS runtime error)*


------
https://chatgpt.com/codex/tasks/task_e_68bbb51b5c54833383b5fa92de91bab2