### PR TITLE
Remove MySQL compatibility header and adjust minimum WordPress version

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -7,10 +7,9 @@
  * Author: Bonus Hunt Guesser Development Team
  * Text Domain: bonus-hunt-guesser
  * Domain Path: /languages
- * Requires at least: 6.3.5
+ * Requires at least: 5.5.5
  * Requires PHP: 7.4
  * License: GPLv2 or later
- * MySQL tested up to: 5.5.5
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -106,7 +105,7 @@ require_once __DIR__ . '/includes/class-bhg-db.php';
 
 // Define plugin constants
 define( 'BHG_VERSION', '8.0.08' );
-define( 'BHG_MIN_WP', '6.3.5' );
+define( 'BHG_MIN_WP', '5.5.5' );
 define( 'BHG_PLUGIN_FILE', __FILE__ );
 define( 'BHG_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BHG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- remove deprecated `MySQL tested up to` header
- set plugin minimum WordPress version to 5.5.5 and update constant

## Testing
- `composer install`
- `composer run phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bc17121798833388032fed9b0e0f1c