### PR TITLE
Replace deprecated get_page_by_title usage

### DIFF
--- a/includes/demo.php
+++ b/includes/demo.php
@@ -241,7 +241,17 @@ function bhg_seed_demo_on_activation() {
 		),
 	);
 	foreach ( $pages as $p ) {
-		if ( ! get_page_by_title( $p['title'] ) ) {
+		$page_query = new WP_Query(
+			array(
+				'post_type'      => 'page',
+				'title'          => $p['title'],
+				'post_status'    => 'any',
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+				'fields'         => 'ids',
+			)
+		);
+		if ( ! $page_query->have_posts() ) {
 			wp_insert_post(
 				array(
 					'post_title'   => $p['title'],
@@ -251,6 +261,7 @@ function bhg_seed_demo_on_activation() {
 				)
 			);
 		}
+		wp_reset_postdata();
 	}
 
 	update_option( 'bhg_demo_seeded', 1 );


### PR DESCRIPTION
## Summary
- use WP_Query instead of deprecated get_page_by_title when seeding demo pages

## Testing
- `composer run phpcs` *(fails: non-sanitized input variable errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2ac1b4e083338e3cfa70dd4cd5c9