### PR TITLE
Add caching to bonus hunt helpers

### DIFF
--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -509,20 +509,21 @@ function bhg_handle_submit_guess() {
 		if ( $allow_edit && $count > 0 ) {
 			$gid = (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM `$g_tbl` WHERE hunt_id=%d AND user_id=%d ORDER BY id DESC LIMIT 1", $hunt_id, $user_id ) );
 			if ( $gid ) {
-				$wpdb->update(
-					$g_tbl,
-					array(
-						'guess'      => $guess,
-						'updated_at' => current_time( 'mysql' ),
-					),
-					array( 'id' => $gid )
-				);
-				if ( wp_doing_ajax() ) {
-					wp_send_json_success();
-				}
-								wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
-				exit;
-			}
+$wpdb->update(
+$g_tbl,
+array(
+'guess'      => $guess,
+'updated_at' => current_time( 'mysql' ),
+),
+array( 'id' => $gid )
+);
+bhg_flush_hunt_cache( $hunt_id );
+if ( wp_doing_ajax() ) {
+wp_send_json_success();
+}
+wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
+exit;
+}
 		}
 		if ( wp_doing_ajax() ) {
 			wp_send_json_error( __( 'You have reached the maximum number of guesses.', 'bonus-hunt-guesser' ) );
@@ -531,20 +532,21 @@ function bhg_handle_submit_guess() {
 	}
 
 	// Insert
-	$wpdb->insert(
-		$g_tbl,
-		array(
-			'hunt_id'    => $hunt_id,
-			'user_id'    => $user_id,
-			'guess'      => $guess,
-			'created_at' => current_time( 'mysql' ),
-		),
-		array( '%d', '%d', '%f', '%s' )
-	);
+$wpdb->insert(
+$g_tbl,
+array(
+'hunt_id'    => $hunt_id,
+'user_id'    => $user_id,
+'guess'      => $guess,
+'created_at' => current_time( 'mysql' ),
+),
+array( '%d', '%d', '%f', '%s' )
+);
+bhg_flush_hunt_cache( $hunt_id );
 
-	if ( wp_doing_ajax() ) {
-		wp_send_json_success();
-	}
+if ( wp_doing_ajax() ) {
+wp_send_json_success();
+}
 
 		wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
 	exit;

--- a/includes/class-bhg-bonus-hunts-helpers.php
+++ b/includes/class-bhg-bonus-hunts-helpers.php
@@ -12,54 +12,87 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 
 if ( ! function_exists( 'bhg_get_hunt' ) ) {
-	function bhg_get_hunt( $hunt_id ) {
-		global $wpdb;
-				$t = $wpdb->prefix . 'bhg_bonus_hunts';
-				return $wpdb->get_row( $wpdb->prepare( "SELECT id, title, starting_balance, final_balance, winners_count, status, closed_at FROM $t WHERE id=%d", (int) $hunt_id ) );
-	}
+       function bhg_get_hunt( $hunt_id ) {
+               global $wpdb;
+               $hunt_id   = (int) $hunt_id;
+               $cache_key = "bhg_hunt_{$hunt_id}";
+
+               $cached = wp_cache_get( $cache_key, 'bhg' );
+               if ( false !== $cached ) {
+                       return $cached;
+               }
+
+               $t    = $wpdb->prefix . 'bhg_bonus_hunts';
+               $hunt = $wpdb->get_row( $wpdb->prepare( "SELECT id, title, starting_balance, final_balance, winners_count, status, closed_at FROM $t WHERE id=%d", $hunt_id ) );
+               wp_cache_set( $cache_key, $hunt, 'bhg', HOUR_IN_SECONDS );
+
+               return $hunt;
+       }
 }
 
 if ( ! function_exists( 'bhg_get_latest_closed_hunts' ) ) {
-	function bhg_get_latest_closed_hunts( $limit = 3 ) {
-		global $wpdb;
-		$t   = $wpdb->prefix . 'bhg_bonus_hunts';
-		$sql = $wpdb->prepare(
-			"SELECT id, title, starting_balance, final_balance, winners_count, closed_at
-							   FROM $t
-							   WHERE status = %s
-							   ORDER BY closed_at DESC
-							   LIMIT %d",
-			'closed',
-			(int) $limit
-		);
-		return $wpdb->get_results( $sql );
-	}
+    function bhg_get_latest_closed_hunts( $limit = 3 ) {
+        global $wpdb;
+        $limit     = (int) $limit;
+        $cache_key = "bhg_latest_closed_hunts_{$limit}";
+
+        $cached = wp_cache_get( $cache_key, 'bhg' );
+        if ( false !== $cached ) {
+            return $cached;
+        }
+
+        $t   = $wpdb->prefix . 'bhg_bonus_hunts';
+        $sql = $wpdb->prepare(
+            "SELECT id, title, starting_balance, final_balance, winners_count, closed_at"
+            . " FROM $t"
+            . " WHERE status = %s"
+            . " ORDER BY closed_at DESC"
+            . " LIMIT %d",
+            'closed',
+            $limit
+        );
+        $rows = $wpdb->get_results( $sql );
+        wp_cache_set( $cache_key, $rows, 'bhg', HOUR_IN_SECONDS );
+
+        return $rows;
+    }
 }
 
 if ( ! function_exists( 'bhg_get_top_winners_for_hunt' ) ) {
-	function bhg_get_top_winners_for_hunt( $hunt_id, $winners_limit = 3 ) {
-		global $wpdb;
-		$t_g = $wpdb->prefix . 'bhg_guesses';
-		$t_h = $wpdb->prefix . 'bhg_bonus_hunts';
+    function bhg_get_top_winners_for_hunt( $hunt_id, $winners_limit = 3 ) {
+        global $wpdb;
+        $t_g    = $wpdb->prefix . 'bhg_guesses';
+        $t_h    = $wpdb->prefix . 'bhg_bonus_hunts';
+        $hunt_id = (int) $hunt_id;
 
-		$hunt = $wpdb->get_row( $wpdb->prepare( "SELECT final_balance, winners_count FROM $t_h WHERE id=%d", (int) $hunt_id ) );
-		if ( ! $hunt || $hunt->final_balance === null ) {
-			return array();
-		}
-			$limit = $winners_limit ? $winners_limit : ( (int) $hunt->winners_count ? (int) $hunt->winners_count : 3 );
+        $hunt = $wpdb->get_row( $wpdb->prepare( "SELECT final_balance, winners_count FROM $t_h WHERE id=%d", $hunt_id ) );
+        if ( ! $hunt || null === $hunt->final_balance ) {
+            return array();
+        }
 
-		$sql = $wpdb->prepare(
-			"SELECT g.user_id, g.guess, ABS(g.guess - %f) AS diff
-			 FROM $t_g g
-			 WHERE g.hunt_id = %d
-			 ORDER BY diff ASC
-			 LIMIT %d",
-			(float) $hunt->final_balance,
-			(int) $hunt_id,
-			(int) $limit
-		);
-		return $wpdb->get_results( $sql );
-	}
+        $limit     = $winners_limit ? $winners_limit : ( (int) $hunt->winners_count ? (int) $hunt->winners_count : 3 );
+        $cache_key = "bhg_top_winners_{$hunt_id}_{$limit}";
+
+        $cached = wp_cache_get( $cache_key, 'bhg' );
+        if ( false !== $cached ) {
+            return $cached;
+        }
+
+        $sql = $wpdb->prepare(
+            "SELECT g.user_id, g.guess, ABS(g.guess - %f) AS diff"
+            . " FROM $t_g g"
+            . " WHERE g.hunt_id = %d"
+            . " ORDER BY diff ASC"
+            . " LIMIT %d",
+            (float) $hunt->final_balance,
+            $hunt_id,
+            (int) $limit
+        );
+        $rows = $wpdb->get_results( $sql );
+        wp_cache_set( $cache_key, $rows, 'bhg', HOUR_IN_SECONDS );
+
+        return $rows;
+    }
 }
 
 if ( ! function_exists( 'bhg_get_all_ranked_guesses' ) ) {
@@ -116,9 +149,30 @@ if ( ! function_exists( 'bhg_get_hunt_participants' ) ) {
 }
 
 if ( ! function_exists( 'bhg_remove_guess' ) ) {
-	function bhg_remove_guess( $guess_id ) {
-		global $wpdb;
-		$t_g = $wpdb->prefix . 'bhg_guesses';
-		return $wpdb->delete( $t_g, array( 'id' => (int) $guess_id ), array( '%d' ) );
-	}
+    function bhg_remove_guess( $guess_id ) {
+        global $wpdb;
+        $t_g      = $wpdb->prefix . 'bhg_guesses';
+        $guess_id = (int) $guess_id;
+
+        $hunt_id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT hunt_id FROM $t_g WHERE id = %d", $guess_id ) );
+        $deleted = $wpdb->delete( $t_g, array( 'id' => $guess_id ), array( '%d' ) );
+
+        if ( $hunt_id ) {
+            bhg_flush_hunt_cache( $hunt_id );
+        }
+
+        return $deleted;
+    }
+}
+
+if ( ! function_exists( 'bhg_flush_hunt_cache' ) ) {
+    function bhg_flush_hunt_cache( $hunt_id ) {
+        $hunt_id = (int) $hunt_id;
+        wp_cache_delete( "bhg_hunt_{$hunt_id}", 'bhg' );
+        for ( $i = 1; $i <= 25; $i++ ) {
+            wp_cache_delete( "bhg_top_winners_{$hunt_id}_{$i}", 'bhg' );
+        }
+        // Latest closed hunts cache uses default limit 3.
+        wp_cache_delete( 'bhg_latest_closed_hunts_3', 'bhg' );
+    }
 }

--- a/includes/class-bhg-models.php
+++ b/includes/class-bhg-models.php
@@ -53,18 +53,20 @@ class BHG_Models {
 
 		// Update hunt status and final details.
 		$now = current_time( 'mysql' );
-		$wpdb->update(
-			$hunts_tbl,
-			array(
-				'status'        => 'closed',
-				'final_balance' => $final_balance,
-				'closed_at'     => $now,
-				'updated_at'    => $now,
-			),
-			array( 'id' => $hunt_id ),
-			array( '%s', '%f', '%s', '%s' ),
-			array( '%d' )
-		);
+                $wpdb->update(
+                        $hunts_tbl,
+                        array(
+                                'status'        => 'closed',
+                                'final_balance' => $final_balance,
+                                'closed_at'     => $now,
+                                'updated_at'    => $now,
+                        ),
+                        array( 'id' => $hunt_id ),
+                        array( '%s', '%f', '%s', '%s' ),
+                        array( '%d' )
+                );
+
+                bhg_flush_hunt_cache( $hunt_id );
 
 		// Fetch winners based on proximity to final balance.
 				$rows = $wpdb->get_results(


### PR DESCRIPTION
## Summary
- cache helper queries for hunts, latest closed hunts, and top winners using `wp_cache_get()`/`wp_cache_set()`
- flush hunt-related caches when hunts or guesses are modified

## Testing
- `composer phpcs` *(fails: existing coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2972e2b48333945d34987ed3aedc