### PR TITLE
Use tabs for indentation in plugin PHP files

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -192,7 +192,7 @@ class BHG_Admin {
 		if ( $guess_id ) {
 			$wpdb->delete( $guesses_table, array( 'id' => $guess_id ), array( '%d' ) );
 		}
-                wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+				wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
 	}
 
@@ -291,7 +291,7 @@ class BHG_Admin {
 					);
 					wp_mail(
 						$u->user_email,
-                                                sprintf( __( 'Results for %s', 'bonus-hunt-guesser' ), $hunt_title ? $hunt_title : 'Bonus Hunt' ),
+												sprintf( __( 'Results for %s', 'bonus-hunt-guesser' ), $hunt_title ? $hunt_title : 'Bonus Hunt' ),
 						$body
 					);
 				}

--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -66,11 +66,11 @@ class BHG_Users_Table extends WP_List_Table {
 	}
 
 	public function prepare_items() {
-               $paged     = max( 1, absint( wp_unslash( $_GET['paged'] ?? '' ) ) );
-               $orderby   = sanitize_key( wp_unslash( $_GET['orderby'] ?? 'username' ) );
-               $order_raw = sanitize_key( wp_unslash( $_GET['order'] ?? '' ) );
-               $order     = in_array( $order_raw, array( 'asc', 'desc' ), true ) ? strtoupper( $order_raw ) : 'ASC';
-               $search    = sanitize_text_field( wp_unslash( $_GET['s'] ?? '' ) );
+			   $paged     = max( 1, absint( wp_unslash( $_GET['paged'] ?? '' ) ) );
+			   $orderby   = sanitize_key( wp_unslash( $_GET['orderby'] ?? 'username' ) );
+			   $order_raw = sanitize_key( wp_unslash( $_GET['order'] ?? '' ) );
+			   $order     = in_array( $order_raw, array( 'asc', 'desc' ), true ) ? strtoupper( $order_raw ) : 'ASC';
+			   $search    = sanitize_text_field( wp_unslash( $_GET['s'] ?? '' ) );
 
 		// Whitelist orderby
 		$allowed = array( 'username', 'email', 'role', 'guesses', 'wins' );

--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -69,7 +69,7 @@ $base     = remove_query_arg( 'ppaged' );
 				</tr>
 				<tr>
 					<th scope="row"><label for="bhg_winners"><?php echo esc_html__( 'Number of Winners', 'bonus-hunt-guesser' ); ?></label></th>
-                                    <td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ? $hunt->winners_count : 3 ); ?>"></td>
+									<td><input type="number" min="1" max="25" id="bhg_winners" name="winners_count" value="<?php echo esc_attr( $hunt->winners_count ? $hunt->winners_count : 3 ); ?>"></td>
 				</tr>
 				<tr>
 					<th scope="row"><label for="bhg_final"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -13,11 +13,11 @@ if ( ! $hunt ) {
 	echo '<div class="wrap"><h1>' . esc_html__( 'Hunt not found', 'bonus-hunt-guesser' ) . '</h1></div>';
 	return; }
 $rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query.
