### PR TITLE
Remove leading whitespace before PHP tag

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -1,4 +1,4 @@
-		<?php
+<?php
 /**
  * Plugin Name: Bonus Hunt Guesser
  * Plugin URI: https://yourdomain.com/


### PR DESCRIPTION
## Summary
- ensure main plugin file begins directly with the PHP tag

## Testing
- `composer install`
- `./vendor/bin/phpcs bonus-hunt-guesser.php` *(fails: 96 errors, 23 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1410bd7c833399d71dda6d40bdec