### PR TITLE
Ensure guesses query selects explicit fields

### DIFF
--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -235,7 +235,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				}
 				$select .= ', tr.wins';
 			}
-			$sql  = $select . $joins . $where . " ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
+                        $sql  = 'SELECT ' . $select . $joins . $where . " ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
 			$rows = $wpdb->get_results( $wpdb->prepare( $sql, $per, $offset ) );
 
 			wp_enqueue_style(


### PR DESCRIPTION
## Summary
- prefix guesses query with the SELECT keyword when listing guesses

## Testing
- `composer phpcs` *(fails: WordPressCS PHPCSHelper::ignore_annotations deprecated issue)*


------
https://chatgpt.com/codex/tasks/task_e_68bbba02b2ec833398121bfeb22f8cd9