### PR TITLE
Use bhg_log for schema ensure errors

### DIFF
--- a/includes/class-bhg-db.php
+++ b/includes/class-bhg-db.php
@@ -250,8 +250,8 @@ class BHG_DB {
 																	dbDelta( sprintf( 'ALTER TABLE `%s` ADD UNIQUE KEY name_unique (name)', $aff_table ) );
 												}
 		} catch ( Throwable $e ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
-				error_log( '[BHG] Schema ensure error: ' . $e->getMessage() );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				bhg_log( 'Schema ensure error: ' . $e->getMessage() );
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- replace direct error_log with bhg_log when schema ensure fails

## Testing
- `composer phpcs` *(fails: Script phpcs --standard=phpcs.xml handling the phpcs event returned with error code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bc296aa2508333babe80e33fa04c80