-        $wpdb->prepare(
-                "SELECT g.id, g.user_id, g.guess, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
-                (float) $hunt->final_balance,
-                $hunt_id
-        )
+		$wpdb->prepare(
+				"SELECT g.id, g.user_id, g.guess, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC",
+				(float) $hunt->final_balance,
+				$hunt_id
+		)
 );
 ?>
 <div class="wrap">

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -32,7 +32,7 @@ if ( 'edit' === $view ) {
 
 /** LIST VIEW */
 if ( 'list' === $view ) :
-                $current_page = max( 1, absint( wp_unslash( $_GET['paged'] ?? '' ) ) );
+				$current_page = max( 1, absint( wp_unslash( $_GET['paged'] ?? '' ) ) );
 		$per_page     = 30;
 		$offset       = ( $current_page - 1 ) * $per_page;
 

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -112,7 +112,7 @@ $affiliate_sites = $bhg_db->get_affiliate_websites();
 
 // Display status messages
 if ( isset( $_GET['message'] ) ) {
-        $message_type = sanitize_text_field( wp_unslash( $_GET['message'] ) );
+		$message_type = sanitize_text_field( wp_unslash( $_GET['message'] ) );
 	switch ( $message_type ) {
 		case 'success':
 			echo '<div class="notice notice-success is-dismissible"><p>' .

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -521,7 +521,7 @@ function bhg_handle_submit_guess() {
 				if ( wp_doing_ajax() ) {
 					wp_send_json_success();
 				}
-                                wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
+								wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
 				exit;
 			}
 		}
@@ -547,7 +547,7 @@ function bhg_handle_submit_guess() {
 		wp_send_json_success();
 	}
 
-        wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
+		wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
 	exit;
 }
 

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
 		if ( ! $hunt || $hunt->final_balance === null ) {
 			return array();
 		}
-            $limit = $winners_limit ? $winners_limit : ( (int) $hunt->winners_count ? (int) $hunt->winners_count : 3 );
+			$limit = $winners_limit ? $winners_limit : ( (int) $hunt->winners_count ? (int) $hunt->winners_count : 3 );
 
 		$sql = $wpdb->prepare(
 			"SELECT g.user_id, g.guess, ABS(g.guess - %f) AS diff

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -706,8 +706,8 @@ if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 					echo '<tr>';
 					echo '<td>' . (int) $pos++ . '</td>';
 					echo '<td>' . esc_html(
-                                            $row->user_login ? $row->user_login : sprintf(
-                                                    /* translators: %d: user ID. */
+											$row->user_login ? $row->user_login : sprintf(
+													/* translators: %d: user ID. */
 							__( 'user#%d', 'bonus-hunt-guesser' ),
 							(int) $row->user_id
 						)

--- a/includes/db.php
+++ b/includes/db.php
@@ -4,131 +4,131 @@
 if (!defined('ABSPATH')) { exit; }
 
 function bhg_install_tables() {
-    global $wpdb;
-    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-    $charset_collate = $wpdb->has_cap('collation') ? $wpdb->get_charset_collate() : 'DEFAULT CHARSET=utf8';
+	global $wpdb;
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	$charset_collate = $wpdb->has_cap('collation') ? $wpdb->get_charset_collate() : 'DEFAULT CHARSET=utf8';
 
-    $hunts = $wpdb->prefix . 'bhg_bonus_hunts';
-    $guesses = $wpdb->prefix . 'bhg_guesses';
-    $aff = $wpdb->prefix . 'bhg_affiliate_websites';
-    $tournaments = $wpdb->prefix . 'bhg_tournaments';
-    $ads = $wpdb->prefix . 'bhg_advertisements';
+	$hunts = $wpdb->prefix . 'bhg_bonus_hunts';
+	$guesses = $wpdb->prefix . 'bhg_guesses';
+	$aff = $wpdb->prefix . 'bhg_affiliate_websites';
+	$tournaments = $wpdb->prefix . 'bhg_tournaments';
+	$ads = $wpdb->prefix . 'bhg_advertisements';
 
-    $sql = array();
+	$sql = array();
 
-    $sql[] = "CREATE TABLE {$hunts} (
-        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-        title varchar(255) NOT NULL,
-        starting_balance decimal(12,2) NOT NULL DEFAULT 0.00,
-        num_bonuses int(11) NOT NULL DEFAULT 0,
-        prizes text NULL,
-        affiliate_site_id bigint(20) unsigned NULL,
-        is_active tinyint(1) NOT NULL DEFAULT 1,
-        final_balance decimal(12,2) NULL,
-        created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        PRIMARY KEY  (id)
-    ) ENGINE=InnoDB {$charset_collate};";
+	$sql[] = "CREATE TABLE {$hunts} (
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		title varchar(255) NOT NULL,
+		starting_balance decimal(12,2) NOT NULL DEFAULT 0.00,
+		num_bonuses int(11) NOT NULL DEFAULT 0,
+		prizes text NULL,
+		affiliate_site_id bigint(20) unsigned NULL,
+		is_active tinyint(1) NOT NULL DEFAULT 1,
+		final_balance decimal(12,2) NULL,
+		created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY  (id)
+	) ENGINE=InnoDB {$charset_collate};";
 
-    $sql[] = "CREATE TABLE {$guesses} (
-        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-        user_id bigint(20) unsigned NOT NULL,
-        hunt_id bigint(20) unsigned NOT NULL,
-        guess_value decimal(12,2) NOT NULL,
-        created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        updated_at datetime NULL,
-        UNIQUE KEY unique_user_hunt (user_id, hunt_id),
-        PRIMARY KEY (id)
-    ) ENGINE=InnoDB {$charset_collate};";
+	$sql[] = "CREATE TABLE {$guesses} (
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		user_id bigint(20) unsigned NOT NULL,
+		hunt_id bigint(20) unsigned NOT NULL,
+		guess_value decimal(12,2) NOT NULL,
+		created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at datetime NULL,
+		UNIQUE KEY unique_user_hunt (user_id, hunt_id),
+		PRIMARY KEY (id)
+	) ENGINE=InnoDB {$charset_collate};";
 
-    $sql[] = "CREATE TABLE {$aff} (
-        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-        name varchar(190) NOT NULL,
-        slug varchar(190) NOT NULL,
-        url varchar(255) NULL,
-        PRIMARY KEY (id),
-        UNIQUE KEY slug (slug)
-    ) ENGINE=InnoDB {$charset_collate};";
+	$sql[] = "CREATE TABLE {$aff} (
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		name varchar(190) NOT NULL,
+		slug varchar(190) NOT NULL,
+		url varchar(255) NULL,
+		PRIMARY KEY (id),
+		UNIQUE KEY slug (slug)
+	) ENGINE=InnoDB {$charset_collate};";
 
