### PR TITLE
Improve admin security and standards

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Admin functionality for Bonus Hunt Guesser.
+ *
+ * @package Bonus_Hunt_Guesser
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+		exit;
 }
 
-
+/**
+ * Class handling admin functionality for Bonus Hunt Guesser.
+ */
 class BHG_Admin {
 
 	/**
@@ -67,17 +75,21 @@ class BHG_Admin {
 				remove_submenu_page( $slug, $slug );
 	}
 
-	/** Enqueue admin assets on BHG screens. */
+		/**
+		 * Enqueue admin assets on BHG screens.
+		 *
+		 * @param string $hook Current admin page hook suffix.
+		 */
 	public function assets( $hook ) {
-		if ( strpos( $hook, 'bhg' ) !== false ) {
-			wp_enqueue_style(
-				'bhg-admin',
-				BHG_PLUGIN_URL . 'assets/css/admin.css',
-				array(),
-				defined( 'BHG_VERSION' ) ? BHG_VERSION : null
-			);
-			$script_path = BHG_PLUGIN_DIR . 'assets/js/admin.js';
-			if ( file_exists( $script_path ) && filesize( $script_path ) > 0 ) {
+		if ( false !== strpos( $hook, 'bhg' ) ) {
+				wp_enqueue_style(
+					'bhg-admin',
+					BHG_PLUGIN_URL . 'assets/css/admin.css',
+					array(),
+					defined( 'BHG_VERSION' ) ? BHG_VERSION : null
+				);
+				$script_path = BHG_PLUGIN_DIR . 'assets/js/admin.js';
+			if ( file_exists( $script_path ) && 0 < filesize( $script_path ) ) {
 				wp_enqueue_script(
 					'bhg-admin',
 					BHG_PLUGIN_URL . 'assets/js/admin.js',
@@ -187,12 +199,12 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
-		check_admin_referer( 'bhg_delete_guess' );
-		global $wpdb;
-		$guesses_table = $wpdb->prefix . 'bhg_guesses';
-		$guess_id      = isset( $_POST['guess_id'] ) ? absint( wp_unslash( $_POST['guess_id'] ) ) : 0;
+				check_admin_referer( 'bhg_delete_guess' );
+				global $wpdb;
+				$guesses_table = esc_sql( $wpdb->prefix . 'bhg_guesses' );
+				$guess_id      = isset( $_POST['guess_id'] ) ? absint( wp_unslash( $_POST['guess_id'] ) ) : 0;
 		if ( $guess_id ) {
-			$wpdb->delete( $guesses_table, array( 'id' => $guess_id ), array( '%d' ) );
+				$wpdb->delete( $guesses_table, array( 'id' => $guess_id ), array( '%d' ) );
 		}
 				wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
 		exit;
@@ -205,19 +217,19 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
-		check_admin_referer( 'bhg_save_hunt' );
-		global $wpdb;
-		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
+				check_admin_referer( 'bhg_save_hunt' );
+				global $wpdb;
+				$hunts_table = esc_sql( $wpdb->prefix . 'bhg_bonus_hunts' );
 
-		$id             = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-		$title          = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
-		$starting       = isset( $_POST['starting_balance'] ) ? floatval( wp_unslash( $_POST['starting_balance'] ) ) : 0;
-		$num_bonuses    = isset( $_POST['num_bonuses'] ) ? absint( wp_unslash( $_POST['num_bonuses'] ) ) : 0;
-		$prizes         = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
-		$winners_count  = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
-		$affiliate_site = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
-		$final_balance  = ( isset( $_POST['final_balance'] ) && $_POST['final_balance'] !== '' ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
-		$status         = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
+		$id                    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$title                 = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
+		$starting              = isset( $_POST['starting_balance'] ) ? floatval( wp_unslash( $_POST['starting_balance'] ) ) : 0;
+		$num_bonuses           = isset( $_POST['num_bonuses'] ) ? absint( wp_unslash( $_POST['num_bonuses'] ) ) : 0;
+		$prizes                = isset( $_POST['prizes'] ) ? wp_kses_post( wp_unslash( $_POST['prizes'] ) ) : '';
+		$winners_count         = isset( $_POST['winners_count'] ) ? max( 1, absint( wp_unslash( $_POST['winners_count'] ) ) ) : 3;
+		$affiliate_site        = isset( $_POST['affiliate_site_id'] ) ? absint( wp_unslash( $_POST['affiliate_site_id'] ) ) : 0;
+				$final_balance = ( isset( $_POST['final_balance'] ) && '' !== $_POST['final_balance'] ) ? floatval( wp_unslash( $_POST['final_balance'] ) ) : null;
+		$status                = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'open';
 
 		$data = array(
 			'title'             => $title,
@@ -233,7 +245,7 @@ class BHG_Admin {
 
 		$format = array( '%s', '%f', '%d', '%s', '%d', '%d', '%f', '%s', '%s' );
 		if ( $id ) {
-			$wpdb->update( $hunts_table, $data, array( 'id' => $id ), $format, array( '%d' ) );
+				$wpdb->update( $hunts_table, $data, array( 'id' => $id ), $format, array( '%d' ) );
 		} else {
 			$data['created_at'] = current_time( 'mysql' );
 			$format[]           = '%s';
@@ -241,30 +253,42 @@ class BHG_Admin {
 			$id = (int) $wpdb->insert_id;
 		}
 
-		if ( $status === 'closed' && $final_balance !== null ) {
-			$winners = BHG_Models::close_hunt( $id, $final_balance );
+		if ( 'closed' === $status && null !== $final_balance ) {
+				$winners = BHG_Models::close_hunt( $id, $final_balance );
 
 			$emails_enabled = (int) get_option( 'bhg_email_enabled', 1 );
 			if ( $emails_enabled ) {
-				$guesses_table = $wpdb->prefix . 'bhg_guesses';
-				$rows          = $wpdb->get_results(
-					$wpdb->prepare(
-						"SELECT DISTINCT user_id FROM {$guesses_table} WHERE hunt_id=%d",
-						$id
-					)
-				);
+								$guesses_table = esc_sql( $wpdb->prefix . 'bhg_guesses' );
+								$cache_key     = 'bhg_hunt_' . $id . '_user_ids';
+								$rows          = wp_cache_get( $cache_key );
+				if ( false === $rows ) {
+						$rows = $wpdb->get_results(
+							$wpdb->prepare(
+								'SELECT DISTINCT user_id FROM %i WHERE hunt_id = %d',
+								$guesses_table,
+								$id
+							)
+						);
+						wp_cache_set( $cache_key, $rows );
+				}
 
 				$template = get_option(
 					'bhg_email_template',
 					'Hi {{username}},\nThe Bonus Hunt "{{hunt}}" is closed. Final balance: €{{final}}. Winners: {{winners}}. Thanks for playing!'
 				);
 
-				$hunt_title = (string) $wpdb->get_var(
-					$wpdb->prepare(
-						"SELECT title FROM {$hunts_table} WHERE id=%d",
-						$id
-					)
-				);
+								$title_cache = 'bhg_hunt_title_' . $id;
+								$hunt_title  = wp_cache_get( $title_cache );
+				if ( false === $hunt_title ) {
+						$hunt_title = (string) $wpdb->get_var(
+							$wpdb->prepare(
+								'SELECT title FROM %i WHERE id = %d',
+								$hunts_table,
+								$id
+							)
+						);
+						wp_cache_set( $title_cache, $hunt_title );
+				}
 
 				$winner_names = array();
 				foreach ( (array) $winners as $winner_id ) {
@@ -277,9 +301,9 @@ class BHG_Admin {
 								$winner_list  = $winner_names ? implode( ', ', $winner_names ) : esc_html__( '—', 'bonus-hunt-guesser' );
 
 				foreach ( $rows as $r ) {
-					$u = get_userdata( (int) $r->user_id );
+										$u = get_userdata( (int) $r->user_id );
 					if ( ! $u ) {
-						continue;
+							continue;
 					}
 					$body = strtr(
 						$template,
@@ -291,11 +315,12 @@ class BHG_Admin {
 							'{{winners}}'  => $winner_list,
 						)
 					);
-					wp_mail(
-						$u->user_email,
+										wp_mail(
+											$u->user_email,
+											/* translators: %s: Bonus hunt title. */
 												sprintf( __( 'Results for %s', 'bonus-hunt-guesser' ), $hunt_title ? $hunt_title : 'Bonus Hunt' ),
-						$body
-					);
+											$body
+										);
 				}
 			}
 		}
@@ -316,9 +341,16 @@ class BHG_Admin {
 		$hunt_id           = isset( $_POST['hunt_id'] ) ? absint( wp_unslash( $_POST['hunt_id'] ) ) : 0;
 		$final_balance_raw = isset( $_POST['final_balance'] ) ? sanitize_text_field( wp_unslash( $_POST['final_balance'] ) ) : '';
 
-		if ( '' === $final_balance_raw || ! is_numeric( $final_balance_raw ) || (float) $final_balance_raw < 0 ) {
-			wp_safe_redirect( add_query_arg( 'bhg_msg', 'invalid_final_balance', admin_url( 'admin.php?page=bhg-bonus-hunts' ) ) );
-			exit;
+		if ( '' === $final_balance_raw || ! is_numeric( $final_balance_raw ) || 0 > (float) $final_balance_raw ) {
+				$redirect_url = add_query_arg(
+					array(
+						'bhg_msg'   => 'invalid_final_balance',
+						'bhg_nonce' => wp_create_nonce( 'bhg_admin_notice' ),
+					),
+					admin_url( 'admin.php?page=bhg-bonus-hunts' )
+				);
+				wp_safe_redirect( $redirect_url );
+				exit;
 		}
 
 		$final_balance = (float) $final_balance_raw;
@@ -340,7 +372,7 @@ class BHG_Admin {
 		}
 		check_admin_referer( 'bhg_save_ad' );
 		global $wpdb;
-		$table = $wpdb->prefix . 'bhg_ads';
+				$table = esc_sql( $wpdb->prefix . 'bhg_ads' );
 
 		$id             = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
 		$title          = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
@@ -364,7 +396,7 @@ class BHG_Admin {
 
 		$format = array( '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%s' );
 		if ( $id ) {
-			$wpdb->update( $table, $data, array( 'id' => $id ), $format, array( '%d' ) );
+				$wpdb->update( $table, $data, array( 'id' => $id ), $format, array( '%d' ) );
 		} else {
 			$data['created_at'] = current_time( 'mysql' );
 			$format[]           = '%s';
@@ -380,17 +412,31 @@ class BHG_Admin {
 	 */
 	public function handle_save_tournament() {
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_safe_redirect( add_query_arg( 'bhg_msg', 'noaccess', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
-			exit;
+				$redirect_url = add_query_arg(
+					array(
+						'bhg_msg'   => 'noaccess',
+						'bhg_nonce' => wp_create_nonce( 'bhg_admin_notice' ),
+					),
+					admin_url( 'admin.php?page=bhg-tournaments' )
+				);
+				wp_safe_redirect( $redirect_url );
+				exit;
 		}
 		if ( ! check_admin_referer( 'bhg_tournament_save_action' ) ) {
-			wp_safe_redirect( add_query_arg( 'bhg_msg', 'nonce', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
-			exit;
+				$redirect_url = add_query_arg(
+					array(
+						'bhg_msg'   => 'nonce',
+						'bhg_nonce' => wp_create_nonce( 'bhg_admin_notice' ),
+					),
+					admin_url( 'admin.php?page=bhg-tournaments' )
+				);
+				wp_safe_redirect( $redirect_url );
+				exit;
 		}
-		global $wpdb;
-		$t    = $wpdb->prefix . 'bhg_tournaments';
-		$id   = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-		$data = array(
+				global $wpdb;
+				$t = esc_sql( $wpdb->prefix . 'bhg_tournaments' );
+		$id        = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$data      = array(
 			'title'       => isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '',
 			'description' => isset( $_POST['description'] ) ? wp_kses_post( wp_unslash( $_POST['description'] ) ) : '',
 			'type'        => isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'weekly',
@@ -400,22 +446,36 @@ class BHG_Admin {
 			'updated_at'  => current_time( 'mysql' ),
 		);
 		try {
-			$format = array( '%s', '%s', '%s', '%s', '%s', '%s', '%s' );
-			if ( $id > 0 ) {
-				$wpdb->update( $t, $data, array( 'id' => $id ), $format, array( '%d' ) );
+				$format = array( '%s', '%s', '%s', '%s', '%s', '%s', '%s' );
+			if ( 0 < $id ) {
+						$wpdb->update( $t, $data, array( 'id' => $id ), $format, array( '%d' ) );
 			} else {
-				$data['created_at'] = current_time( 'mysql' );
-				$format[]           = '%s';
-				$wpdb->insert( $t, $data, $format );
+							$data['created_at'] = current_time( 'mysql' );
+							$format[]           = '%s';
+							$wpdb->insert( $t, $data, $format );
 			}
-			wp_safe_redirect( add_query_arg( 'bhg_msg', 't_saved', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
-			exit;
+							$redirect_url = add_query_arg(
+								array(
+									'bhg_msg'   => 't_saved',
+									'bhg_nonce' => wp_create_nonce( 'bhg_admin_notice' ),
+								),
+								admin_url( 'admin.php?page=bhg-tournaments' )
+							);
+				wp_safe_redirect( $redirect_url );
+				exit;
 		} catch ( Throwable $e ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
-				error_log( '[BHG] tournament save error: ' . $e->getMessage() );
+			if ( function_exists( 'bhg_log' ) ) {
+						bhg_log( 'tournament save error: ' . $e->getMessage() );
 			}
-			wp_safe_redirect( add_query_arg( 'bhg_msg', 't_error', admin_url( 'admin.php?page=bhg-tournaments' ) ) );
-			exit;
+				$redirect_url = add_query_arg(
+					array(
+						'bhg_msg'   => 't_error',
+						'bhg_nonce' => wp_create_nonce( 'bhg_admin_notice' ),
+					),
+					admin_url( 'admin.php?page=bhg-tournaments' )
+				);
+				wp_safe_redirect( $redirect_url );
+				exit;
 		}
 	}
 
@@ -427,12 +487,12 @@ class BHG_Admin {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
 		check_admin_referer( 'bhg_save_affiliate' );
-		global $wpdb;
-		$table  = $wpdb->prefix . 'bhg_affiliates';
-		$id     = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
-		$name   = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
-		$url    = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
-		$status = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active';
+				global $wpdb;
+				$table = esc_sql( $wpdb->prefix . 'bhg_affiliates' );
+		$id            = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+		$name          = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+		$url           = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
+		$status        = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : 'active';
 
 		$data   = array(
 			'name'       => $name,
@@ -460,9 +520,9 @@ class BHG_Admin {
 			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
 		}
 		check_admin_referer( 'bhg_delete_affiliate' );
-		global $wpdb;
-		$table = $wpdb->prefix . 'bhg_affiliates';
-		$id    = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
+				global $wpdb;
+				$table = esc_sql( $wpdb->prefix . 'bhg_affiliates' );
+		$id            = isset( $_POST['id'] ) ? absint( wp_unslash( $_POST['id'] ) ) : 0;
 		if ( $id ) {
 			$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
 		}
@@ -515,19 +575,23 @@ class BHG_Admin {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
-		if ( ! isset( $_GET['bhg_msg'] ) ) {
-			return;
+		if ( ! isset( $_GET['bhg_msg'], $_GET['bhg_nonce'] ) ) {
+				return;
 		}
-		$msg   = sanitize_text_field( wp_unslash( $_GET['bhg_msg'] ) );
-		$map   = array(
+				$nonce = sanitize_text_field( wp_unslash( $_GET['bhg_nonce'] ) );
+		if ( ! wp_verify_nonce( $nonce, 'bhg_admin_notice' ) ) {
+				return;
+		}
+				$msg   = sanitize_text_field( wp_unslash( $_GET['bhg_msg'] ) );
+		$map           = array(
 			't_saved'               => __( 'Tournament saved.', 'bonus-hunt-guesser' ),
 			't_error'               => __( 'Could not save tournament. Check logs.', 'bonus-hunt-guesser' ),
 			'nonce'                 => __( 'Security check failed. Please retry.', 'bonus-hunt-guesser' ),
 			'noaccess'              => __( 'You do not have permission to do that.', 'bonus-hunt-guesser' ),
 			'invalid_final_balance' => __( 'Invalid final balance. Please enter a non-negative number.', 'bonus-hunt-guesser' ),
 		);
-		$class = ( strpos( $msg, 'error' ) !== false || 'nonce' === $msg || 'noaccess' === $msg ) ? 'notice notice-error' : 'notice notice-success';
-		$text  = isset( $map[ $msg ] ) ? $map[ $msg ] : esc_html( $msg );
+				$class = ( false !== strpos( $msg, 'error' ) || 'nonce' === $msg || 'noaccess' === $msg ) ? 'notice notice-error' : 'notice notice-success';
+		$text          = isset( $map[ $msg ] ) ? $map[ $msg ] : esc_html( $msg );
 		echo '<div class="' . esc_attr( $class ) . '"><p>' . esc_html( $text ) . '</p></div>';
 	}
 }


### PR DESCRIPTION
## Summary
- Add PHPDoc blocks and document parameters in admin class
- Enforce Yoda conditions, sanitize table names, and add nonce validation with caching
- Replace error_log with bhg_log and wrap repeated DB reads in wp_cache

## Testing
- `composer install`
- `vendor/bin/phpcbf --standard=phpcs.xml admin/class-bhg-admin.php`
- `vendor/bin/phpcs --standard=phpcs.xml admin/class-bhg-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc266757d8833390342216f83c5d74