### PR TITLE
refactor: replace short ternary operators

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -192,7 +192,7 @@ class BHG_Admin {
 		if ( $guess_id ) {
 			$wpdb->delete( $guesses_table, array( 'id' => $guess_id ), array( '%d' ) );
 		}
-		wp_safe_redirect( wp_get_referer() ?: admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+                wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -291,7 +291,7 @@ class BHG_Admin {
 					);
 					wp_mail(
 						$u->user_email,
-						sprintf( __( 'Results for %s', 'bonus-hunt-guesser' ), $hunt_title ?: 'Bonus Hunt' ),
+                                                sprintf( __( 'Results for %s', 'bonus-hunt-guesser' ), $hunt_title ? $hunt_title : 'Bonus Hunt' ),
 						$body
 					);
 				}

--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -69,7 +69,7 @@ $base     = remove_query_arg( 'ppaged' );
 				</tr>
 				<tr>
 					<th scope="row"><label for="bhg_winners"><?php echo esc_html__( 'Number of Winners', 'bonus-hunt-guesser' ); ?></label></th>
-					<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ?: 3 ); ?>"></td>
+                                    <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ? $hunt->winners_count : 3 ); ?>"></td>
 				</tr>
 				<tr>
 					<th scope="row"><label for="bhg_final"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -521,7 +521,7 @@ function bhg_handle_submit_guess() {
 				if ( wp_doing_ajax() ) {
 					wp_send_json_success();
 				}
-				wp_safe_redirect( wp_get_referer() ?: home_url() );
+                                wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
 				exit;
 			}
 		}
@@ -547,7 +547,7 @@ function bhg_handle_submit_guess() {
 		wp_send_json_success();
 	}
 
-	wp_safe_redirect( wp_get_referer() ?: home_url() );
+        wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
 	exit;
 }
 

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
 		if ( ! $hunt || $hunt->final_balance === null ) {
 			return array();
 		}