-    $sql[] = "CREATE TABLE {$tournaments} (
-        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-        title varchar(190) NOT NULL,
-        type varchar(20) NOT NULL,
-        from_date date NOT NULL,
-        to_date date NOT NULL,
-        PRIMARY KEY (id)
-    ) ENGINE=InnoDB {$charset_collate};";
+	$sql[] = "CREATE TABLE {$tournaments} (
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		title varchar(190) NOT NULL,
+		type varchar(20) NOT NULL,
+		from_date date NOT NULL,
+		to_date date NOT NULL,
+		PRIMARY KEY (id)
+	) ENGINE=InnoDB {$charset_collate};";
 
-    $sql[] = "CREATE TABLE {$ads} (
-        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-        message text NOT NULL,
-        link varchar(255) NULL,
-        placement varchar(50) NOT NULL DEFAULT 'footer',
-        visibility varchar(50) NOT NULL DEFAULT 'all',
-        PRIMARY KEY (id)
-    ) ENGINE=InnoDB {$charset_collate};";
+	$sql[] = "CREATE TABLE {$ads} (
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+		message text NOT NULL,
+		link varchar(255) NULL,
+		placement varchar(50) NOT NULL DEFAULT 'footer',
+		visibility varchar(50) NOT NULL DEFAULT 'all',
+		PRIMARY KEY (id)
+	) ENGINE=InnoDB {$charset_collate};";
 
