### PR TITLE
Sanitize admin GET parameters

### DIFF
--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -66,11 +66,11 @@ class BHG_Users_Table extends WP_List_Table {
 	}
 
 	public function prepare_items() {
-		$paged     = isset( $_GET['paged'] ) ? max( 1, absint( wp_unslash( $_GET['paged'] ) ) ) : 1;
-		$orderby   = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'username';
-		$order_raw = isset( $_GET['order'] ) ? sanitize_key( wp_unslash( $_GET['order'] ) ) : '';
-		$order     = in_array( $order_raw, array( 'asc', 'desc' ), true ) ? strtoupper( $order_raw ) : 'ASC';
-		$search    = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+               $paged     = max( 1, absint( wp_unslash( $_GET['paged'] ?? '' ) ) );
+               $orderby   = sanitize_key( wp_unslash( $_GET['orderby'] ?? 'username' ) );
+               $order_raw = sanitize_key( wp_unslash( $_GET['order'] ?? '' ) );
+               $order     = in_array( $order_raw, array( 'asc', 'desc' ), true ) ? strtoupper( $order_raw ) : 'ASC';
+               $search    = sanitize_text_field( wp_unslash( $_GET['s'] ?? '' ) );
 
 		// Whitelist orderby
 		$allowed = array( 'username', 'email', 'role', 'guesses', 'wins' );

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -8,7 +8,7 @@ global $wpdb;
 $table = $wpdb->prefix . 'bhg_affiliates';
 
 // Load for edit
-$edit_id = isset( $_GET['edit'] ) ? (int) $_GET['edit'] : 0;
+$edit_id = absint( wp_unslash( $_GET['edit'] ?? '' ) );
 $row     = $edit_id ? $wpdb->get_row( $wpdb->prepare( "SELECT id, name, url, status FROM `$table` WHERE id=%d", $edit_id ) ) : null;
 
 // List

--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -7,7 +7,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 
 global $wpdb;
 
-$id   = isset( $_GET['id'] ) ? (int) wp_unslash( $_GET['id'] ) : 0;
+$id   = absint( wp_unslash( $_GET['id'] ?? '' ) );
 $hunt = bhg_get_hunt( $id );
 if ( ! $hunt ) {
 		echo '<div class="notice notice-error"><p>' . esc_html__( 'Invalid hunt', 'bonus-hunt-guesser' ) . '</p></div>';
@@ -22,7 +22,7 @@ $aff_table = esc_sql( $aff_table );
 $affs      = $wpdb->get_results( "SELECT id, name FROM {$aff_table} ORDER BY name ASC" );
 $sel       = isset( $hunt->affiliate_site_id ) ? (int) $hunt->affiliate_site_id : 0;
 
-$paged    = max( 1, isset( $_GET['ppaged'] ) ? (int) wp_unslash( $_GET['ppaged'] ) : 1 );
+$paged    = max( 1, absint( wp_unslash( $_GET['ppaged'] ?? '' ) ) );
 $per_page = 30;
 $data     = bhg_get_hunt_participants( $id, $paged, $per_page );
 $rows     = $data['rows'];

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -5,7 +5,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'Insufficient permissions', 'bonus-hunt-guesser' ) );
 }
 global $wpdb;
