### PR TITLE
Update minimum WordPress requirement

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -7,14 +7,14 @@
  * Author: Bonus Hunt Guesser Development Team
  * Text Domain: bonus-hunt-guesser
  * Domain Path: /languages
- * Requires at least: 5.5.5
+ * Requires at least: 6.3.5
  * Requires PHP: 7.4
  * License: GPLv2 or later
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
-		}
+}
 
 // Helper: parse human-entered money-like strings into float
 if ( ! function_exists( 'bhg_parse_amount' ) ) {
@@ -105,7 +105,7 @@ require_once __DIR__ . '/includes/class-bhg-db.php';
 
 // Define plugin constants
 define( 'BHG_VERSION', '8.0.08' );
-define( 'BHG_MIN_WP', '5.5.5' );
+define( 'BHG_MIN_WP', '6.3.5' );
 define( 'BHG_PLUGIN_FILE', __FILE__ );
 define( 'BHG_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BHG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- bump minimum WordPress version to 6.3.5
- update BHG_MIN_WP constant accordingly
- format ABSPATH guard with tab indentation

## Testing
- `composer install`
- `composer phpcs` *(fails: Missing doc comment for function render_dashboard, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1d484bb0833392a98dc16acbcf7d