### PR TITLE
style: fix brace formatting in get_hunt_guesses_ranked

### DIFF
--- a/includes/class-bhg-bonus-hunts.php
+++ b/includes/class-bhg-bonus-hunts.php
@@ -87,7 +87,8 @@ class BHG_Bonus_Hunts {
 		$hunt          = self::get_hunt( $hunt_id );
 
 		if ( ! $hunt ) {
-			return array(); }
+			return array();
+		}
 
 		if ( null !== $hunt->final_balance ) {
 				return $wpdb->get_results(


### PR DESCRIPTION
## Summary
- place early-return closing brace on its own line in `get_hunt_guesses_ranked`

## Testing
- `composer install`
- `vendor/bin/phpcs --standard=phpcs.xml includes/class-bhg-bonus-hunts.php` *(fails: 6 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc236d4e1c8333a1d6a30326cb5dac