-$hunt_id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
+$hunt_id = absint( wp_unslash( $_GET['id'] ?? '' ) );
 $hunts   = $wpdb->prefix . 'bhg_bonus_hunts';
 $guesses = $wpdb->prefix . 'bhg_guesses';
 $hunt    = $wpdb->get_row( $wpdb->prepare( "SELECT id, title, final_balance, winners_count FROM `$hunts` WHERE id=%d", $hunt_id ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query.

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -32,7 +32,7 @@ if ( 'edit' === $view ) {
 
 /** LIST VIEW */
 if ( 'list' === $view ) :
-		$current_page = max( 1, isset( $_GET['paged'] ) ? (int) wp_unslash( $_GET['paged'] ) : 1 );
+                $current_page = max( 1, absint( wp_unslash( $_GET['paged'] ?? '' ) ) );
 		$per_page     = 30;
 		$offset       = ( $current_page - 1 ) * $per_page;
 

--- a/admin/views/demo-tools.php
+++ b/admin/views/demo-tools.php
@@ -15,7 +15,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 
 $notice = '';
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-if ( isset( $_GET['demo_reset'] ) && 1 === absint( $_GET['demo_reset'] ) ) {
+if ( 1 === absint( wp_unslash( $_GET['demo_reset'] ?? '' ) ) ) {
 	$notice = __( 'Demo data reseeded.', 'bonus-hunt-guesser' );
 }
 ?>

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -112,7 +112,7 @@ $affiliate_sites = $bhg_db->get_affiliate_websites();
 
 // Display status messages
 if ( isset( $_GET['message'] ) ) {
-	$message_type = sanitize_text_field( $_GET['message'] );
+        $message_type = sanitize_text_field( wp_unslash( $_GET['message'] ) );
 	switch ( $message_type ) {
 		case 'success':
 			echo '<div class="notice notice-success is-dismissible"><p>' .

--- a/admin/views/hunt-results.php
+++ b/admin/views/hunt-results.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( __( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) ); }
 
-$hunt_id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
+$hunt_id = absint( wp_unslash( $_GET['id'] ?? '' ) );
 if ( ! $hunt_id ) {
 	wp_die( __( 'Missing hunt id', 'bonus-hunt-guesser' ) ); }
 

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) ); }
 
-$hunt_id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
+$hunt_id = absint( wp_unslash( $_GET['id'] ?? '' ) );
 if ( ! $hunt_id ) {
 	wp_die( esc_html__( 'Missing hunt id', 'bonus-hunt-guesser' ) ); }
 
@@ -27,7 +27,7 @@ $hunt = bhg_get_hunt( $hunt_id );
 if ( ! $hunt ) {
 	wp_die( esc_html__( 'Hunt not found', 'bonus-hunt-guesser' ) ); }
 
-$paged    = max( 1, isset( $_GET['ppaged'] ) ? (int) $_GET['ppaged'] : 1 );
+$paged    = max( 1, absint( wp_unslash( $_GET['ppaged'] ?? '' ) ) );
 $per_page = 30;
 $data     = bhg_get_hunt_participants( $hunt_id, $paged, $per_page );
 $rows     = $data['rows'];

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -7,7 +7,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 global $wpdb;
 $t = $wpdb->prefix . 'bhg_hunts';
 
-$paged    = max( 1, isset( $_GET['paged'] ) ? absint( wp_unslash( $_GET['paged'] ) ) : 1 );
+$paged    = max( 1, absint( wp_unslash( $_GET['paged'] ?? '' ) ) );
 $per_page = 20;
 $offset   = ( $paged - 1 ) * $per_page;
 

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -12,7 +12,7 @@ if ( ! in_array( $table, $allowed_tables, true ) ) {
 }
 $table = esc_sql( $table );
 
-$edit_id = isset( $_GET['edit'] ) ? (int) wp_unslash( $_GET['edit'] ) : 0;
+$edit_id = absint( wp_unslash( $_GET['edit'] ?? '' ) );
 $row     = $edit_id
 		? $wpdb->get_row( $wpdb->prepare( "SELECT id, title, description, type, start_date, end_date, status FROM {$table} WHERE id = %d", $edit_id ) )
 		: null;

--- a/admin/views/users.php
+++ b/admin/views/users.php
@@ -5,7 +5,7 @@ if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
-$paged           = max( 1, isset( $_GET['paged'] ) ? (int) $_GET['paged'] : 1 );
+$paged           = max( 1, absint( wp_unslash( $_GET['paged'] ?? '' ) ) );
 $per_page        = 30;
 $search          = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
 $allowed_orderby = array( 'user_login', 'display_name', 'user_email' );


### PR DESCRIPTION
## Summary
- Wrap all admin view `$_GET` references with `wp_unslash()` and sanitize using `absint`, `sanitize_key`, or `sanitize_text_field`
- Update pagination and ID handling across admin pages to prevent unsanitized input

## Testing
- `composer install`
- `composer phpcs` *(fails: numerous pre-existing coding standard violations across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0c73f4c08333a85d35645dd0ba50