### PR TITLE
Standardize indentation and ABSPATH guards

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 class BHG_Admin {
 

--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 /**
  * Handles demo reseeding actions.
  */

--- a/admin/class-bhg-users-table.php
+++ b/admin/class-bhg-users-table.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 if ( ! class_exists( 'WP_List_Table' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';

--- a/admin/views/advertising.php
+++ b/admin/views/advertising.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }

--- a/admin/views/affiliate-websites.php
+++ b/admin/views/affiliate-websites.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }

--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 if ( ! current_user_can( 'manage_options' ) ) {
 		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'Insufficient permissions', 'bonus-hunt-guesser' ) );
 }

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 /**
  * Admin view for managing bonus hunts.

--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -4,6 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die(
 		__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' )

--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );

--- a/admin/views/demo-tools.php
+++ b/admin/views/demo-tools.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }

--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -3,6 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 // Check user capabilities
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( __( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );

--- a/admin/views/hunt-results.php
+++ b/admin/views/hunt-results.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( __( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) ); }
 

--- a/admin/views/hunts-edit.php
+++ b/admin/views/hunts-edit.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) ); }
 

--- a/admin/views/hunts-list.php
+++ b/admin/views/hunts-list.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) ); }
 

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -3,6 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 // Check user capabilities
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );

--- a/admin/views/tools.php
+++ b/admin/views/tools.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 ?>
 <div class="wrap">
 	<h1><?php echo esc_html__( 'BHG Tools', 'bonus-hunt-guesser' ); ?></h1>

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }

--- a/admin/views/translations.php
+++ b/admin/views/translations.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }

--- a/admin/views/users.php
+++ b/admin/views/users.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 add_action(
 	'admin_post_bhg_save_hunt',

--- a/includes/class-bhg-ads.php
+++ b/includes/class-bhg-ads.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 class BHG_Ads {
 

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 /**
  * Helper functions for hunts and guesses used by admin dashboard, list and results.

--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 /**
  * Bonus hunt data helpers.

--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 class BHG_DB {
 

--- a/includes/class-bhg-front-menus.php
+++ b/includes/class-bhg-front-menus.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 /**
  * Front-end menus.
  */

--- a/includes/class-bhg-logger.php
+++ b/includes/class-bhg-logger.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 /**
  * Logging helper class.
  */

--- a/includes/class-bhg-login-redirect.php
+++ b/includes/class-bhg-login-redirect.php
@@ -3,6 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 if ( ! class_exists( 'BHG_Login_Redirect' ) ) {
 	class BHG_Login_Redirect {
 

--- a/includes/class-bhg-menus.php
+++ b/includes/class-bhg-menus.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 if ( ! class_exists( 'BHG_Menus' ) ) {
 	class BHG_Menus {

--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -12,8 +12,9 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-        exit;
+	exit;
 }
+
 
 class BHG_Models {
 
@@ -39,13 +40,13 @@ class BHG_Models {
 		$guesses_tbl = $wpdb->prefix . 'bhg_guesses';
 
 		// Determine number of winners for this hunt.
-                $winners_count = (int) $wpdb->get_var(
-                        $wpdb->prepare(
-                                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a variable.
-                                "SELECT winners_count FROM {$hunts_tbl} WHERE id = %d",
-                                $hunt_id
-                        )
-                );
+				$winners_count = (int) $wpdb->get_var(
+						$wpdb->prepare(
+								// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a variable.
+								"SELECT winners_count FROM {$hunts_tbl} WHERE id = %d",
+								$hunt_id
+						)
+				);
 		if ( $winners_count <= 0 ) {
 			$winners_count = 1;
 		}
@@ -66,15 +67,15 @@ class BHG_Models {
 		);
 
 		// Fetch winners based on proximity to final balance.
-                $rows = $wpdb->get_results(
-                        $wpdb->prepare(
-                                // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a variable.
-                                "SELECT user_id FROM {$guesses_tbl} WHERE hunt_id = %d ORDER BY ABS(guess - %f) ASC, id ASC LIMIT %d",
-                                $hunt_id,
-                                $final_balance,
-                                $winners_count
-                        )
-                );
+				$rows = $wpdb->get_results(
+						$wpdb->prepare(
+								// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is a variable.
+								"SELECT user_id FROM {$guesses_tbl} WHERE hunt_id = %d ORDER BY ABS(guess - %f) ASC, id ASC LIMIT %d",
+								$hunt_id,
+								$final_balance,
+								$winners_count
+						)
+				);
 
 		if ( empty( $rows ) ) {
 			return array();

--- a/includes/class-bhg-settings.php
+++ b/includes/class-bhg-settings.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 class BHG_Settings {
 	public static function render() {
 		BHG_Utils::require_cap();

--- a/includes/class-bhg-shortcodes.php
+++ b/includes/class-bhg-shortcodes.php
@@ -6,7 +6,9 @@
  * It registers the required shortcodes on `init` and avoids "public function outside class" parse errors.
  */
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 if ( ! class_exists( 'BHG_Shortcodes' ) ) {
 

--- a/includes/class-bhg-utils.php
+++ b/includes/class-bhg-utils.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 /**
  * General utility methods used throughout the plugin.
  */

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 function bhg_seed_demo_on_activation() {
 	// Only seed once

--- a/includes/helpers-aff-dot.php
+++ b/includes/helpers-aff-dot.php
@@ -6,8 +6,9 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-		exit;
+	exit;
 }
+
 
 if ( ! function_exists( 'bhg_render_affiliate_dot' ) ) {
 		/**

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+	exit;
+}
+
 
 /**
  * Log debug messages when WP_DEBUG is enabled.

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -3,6 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 /**
  * BHG Shortcodes
  * Implements all required frontend shortcodes with full DB wiring.

--- a/includes/upgrade/add-winners-limit.php
+++ b/includes/upgrade/add-winners-limit.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
 /**
  * Add winners_count column to bonus hunts table if missing.
  *


### PR DESCRIPTION
## Summary
- Replace leading spaces with tabs across admin and includes directories
- Format `ABSPATH` guard blocks on their own lines for consistency

## Testing
- `composer phpcs admin includes` *(fails: Missing file doc comment, unsanitized input, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1a5a4ab8833395f213f279b1a148