### PR TITLE
Add documentation headers to database and demo files

### DIFF
--- a/admin/views/database.php
+++ b/admin/views/database.php
@@ -1,6 +1,13 @@
 <?php
+/**
+ * Database tools admin view.
+ *
+ * @package Bonus_Hunt_Guesser
+ * @since 1.0.0
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+      exit;
 }
 
 

--- a/includes/demo.php
+++ b/includes/demo.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Demo data management functions.
+ *
+ * @package Bonus_Hunt_Guesser
+ * @since 1.0.0
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
         exit;
 }


### PR DESCRIPTION
## Summary
- add PHPDoc headers for database admin view
- document demo data functions

## Testing
- `composer install`
- `composer phpcs` *(fails: coding standard errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2ab970ec833397c4c00be0330165