-		$limit = $winners_limit ?: (int) $hunt->winners_count ?: 3;
+            $limit = $winners_limit ? $winners_limit : ( (int) $hunt->winners_count ? (int) $hunt->winners_count : 3 );
 
 		$sql = $wpdb->prepare(
 			"SELECT g.user_id, g.guess, ABS(g.guess - %f) AS diff

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -706,8 +706,8 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					echo '<tr>';
 					echo '<td>' . (int) $pos++ . '</td>';
 					echo '<td>' . esc_html(
-						$row->user_login ?: sprintf(
-										/* translators: %d: user ID. */
+                                            $row->user_login ? $row->user_login : sprintf(
+                                                    /* translators: %d: user ID. */
 							__( 'user#%d', 'bonus-hunt-guesser' ),
 							(int) $row->user_id
 						)

--- a/includes/db.php
+++ b/includes/db.php
@@ -77,14 +77,14 @@ add_action('wp_footer', function(){
     $table = $wpdb->prefix . 'bhg_advertisements';
     if ($wpdb->get_results("SELECT * FROM `" . $hunt_id . "`");
     if(!$hunt || !$hunt->is_active){
-        wp_safe_redirect( add_query_arg('bhg_msg','closed', wp_get_referer() ?: home_url('/')) );
+        wp_safe_redirect( add_query_arg('bhg_msg','closed', wp_get_referer() ? wp_get_referer() : home_url('/')) );
         exit;
     }
     $allow_edit = get_option('bhg_allow_guess_alteration','1') === '1';
     $exists = $wpdb->get_results("SELECT * FROM `" . $user_id . "`");
     if($exists){
         if(!$allow_edit){
-            wp_safe_redirect( add_query_arg('bhg_msg','noedit', wp_get_referer() ?: home_url('/')) );
+            wp_safe_redirect( add_query_arg('bhg_msg','noedit', wp_get_referer() ? wp_get_referer() : home_url('/')) );
             exit;
         }
         $wpdb->update($guesses, array(
@@ -99,7 +99,7 @@ add_action('wp_footer', function(){
             'created_at' => current_time('mysql')
         ));
     }
-    wp_safe_redirect( add_query_arg('bhg_msg','saved', wp_get_referer() ?: home_url('/')) );
+    wp_safe_redirect( add_query_arg('bhg_msg','saved', wp_get_referer() ? wp_get_referer() : home_url('/')) );
     exit;
 }
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -357,7 +357,7 @@ function bhg_get_user_display_name( $user_id ) {
 		return __( 'Unknown User', 'bonus-hunt-guesser' );
 	}
 
-	$display_name = $user->display_name ?: $user->user_login;
+    $display_name = $user->display_name ? $user->display_name : $user->user_login;
 	$is_affiliate = bhg_is_user_affiliate( $user_id );
 
 	if ( $is_affiliate ) {
@@ -479,7 +479,7 @@ function bhg_render_ads( $placement = 'footer', $hunt_id = 0 ) {
 
 	$out = '<div class="bhg-ads bhg-ads-' . esc_attr( $placement ) . '">';
 	foreach ( $rows as $r ) {
-		$vis  = $r->visible_to ?: 'all';
+        $vis  = $r->visible_to ? $r->visible_to : 'all';
 		$show = false;
 		if ( $vis === 'all' ) {
 			$show = true;

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -22,7 +22,7 @@ add_shortcode(
 		// Basic profile
 		ob_start(); ?>
 	<div class="bhg-box">
-		<h3><?php echo esc_html( $u->display_name ?: $u->user_login ); ?></h3>
+                <h3><?php echo esc_html( $u->display_name ? $u->display_name : $u->user_login ); ?></h3>
 		<p><?php echo esc_html( $u->user_email ); ?></p>
 		<?php
 		if ( function_exists( 'bhg_get_affiliate_sites' ) ) :
@@ -59,7 +59,7 @@ add_shortcode(
 			<h4><?php esc_html_e( 'Your Hunts', 'bonus-hunt-guesser' ); ?></h4>
 			<ul class="bhg-list">
 			<?php foreach ( $rows as $r ) : ?>
-				<li><?php echo esc_html( $r->title ?: ( '#' . $r->id ) ); ?> — <?php echo esc_html( ucfirst( $r->status ) ); ?></li>
+                                <li><?php echo esc_html( $r->title ? $r->title : ( '#' . $r->id ) ); ?> — <?php echo esc_html( ucfirst( $r->status ) ); ?></li>
 			<?php endforeach; ?>
 			</ul>
 		<?php endif; ?>
@@ -100,7 +100,7 @@ add_shortcode(
 		<?php if ( $rows ) : ?>
 			<ul class="bhg-list">
 				<?php foreach ( $rows as $r ) : ?>
-					<li><?php echo esc_html( $r->title ?: ( '#' . $r->id ) ); ?></li>
+                                        <li><?php echo esc_html( $r->title ? $r->title : ( '#' . $r->id ) ); ?></li>
 				<?php endforeach; ?>
 			</ul>
 		<?php else : ?>
@@ -153,9 +153,9 @@ add_shortcode(
 				<tbody>
 					<?php foreach ( $rows as $r ) : ?>
 						<tr>
-							<td><?php echo esc_html( $r->hunt_title ?: ( '#' . $r->hunt_id ) ); ?></td>
+                                                        <td><?php echo esc_html( $r->hunt_title ? $r->hunt_title : ( '#' . $r->hunt_id ) ); ?></td>
 							<td><?php echo esc_html( number_format_i18n( $r->guess, 2 ) ); ?></td>
-							<td><?php echo esc_html( ucfirst( $r->hunt_status ?: 'open' ) ); ?></td>
+                                                        <td><?php echo esc_html( ucfirst( $r->hunt_status ? $r->hunt_status : 'open' ) ); ?></td>
 							<td><?php echo esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ); ?></td>
 						</tr>
 					<?php endforeach; ?>
@@ -224,10 +224,10 @@ add_shortcode(
 				$u = isset( $r->user_id ) && $r->user_id ? get_userdata( $r->user_id ) : null;
 				?>
 				<li>
-					<strong><?php echo esc_html( $r->title ?: ( '#' . $r->hunt_id ) ); ?></strong>
+                                        <strong><?php echo esc_html( $r->title ? $r->title : ( '#' . $r->hunt_id ) ); ?></strong>
 					
 					<?php if ( $u ) : ?>
-						— <?php echo esc_html( $u->display_name ?: $u->user_login ); ?>
+                                                — <?php echo esc_html( $u->display_name ? $u->display_name : $u->user_login ); ?>
 						<?php if ( ! empty( $r->position ) ) : ?>
 							(<?php echo intval( $r->position ); ?>)
 						<?php endif; ?>


### PR DESCRIPTION
## Summary
- refactor: replace short ternary operators with explicit ternaries

## Testing
- `composer run phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*
- `vendor/bin/phpcs --standard=phpcs.xml --sniffs=Universal.Operators.DisallowShortTernary`

------
https://chatgpt.com/codex/tasks/task_e_68bc0ae6e15883338f440d31137378f2