### PR TITLE
Seed default translations dynamically

### DIFF
--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -16,9 +16,8 @@ if ( ! current_user_can( 'manage_options' ) ) {
 global $wpdb;
 $table = $wpdb->prefix . 'bhg_translations';
 
-if ( function_exists( 'bhg_seed_default_translations_if_empty' ) ) {
-	bhg_seed_default_translations_if_empty();
-}
+// Ensure default translations are present for listing.
+bhg_seed_default_translations_if_empty();
 
 $default_translations = function_exists( 'bhg_get_default_translations' ) ? bhg_get_default_translations() : array();
 $default_keys         = array_keys( $default_translations );


### PR DESCRIPTION
## Summary
- Auto-collect shortcode and admin strings for translation defaults
- Insert missing translation defaults without overwriting existing values
- Ensure translation admin view always seeds defaults for display

## Testing
- `composer install`
- `composer run phpcs` *(fails: trim(): Passing null to parameter #1 ($string) of type string is deprecated in wpcs/WordPress/Sniffs/WP/I18nSniff.php)*
- `vendor/bin/phpcs includes/helpers.php admin/views/translations.php` *(fails: trim(): Passing null to parameter #1 ($string) of type string is deprecated in wpcs/WordPress/Sniffs/WP/I18nSniff.php)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfbc630d88333bb6929f054136616