-    foreach ($sql as $q) { dbDelta($q); }
+	foreach ($sql as $q) { dbDelta($q); }
 }
 
 // Advertisement renderer
 add_action('wp_footer', function(){
-    if (is_admin()) return;
-    global $wpdb;
-    $table = $wpdb->prefix . 'bhg_advertisements';
-    if ($wpdb->get_results("SELECT * FROM `" . $hunt_id . "`");
-    if(!$hunt || !$hunt->is_active){
-        wp_safe_redirect( add_query_arg('bhg_msg','closed', wp_get_referer() ? wp_get_referer() : home_url('/')) );
-        exit;
-    }
-    $allow_edit = get_option('bhg_allow_guess_alteration','1') === '1';
-    $exists = $wpdb->get_results("SELECT * FROM `" . $user_id . "`");
-    if($exists){
-        if(!$allow_edit){
-            wp_safe_redirect( add_query_arg('bhg_msg','noedit', wp_get_referer() ? wp_get_referer() : home_url('/')) );
-            exit;
-        }
-        $wpdb->update($guesses, array(
-            'guess_value' => $guess,
-            'updated_at' => current_time('mysql')
-        ), array('id' => $exists->id));
-    } else {
-        $wpdb->insert($guesses, array(
-            'user_id' => $user_id,
-            'hunt_id' => $hunt_id,
-            'guess_value' => $guess,
-            'created_at' => current_time('mysql')
-        ));
-    }
-    wp_safe_redirect( add_query_arg('bhg_msg','saved', wp_get_referer() ? wp_get_referer() : home_url('/')) );
-    exit;
+	if (is_admin()) return;
+	global $wpdb;
+	$table = $wpdb->prefix . 'bhg_advertisements';
+	if ($wpdb->get_results("SELECT * FROM `" . $hunt_id . "`");
+	if(!$hunt || !$hunt->is_active){
+		wp_safe_redirect( add_query_arg('bhg_msg','closed', wp_get_referer() ? wp_get_referer() : home_url('/')) );
+		exit;
+	}
+	$allow_edit = get_option('bhg_allow_guess_alteration','1') === '1';
+	$exists = $wpdb->get_results("SELECT * FROM `" . $user_id . "`");
+	if($exists){
+		if(!$allow_edit){
+			wp_safe_redirect( add_query_arg('bhg_msg','noedit', wp_get_referer() ? wp_get_referer() : home_url('/')) );
+			exit;
+		}
+		$wpdb->update($guesses, array(
+			'guess_value' => $guess,
+			'updated_at' => current_time('mysql')
+		), array('id' => $exists->id));
+	} else {
+		$wpdb->insert($guesses, array(
+			'user_id' => $user_id,
+			'hunt_id' => $hunt_id,
+			'guess_value' => $guess,
+			'created_at' => current_time('mysql')
+		));
+	}
+	wp_safe_redirect( add_query_arg('bhg_msg','saved', wp_get_referer() ? wp_get_referer() : home_url('/')) );
+	exit;
 }
 
 // When closing a hunt, compute winners and notify
 function bhg_compute_and_notify_winners($hunt_id){
-    global $wpdb;
-    $hunts = $wpdb->prefix.'bhg_bonus_hunts';
-    $guesses = $wpdb->prefix.'bhg_guesses';
+	global $wpdb;
+	$hunts = $wpdb->prefix.'bhg_bonus_hunts';
+	$guesses = $wpdb->prefix.'bhg_guesses';
 
-    $hunt = $wpdb->get_results("SELECT * FROM `" . $hunt_id . "`");
-    if(!$hunt || is_null($hunt->final_balance)) return;
+	$hunt = $wpdb->get_results("SELECT * FROM `" . $hunt_id . "`");
+	if(!$hunt || is_null($hunt->final_balance)) return;
 
-    $rows = $wpdb->get_results("SELECT * FROM `" . $hunt_id . "`");
-    if(!$rows) return;
-    // closest by absolute difference
-    usort($rows, function($a,$b) use ($hunt){
-        $da = abs(floatval($a->guess_value) - floatval($hunt->final_balance));
-        $db = abs(floatval($b->guess_value) - floatval($hunt->final_balance));
-        if ($da == $db) return 0;
-        return ($da < $db) ? -1 : 1;
-    });
-    // Take top 3 for emailing (customize as needed)
-    $winners = array_slice($rows, 0, 3);
-    foreach($winners as $pos => $row){
-        $user = get_userdata($row->user_id);
-        if(!$user) continue;
-        $subject = sprintf(__('You placed #%d in %s','bonus-hunt-guesser'), $pos+1, $hunt->title);
-        $body = sprintf("Hello %s,\n\nGood news! You placed #%d in the bonus hunt '%s'.\nFinal balance: €%s\nYour guess: €%s\n\nWe will contact you with prize details.\n\nThanks,\nBonus Hunt Team",
-            $user->display_name, $pos+1, $hunt->title, number_format_i18n($hunt->final_balance,2), number_format_i18n($row->guess_value,2));
-        wp_mail($user->user_email, $subject, $body);
-    }
+	$rows = $wpdb->get_results("SELECT * FROM `" . $hunt_id . "`");
+	if(!$rows) return;
+	// closest by absolute difference
+	usort($rows, function($a,$b) use ($hunt){
+		$da = abs(floatval($a->guess_value) - floatval($hunt->final_balance));
+		$db = abs(floatval($b->guess_value) - floatval($hunt->final_balance));
+		if ($da == $db) return 0;
+		return ($da < $db) ? -1 : 1;
+	});
+	// Take top 3 for emailing (customize as needed)
+	$winners = array_slice($rows, 0, 3);
+	foreach($winners as $pos => $row){
+		$user = get_userdata($row->user_id);
+		if(!$user) continue;
+		$subject = sprintf(__('You placed #%d in %s','bonus-hunt-guesser'), $pos+1, $hunt->title);
+		$body = sprintf("Hello %s,\n\nGood news! You placed #%d in the bonus hunt '%s'.\nFinal balance: €%s\nYour guess: €%s\n\nWe will contact you with prize details.\n\nThanks,\nBonus Hunt Team",
+			$user->display_name, $pos+1, $hunt->title, number_format_i18n($hunt->final_balance,2), number_format_i18n($row->guess_value,2));
+		wp_mail($user->user_email, $subject, $body);
+	}
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -357,7 +357,7 @@ function bhg_get_user_display_name( $user_id ) {
 		return __( 'Unknown User', 'bonus-hunt-guesser' );
 	}
 
-    $display_name = $user->display_name ? $user->display_name : $user->user_login;
+	$display_name = $user->display_name ? $user->display_name : $user->user_login;
 	$is_affiliate = bhg_is_user_affiliate( $user_id );
 
 	if ( $is_affiliate ) {
@@ -479,7 +479,7 @@ function bhg_render_ads( $placement = 'footer', $hunt_id = 0 ) {
 
 	$out = '<div class="bhg-ads bhg-ads-' . esc_attr( $placement ) . '">';
 	foreach ( $rows as $r ) {
-        $vis  = $r->visible_to ? $r->visible_to : 'all';
+		$vis  = $r->visible_to ? $r->visible_to : 'all';
 		$show = false;
 		if ( $vis === 'all' ) {
 			$show = true;

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -22,7 +22,7 @@ add_shortcode(
 		// Basic profile
 		ob_start(); ?>
 	<div class="bhg-box">
-                <h3><?php echo esc_html( $u->display_name ? $u->display_name : $u->user_login ); ?></h3>
+				<h3><?php echo esc_html( $u->display_name ? $u->display_name : $u->user_login ); ?></h3>
 		<p><?php echo esc_html( $u->user_email ); ?></p>
 		<?php
 		if ( function_exists( 'bhg_get_affiliate_sites' ) ) :
@@ -46,10 +46,10 @@ add_shortcode(
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT DISTINCT h.id, h.title, h.status 
-            FROM {$wpdb->prefix}bhg_bonus_hunts h 
-            INNER JOIN {$wpdb->prefix}bhg_guesses g ON g.hunt_id = h.id 
-            WHERE g.user_id = %d 
-            ORDER BY h.id DESC",
+			FROM {$wpdb->prefix}bhg_bonus_hunts h 
+			INNER JOIN {$wpdb->prefix}bhg_guesses g ON g.hunt_id = h.id 
+			WHERE g.user_id = %d 
+			ORDER BY h.id DESC",
 				$uid
 			)
 		);
@@ -59,7 +59,7 @@ add_shortcode(
 			<h4><?php esc_html_e( 'Your Hunts', 'bonus-hunt-guesser' ); ?></h4>
 			<ul class="bhg-list">
 			<?php foreach ( $rows as $r ) : ?>
-                                <li><?php echo esc_html( $r->title ? $r->title : ( '#' . $r->id ) ); ?> — <?php echo esc_html( ucfirst( $r->status ) ); ?></li>
+								<li><?php echo esc_html( $r->title ? $r->title : ( '#' . $r->id ) ); ?> — <?php echo esc_html( ucfirst( $r->status ) ); ?></li>
 			<?php endforeach; ?>
 			</ul>
 		<?php endif; ?>
@@ -100,7 +100,7 @@ add_shortcode(
 		<?php if ( $rows ) : ?>
 			<ul class="bhg-list">
 				<?php foreach ( $rows as $r ) : ?>
-                                        <li><?php echo esc_html( $r->title ? $r->title : ( '#' . $r->id ) ); ?></li>
+										<li><?php echo esc_html( $r->title ? $r->title : ( '#' . $r->id ) ); ?></li>
 				<?php endforeach; ?>
 			</ul>
 		<?php else : ?>
@@ -126,10 +126,10 @@ add_shortcode(
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT g.*, h.title as hunt_title, h.status as hunt_status 
-        FROM {$wpdb->prefix}bhg_guesses g 
-        LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id 
-        WHERE g.user_id = %d 
-        ORDER BY g.id DESC",
+		FROM {$wpdb->prefix}bhg_guesses g 
+		LEFT JOIN {$wpdb->prefix}bhg_bonus_hunts h ON h.id = g.hunt_id 
+		WHERE g.user_id = %d 
+		ORDER BY g.id DESC",
 				$uid
 			)
 		);
@@ -153,9 +153,9 @@ add_shortcode(
 				<tbody>
 					<?php foreach ( $rows as $r ) : ?>
 						<tr>
-                                                        <td><?php echo esc_html( $r->hunt_title ? $r->hunt_title : ( '#' . $r->hunt_id ) ); ?></td>
+														<td><?php echo esc_html( $r->hunt_title ? $r->hunt_title : ( '#' . $r->hunt_id ) ); ?></td>
 							<td><?php echo esc_html( number_format_i18n( $r->guess, 2 ) ); ?></td>
-                                                        <td><?php echo esc_html( ucfirst( $r->hunt_status ? $r->hunt_status : 'open' ) ); ?></td>
+														<td><?php echo esc_html( ucfirst( $r->hunt_status ? $r->hunt_status : 'open' ) ); ?></td>
 							<td><?php echo esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ); ?></td>
 						</tr>
 					<?php endforeach; ?>
@@ -182,7 +182,7 @@ add_shortcode(
 		$table_exists  = $wpdb->get_var(
 			$wpdb->prepare(
 				'SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES 
-        WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
+		WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s',
 				DB_NAME,
 				$winners_table
 			)
@@ -192,10 +192,10 @@ add_shortcode(
 			$rows = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT h.id as hunt_id, h.title, w.user_id, w.position 
-            FROM {$wpdb->prefix}bhg_bonus_hunts h 
-            INNER JOIN {$wpdb->prefix}bhg_hunt_winners w ON w.hunt_id = h.id 
-            WHERE h.status = %s 
-            ORDER BY h.id DESC",
+			FROM {$wpdb->prefix}bhg_bonus_hunts h 
+			INNER JOIN {$wpdb->prefix}bhg_hunt_winners w ON w.hunt_id = h.id 
+			WHERE h.status = %s 
+			ORDER BY h.id DESC",
 					'closed'
 				)
 			);
@@ -203,9 +203,9 @@ add_shortcode(
 			$rows = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT id as hunt_id, title 
-            FROM {$wpdb->prefix}bhg_bonus_hunts 
-            WHERE status = %s 
-            ORDER BY id DESC",
+			FROM {$wpdb->prefix}bhg_bonus_hunts 
+			WHERE status = %s 
+			ORDER BY id DESC",
 					'closed'
 				)
 			);
@@ -224,10 +224,10 @@ add_shortcode(
 				$u = isset( $r->user_id ) && $r->user_id ? get_userdata( $r->user_id ) : null;
 				?>
 				<li>
-                                        <strong><?php echo esc_html( $r->title ? $r->title : ( '#' . $r->hunt_id ) ); ?></strong>
+										<strong><?php echo esc_html( $r->title ? $r->title : ( '#' . $r->hunt_id ) ); ?></strong>
 					
 					<?php if ( $u ) : ?>
-                                                — <?php echo esc_html( $u->display_name ? $u->display_name : $u->user_login ); ?>
+												— <?php echo esc_html( $u->display_name ? $u->display_name : $u->user_login ); ?>
 						<?php if ( ! empty( $r->position ) ) : ?>
 							(<?php echo intval( $r->position ); ?>)
 						<?php endif; ?>


### PR DESCRIPTION
## Summary
- Replace leading four-space indentation with single tabs in main plugin file and all PHP files under `admin/` and `includes/` to match WordPress coding standards.
- Run `composer phpcs` to verify coding standard compliance (reports remaining warnings and errors unrelated to indentation).

## Testing
- `composer install`
- `composer phpcs` *(fails: direct database calls and placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_68bc16006a108333a79b43b309d8c489