### PR TITLE
Use tabs for indentation

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -475,7 +475,7 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
-			   check_admin_referer( 'bhg_save_settings', 'bhg_nonce' );
+		check_admin_referer( 'bhg_save_settings', 'bhg_nonce' );
 		$opts = array(
 			'allow_guess_edit_until_close' => isset( $_POST['allow_guess_edit_until_close'] ) ? 'yes' : 'no',
 			'guesses_max'                  => isset( $_POST['guesses_max'] ) ? max( 1, absint( wp_unslash( $_POST['guesses_max'] ) ) ) : 1,

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -1,87 +1,87 @@
 <?php
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 if ( ! current_user_can( 'manage_options' ) ) {
-    wp_die(
-        __( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' )
-    );
+	wp_die(
+		__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' )
+	);
 }
 
 if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {
-    wp_die(
-        __(
-            'Helper function bhg_get_latest_closed_hunts() missing. Please include class-bhg-bonus-hunts.php helpers.',
-            'bonus-hunt-guesser'
-        )
-    );
+	wp_die(
+		__(
+			'Helper function bhg_get_latest_closed_hunts() missing. Please include class-bhg-bonus-hunts.php helpers.',
+			'bonus-hunt-guesser'
+		)
+	);
 }
 
 $hunts = bhg_get_latest_closed_hunts( 3 );
 ?>
 
 <div class="wrap bhg-wrap bhg-admin">
-    <h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
-    <div class="bhg-dashboard-grid">
-        <?php if ( $hunts ) : ?>
-            <?php foreach ( $hunts as $h ) : ?>
-                <?php
-                $winners = function_exists( 'bhg_get_top_winners_for_hunt' )
-                    ? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
-                    : array();
-                ?>
-                <div class="bhg-hunt-card">
-                    <h2 class="bhg-hunt-title">
-                        <span class="dashicons dashicons-calendar-alt bhg-icon" aria-hidden="true"></span>
-                        <?php echo esc_html( $h->title ); ?>
-                    </h2>
-                    <ul class="bhg-winners">
-                        <?php if ( $winners ) : ?>
-                            <?php foreach ( $winners as $i => $w ) : ?>
-                                <?php
-                                $u  = get_userdata( (int) $w->user_id );
-                                $nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
-                                ?>
-                                <li class="bhg-winner winner-<?php echo (int) $i + 1; ?>">
-                                    <span class="dashicons dashicons-awards bhg-icon" aria-hidden="true"></span>
-                                    <?php echo esc_html( $nm ); ?>
-                                    <?php esc_html_e( '—', 'bonus-hunt-guesser' ); ?>
-                                    <?php echo esc_html( number_format_i18n( (float) $w->guess, 2 ) ); ?>
-                                    <span class="bhg-diff">
-                                        (<?php esc_html_e( 'diff', 'bonus-hunt-guesser' ); ?>
-                                        <?php echo esc_html( number_format_i18n( (float) $w->diff, 2 ) ); ?>)
-                                    </span>
-                                </li>
-                            <?php endforeach; ?>
-                        <?php else : ?>
-                            <li class="bhg-winner none">
-                                <span class="dashicons dashicons-dismiss bhg-icon" aria-hidden="true"></span>
-                                <?php esc_html_e( 'No winners yet', 'bonus-hunt-guesser' ); ?>
-                            </li>
-                        <?php endif; ?>
-                    </ul>
-                    <div class="bhg-balance bhg-start">
-                        <span class="dashicons dashicons-money-alt bhg-icon" aria-hidden="true"></span>
-                        <?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?>:
-                        <?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?>
-                    </div>
-                    <div class="bhg-balance bhg-final">
-                        <span class="dashicons dashicons-chart-bar bhg-icon" aria-hidden="true"></span>
-                        <?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?>:
-                        <?php echo ( null !== $h->final_balance ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?>
-                    </div>
-                    <div class="bhg-closed">
-                        <span class="dashicons dashicons-clock bhg-icon" aria-hidden="true"></span>
-                        <?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?>:
-                        <?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?>
-                    </div>
-                </div>
-            <?php endforeach; ?>
-        <?php else : ?>
-            <p><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></p>
-        <?php endif; ?>
-    </div>
+	<h1><?php esc_html_e( 'Latest Hunts', 'bonus-hunt-guesser' ); ?></h1>
+	<div class="bhg-dashboard-grid">
+		<?php if ( $hunts ) : ?>
+			<?php foreach ( $hunts as $h ) : ?>
+				<?php
+				$winners = function_exists( 'bhg_get_top_winners_for_hunt' )
+					? bhg_get_top_winners_for_hunt( $h->id, (int) $h->winners_count )
+					: array();
+				?>
+				<div class="bhg-hunt-card">
+					<h2 class="bhg-hunt-title">
+						<span class="dashicons dashicons-calendar-alt bhg-icon" aria-hidden="true"></span>
+						<?php echo esc_html( $h->title ); ?>
+					</h2>
+					<ul class="bhg-winners">
+						<?php if ( $winners ) : ?>
+							<?php foreach ( $winners as $i => $w ) : ?>
+								<?php
+								$u  = get_userdata( (int) $w->user_id );
+								$nm = $u ? $u->user_login : sprintf( __( 'User #%d', 'bonus-hunt-guesser' ), (int) $w->user_id );
+								?>
+								<li class="bhg-winner winner-<?php echo (int) $i + 1; ?>">
+									<span class="dashicons dashicons-awards bhg-icon" aria-hidden="true"></span>
+									<?php echo esc_html( $nm ); ?>
+									<?php esc_html_e( '—', 'bonus-hunt-guesser' ); ?>
+									<?php echo esc_html( number_format_i18n( (float) $w->guess, 2 ) ); ?>
+									<span class="bhg-diff">
+										(<?php esc_html_e( 'diff', 'bonus-hunt-guesser' ); ?>
+										<?php echo esc_html( number_format_i18n( (float) $w->diff, 2 ) ); ?>)
+									</span>
+								</li>
+							<?php endforeach; ?>
+						<?php else : ?>
+							<li class="bhg-winner none">
+								<span class="dashicons dashicons-dismiss bhg-icon" aria-hidden="true"></span>
+								<?php esc_html_e( 'No winners yet', 'bonus-hunt-guesser' ); ?>
+							</li>
+						<?php endif; ?>
+					</ul>
+					<div class="bhg-balance bhg-start">
+						<span class="dashicons dashicons-money-alt bhg-icon" aria-hidden="true"></span>
+						<?php esc_html_e( 'Start Balance', 'bonus-hunt-guesser' ); ?>:
+						<?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?>
+					</div>
+					<div class="bhg-balance bhg-final">
+						<span class="dashicons dashicons-chart-bar bhg-icon" aria-hidden="true"></span>
+						<?php esc_html_e( 'Final Balance', 'bonus-hunt-guesser' ); ?>:
+						<?php echo ( null !== $h->final_balance ) ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?>
+					</div>
+					<div class="bhg-closed">
+						<span class="dashicons dashicons-clock bhg-icon" aria-hidden="true"></span>
+						<?php esc_html_e( 'Closed At', 'bonus-hunt-guesser' ); ?>:
+						<?php echo $h->closed_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $h->closed_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?>
+					</div>
+				</div>
+			<?php endforeach; ?>
+		<?php else : ?>
+			<p><?php esc_html_e( 'No closed hunts yet.', 'bonus-hunt-guesser' ); ?></p>
+		<?php endif; ?>
+	</div>
 </div>
 

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -53,7 +53,7 @@ if ( ! empty( $error ) ) {
 	
 	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 		<input type="hidden" name="action" value="bhg_save_settings">
-               <?php wp_nonce_field( 'bhg_save_settings', 'bhg_nonce' ); ?>
+			<?php wp_nonce_field( 'bhg_save_settings', 'bhg_nonce' ); ?>
 
 		<table class="form-table">
 			<tr>

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -235,7 +235,7 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 				}
 				$select .= ', tr.wins';
 			}
-                        $sql  = 'SELECT ' . $select . $joins . $where . " ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
+						$sql  = 'SELECT ' . $select . $joins . $where . " ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
 			$rows = $wpdb->get_results( $wpdb->prepare( $sql, $per, $offset ) );
 
 			wp_enqueue_style(


### PR DESCRIPTION
## Summary
- replace leading spaces with tabs in admin and shortcode PHP files
- normalize dashboard and settings templates to WordPress tab-based indentation
- enforce tab indentation when checking settings save routine

## Testing
- `./vendor/bin/phpcs admin/class-bhg-admin.php` *(fails: WordPressCS\WordPress\PHPCSHelper::ignore_annotations(): Implicitly marking parameter $phpcsFile as nullable is deprecated, the explicit nullable type must be used)*
- `./vendor/bin/phpcs includes/class-bhg-shortcodes.php` *(fails: WordPressCS\WordPress\PHPCSHelper::ignore_annotations(): Implicitly marking parameter $phpcsFile as nullable is deprecated, the explicit nullable type must be used)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbb9102a483339c6fe9d156baab0f