### PR TITLE
Improve admin security and standards

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Admin functionality for the Bonus Hunt Guesser plugin.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+		exit;
 }
 
-
+/**
+ * Handles Bonus Hunt Guesser admin pages and actions.
+ */
 class BHG_Admin {
 
 	/**
@@ -67,17 +75,21 @@ class BHG_Admin {
 				remove_submenu_page( $slug, $slug );
 	}
 
-	/** Enqueue admin assets on BHG screens. */
+		/**
+		 * Enqueue admin assets on BHG screens.
+		 *
+		 * @param string $hook Current admin page hook suffix.
+		 */
 	public function assets( $hook ) {
-		if ( strpos( $hook, 'bhg' ) !== false ) {
-			wp_enqueue_style(
-				'bhg-admin',
-				BHG_PLUGIN_URL . 'assets/css/admin.css',
-				array(),
-				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-			);
-			$script_path = BHG_PLUGIN_DIR . 'assets/js/admin.js';
-			if ( file_exists( $script_path ) && filesize( $script_path ) > 0 ) {
+		if ( false !== strpos( $hook, 'bhg' ) ) {
+				wp_enqueue_style(
+					'bhg-admin',
+					BHG_PLUGIN_URL . 'assets/css/admin.css',
+					array(),
+					defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+				);
+				$script_path = BHG_PLUGIN_DIR . 'assets/js/admin.js';
+			if ( file_exists( $script_path ) && 0 < filesize( $script_path ) ) {
 				wp_enqueue_script(
 					'bhg-admin',
 					BHG_PLUGIN_URL . 'assets/js/admin.js',
@@ -188,11 +200,11 @@ class BHG_Admin {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
 		check_admin_referer( 'bhg_delete_guess' );
-		global $wpdb;
-		$guesses_table = $wpdb->prefix . 'bhg_guesses';
-		$guess_id      = isset( $_POST['guess_id'] ) ? absint( wp_unslash( $_POST['guess_id'] ) ) : 0;
-		if ( $guess_id ) {
-			$wpdb->delete( $guesses_table, array( 'id' => $guess_id ), array( '%d' ) );
+				global $wpdb;
+				$guesses_table = esc_sql( $wpdb->prefix . 'bhg_guesses' );
+				$guess_id      = isset( $_POST['guess_id'] ) ? absint( wp_unslash( $_POST['guess_id'] ) ) : 0;
+		if ( 0 !== $guess_id ) {
+				$wpdb->delete( $guesses_table, array( 'id' => $guess_id ), array( '%d' ) );
 		}
 				wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
@@ -206,18 +218,18 @@ class BHG_Admin {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
 		check_admin_referer( 'bhg_save_hunt' );
-		global $wpdb;
-		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
+				global $wpdb;
+				$hunts_table = esc_sql( $wpdb->prefix . 'bhg_bonus_hunts' );
 
-		$id             = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-		$title          = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
-		$starting       = isset( $_POST['starting_balance'] ) ? floatval( wp_unslash( $_POST['starting_balance'] ) ) : 0;
-		$num_bonuses    = isset( $_POST['num_bonuses'] ) ? absint( wp_unslash( $_POST['num_bonuses'] ) ) : 0;
-		$prizes         = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
-		$winners_count  = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
-		$affiliate_site = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
-		$final_balance  = ( isset( $_POST['final_balance'] ) && $_POST['final_balance'] !== '' ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
-		$status         = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
+				$id            = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$title                 = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
+		$starting              = isset( $_POST['starting_balance'] ) ? floatval( wp_unslash( $_POST['starting_balance'] ) ) : 0;
+		$num_bonuses           = isset( $_POST['num_bonuses'] ) ? absint( wp_unslash( $_POST['num_bonuses'] ) ) : 0;
+		$prizes                = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
+		$winners_count         = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
+		$affiliate_site        = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
+				$final_balance = ( isset( $_POST['final_balance'] ) && '' !== $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
+		$status                = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
 
 		$data = array(
 			'title'             => $title,
@@ -232,39 +244,49 @@ class BHG_Admin {
 		);
 
 		$format = array( '%s', '%f', '%d', '%s', '%d', '%d', '%f', '%s', '%s' );
-		if ( $id ) {
-			$wpdb->update( $hunts_table, $data, array( 'id' => $id ), $format, array( '%d' ) );
+		if ( 0 !== $id ) {
+				$wpdb->update( $hunts_table, $data, array( 'id' => $id ), $format, array( '%d' ) );
 		} else {
-			$data['created_at'] = current_time( 'mysql' );
-			$format[]           = '%s';
-			$wpdb->insert( $hunts_table, $data, $format );
-			$id = (int) $wpdb->insert_id;
+				$data['created_at'] = current_time( 'mysql' );
+				$format[]           = '%s';
+				$wpdb->insert( $hunts_table, $data, $format );
+				$id = (int) $wpdb->insert_id;
 		}
 
-		if ( $status === 'closed' && $final_balance !== null ) {
-			$winners = BHG_Models::close_hunt( $id, $final_balance );
+				wp_cache_delete( "bhg_hunt_title_{$id}", 'bhg' );
 
-			$emails_enabled = (int) get_option( 'bhg_email_enabled', 1 );
+		if ( 'closed' === $status && null !== $final_balance ) {
+				$winners = BHG_Models::close_hunt( $id, $final_balance );
+
+				$emails_enabled = (int) get_option( 'bhg_email_enabled', 1 );
 			if ( $emails_enabled ) {
-				$guesses_table = $wpdb->prefix . 'bhg_guesses';
-				$rows          = $wpdb->get_results(
-					$wpdb->prepare(
-						"SELECT DISTINCT user_id FROM {$guesses_table} WHERE hunt_id=%d",
-						$id
-					)
-				);
+						$guesses_table = esc_sql( $wpdb->prefix . 'bhg_guesses' );
+						$rows          = wp_cache_get( "bhg_hunt_users_{$id}", 'bhg' );
+				if ( false === $rows ) {
+					$rows = $wpdb->get_results(
+						$wpdb->prepare(
+							"SELECT DISTINCT user_id FROM {$guesses_table} WHERE hunt_id=%d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+							$id
+						)
+					);
+					wp_cache_set( "bhg_hunt_users_{$id}", $rows, 'bhg' );
+				}
 
-				$template = get_option(
-					'bhg_email_template',
-					'Hi {{username}},\nThe Bonus Hunt "{{hunt}}" is closed. Final balance: €{{final}}. Winners: {{winners}}. Thanks for playing!'
-				);
+						$template = get_option(
+							'bhg_email_template',
+							'Hi {{username}},\nThe Bonus Hunt "{{hunt}}" is closed. Final balance: €{{final}}. Winners: {{winners}}. Thanks for playing!'
+						);
 
-				$hunt_title = (string) $wpdb->get_var(
-					$wpdb->prepare(
-						"SELECT title FROM {$hunts_table} WHERE id=%d",
-						$id
-					)
-				);
+						$hunt_title = wp_cache_get( "bhg_hunt_title_{$id}", 'bhg' );
+				if ( false === $hunt_title ) {
+					$hunt_title = (string) $wpdb->get_var(
+						$wpdb->prepare(
+							"SELECT title FROM {$hunts_table} WHERE id=%d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+							$id
+						)
+					);
+					wp_cache_set( "bhg_hunt_title_{$id}", $hunt_title, 'bhg' );
+				}
 
 				$winner_names = array();
 				foreach ( (array) $winners as $winner_id ) {
@@ -273,8 +295,8 @@ class BHG_Admin {
 						$winner_names[] = $wu->user_login;
 					}
 				}
-								$winner_first = $winner_names ? $winner_names[0] : esc_html__( '—', 'bonus-hunt-guesser' );
-								$winner_list  = $winner_names ? implode( ', ', $winner_names ) : esc_html__( '—', 'bonus-hunt-guesser' );
+						$winner_first = $winner_names ? $winner_names[0] : esc_html__( '—', 'bonus-hunt-guesser' );
+						$winner_list  = $winner_names ? implode( ', ', $winner_names ) : esc_html__( '—', 'bonus-hunt-guesser' );
 
 				foreach ( $rows as $r ) {
 					$u = get_userdata( (int) $r->user_id );
@@ -291,11 +313,12 @@ class BHG_Admin {
 							'{{winners}}'  => $winner_list,
 						)
 					);
-					wp_mail(
-						$u->user_email,
+										wp_mail(
+											$u->user_email,
+											/* translators: %s: Bonus hunt title. */
 												sprintf( __( 'Results for %s', 'bonus-hunt-guesser' ), $hunt_title ? $hunt_title : 'Bonus Hunt' ),
-						$body
-					);
+											$body
+										);
 				}
 			}
 		}
@@ -316,15 +339,15 @@ class BHG_Admin {
 		$hunt_id           = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
 		$final_balance_raw = isset( $_POST['final_balance'] ) ? sanitize_text_field( wp_unslash( $_POST['final_balance'] ) ) : '';
 
-		if ( '' === $final_balance_raw || ! is_numeric( $final_balance_raw ) || (float) $final_balance_raw < 0 ) {
+		if ( '' === $final_balance_raw || ! is_numeric( $final_balance_raw ) || 0 > (float) $final_balance_raw ) {
 			wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
 			exit;
 		}
 
 		$final_balance = (float) $final_balance_raw;
 
-		if ( $hunt_id ) {
-			BHG_Models::close_hunt( $hunt_id, $final_balance );
+		if ( 0 !== $hunt_id ) {
+				BHG_Models::close_hunt( $hunt_id, $final_balance );
 		}
 
 		wp_safe_redirect( admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
@@ -339,10 +362,10 @@ class BHG_Admin {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
 		check_admin_referer( 'bhg_save_ad' );
-		global $wpdb;
-		$table = $wpdb->prefix . 'bhg_ads';
+				global $wpdb;
+				$table = esc_sql( $wpdb->prefix . 'bhg_ads' );
 
-		$id             = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+				$id     = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
 		$title          = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
 		$content        = isset( $_POST['content'] ) ? wp_kses_post( wp_unslash( $_POST['content'] ) ) : '';
 		$link           = isset( $_POST['link_url'] ) ? esc_url_raw( wp_unslash( $_POST['link_url'] ) ) : '';
@@ -363,12 +386,12 @@ class BHG_Admin {
 		);
 
 		$format = array( '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s' );
-		if ( $id ) {
-			$wpdb->update( $table, $data, array( 'id' => $id ), $format, array( '%d' ) );
+		if ( 0 !== $id ) {
+				$wpdb->update( $table, $data, array( 'id' => $id ), $format, array( '%d' ) );
 		} else {
-			$data['created_at'] = current_time( 'mysql' );
-			$format[]           = '%s';
-			$wpdb->insert( $table, $data, $format );
+				$data['created_at'] = current_time( 'mysql' );
+				$format[]           = '%s';
+				$wpdb->insert( $table, $data, $format );
 		}
 
 		wp_safe_redirect( admin_url( 'admin.php?page=bhg-ads' ) );
@@ -387,10 +410,10 @@ class BHG_Admin {
 			wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 		}
-		global $wpdb;
-		$t    = $wpdb->prefix . 'bhg_tournaments';
-		$id   = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-		$data = array(
+				global $wpdb;
+				$t  = esc_sql( $wpdb->prefix . 'bhg_tournaments' );
+				$id = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$data       = array(
 			'title'       => isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '',
 			'description' => isset( $_POST['description'] ) ? wp_kses_post( wp_unslash( $_POST['description'] ) ) : '',
 			'type'        => isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'weekly',
@@ -401,18 +424,18 @@ class BHG_Admin {
 		);
 		try {
 			$format = array( '%s', '%s', '%s', '%s', '%s', '%s', '%s' );
-			if ( $id > 0 ) {
-				$wpdb->update( $t, $data, array( 'id' => $id ), $format, array( '%d' ) );
+			if ( 0 < $id ) {
+					$wpdb->update( $t, $data, array( 'id' => $id ), $format, array( '%d' ) );
 			} else {
-				$data['created_at'] = current_time( 'mysql' );
-				$format[]           = '%s';
-				$wpdb->insert( $t, $data, $format );
+					$data['created_at'] = current_time( 'mysql' );
+					$format[]           = '%s';
+					$wpdb->insert( $t, $data, $format );
 			}
 			wp_safe_redirect( add_query_arg( 'bhg_msg', 't_saved', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
 		} catch ( Throwable $e ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
-				error_log( '[BHG] tournament save error: ' . $e->getMessage() );
+			if ( class_exists( 'BHG_Logger' ) ) {
+					BHG_Logger::error( 'tournament save error: ' . $e->getMessage() );
 			}
 			wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
 			exit;
@@ -427,12 +450,12 @@ class BHG_Admin {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
 		check_admin_referer( 'bhg_save_affiliate' );
-		global $wpdb;
-		$table  = $wpdb->prefix . 'bhg_affiliates';
-		$id     = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-		$name   = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
-		$url    = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
-		$status = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active';
+				global $wpdb;
+				$table = esc_sql( $wpdb->prefix . 'bhg_affiliates' );
+				$id    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$name          = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+		$url           = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
+		$status        = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active';
 
 		$data   = array(
 			'name'       => $name,
@@ -441,12 +464,12 @@ class BHG_Admin {
 			'updated_at' => current_time( 'mysql' ),
 		);
 		$format = array( '%s', '%s', '%s', '%s' );
-		if ( $id ) {
-			$wpdb->update( $table, $data, array( 'id' => $id ), $format, array( '%d' ) );
+		if ( 0 !== $id ) {
+				$wpdb->update( $table, $data, array( 'id' => $id ), $format, array( '%d' ) );
 		} else {
-			$data['created_at'] = current_time( 'mysql' );
-			$format[]           = '%s';
-			$wpdb->insert( $table, $data, $format );
+				$data['created_at'] = current_time( 'mysql' );
+				$format[]           = '%s';
+				$wpdb->insert( $table, $data, $format );
 		}
 		wp_safe_redirect( admin_url( 'admin.php?page=bhg-affiliates' ) );
 		exit;
@@ -460,11 +483,11 @@ class BHG_Admin {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
 		check_admin_referer( 'bhg_delete_affiliate' );
-		global $wpdb;
-		$table = $wpdb->prefix . 'bhg_affiliates';
-		$id    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-		if ( $id ) {
-			$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
+				global $wpdb;
+				$table = esc_sql( $wpdb->prefix . 'bhg_affiliates' );
+				$id    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		if ( 0 !== $id ) {
+				$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
 		}
 		wp_safe_redirect( admin_url( 'admin.php?page=bhg-affiliates' ) );
 		exit;
@@ -497,10 +520,10 @@ class BHG_Admin {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
 		check_admin_referer( 'bhg_save_user_meta' );
-		$user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;
-		if ( $user_id ) {
-			$real_name                = isset( $_POST['bhg_real_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bhg_real_name'] ) ) : '';
-						$is_affiliate = isset( $_POST['bhg_is_affiliate'] ) ? absint( wp_unslash( $_POST['bhg_is_affiliate'] ) ) : 0;
+				$user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;
+		if ( 0 !== $user_id ) {
+			$real_name        = isset( $_POST['bhg_real_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bhg_real_name'] ) ) : '';
+				$is_affiliate = isset( $_POST['bhg_is_affiliate'] ) ? absint( wp_unslash( $_POST['bhg_is_affiliate'] ) ) : 0;
 			update_user_meta( $user_id, 'bhg_real_name', $real_name );
 			update_user_meta( $user_id, 'bhg_is_affiliate', $is_affiliate );
 		}
@@ -515,19 +538,19 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
-		if ( ! isset( $_GET['bhg_msg'] ) ) {
-			return;
+		if ( ! isset( $_GET['bhg_msg'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				return;
 		}
-		$msg   = sanitize_text_field( wp_unslash( $_GET['bhg_msg'] ) );
-		$map   = array(
+				$msg   = sanitize_text_field( wp_unslash( $_GET['bhg_msg'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$map           = array(
 			't_saved'               => __( 'Tournament saved.', 'bonus-hunt-guesser' ),
 			't_error'               => __( 'Could not save tournament. Check logs.', 'bonus-hunt-guesser' ),
 			'nonce'                 => __( 'Security check failed. Please retry.', 'bonus-hunt-guesser' ),
 			'noaccess'              => __( 'You do not have permission to do that.', 'bonus-hunt-guesser' ),
 			'invalid_final_balance' => __( 'Invalid final balance. Please enter a non-negative number.', 'bonus-hunt-guesser' ),
 		);
-		$class = ( strpos( $msg, 'error' ) !== false || 'nonce' === $msg || 'noaccess' === $msg ) ? 'notice notice-error' : 'notice notice-success';
-		$text  = isset( $map[ $msg ] ) ? $map[ $msg ] : esc_html( $msg );
+				$class = ( false !== strpos( $msg, 'error' ) || 'nonce' === $msg || 'noaccess' === $msg ) ? 'notice notice-error' : 'notice notice-success';
+		$text          = isset( $map[ $msg ] ) ? $map[ $msg ] : esc_html( $msg );
 		echo '<div class="' . esc_attr( $class ) . '"><p>' . esc_html( $text ) . '</p></div>';
 	}
 }


### PR DESCRIPTION
## Summary
- document admin class and asset loader
- sanitize table names and adopt Yoda conditions
- add caching and logger usage for admin DB operations

## Testing
- `vendor/bin/phpcs --standard=phpcs.xml admin/class-bhg-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc24ca4dc883338f414c45b1e28b97