### PR TITLE
Use wp_safe_redirect in admin header

### DIFF
--- a/admin/views/header.php
+++ b/admin/views/header.php
@@ -103,7 +103,8 @@ if ( isset( $_POST['bhg_action'] ) ) {
 	}
 
 	// Redirect to avoid form resubmission
-	wp_redirect( add_query_arg( 'message', $message, $_SERVER['REQUEST_URI'] ) );
+	$url = esc_url_raw( add_query_arg( 'message', $message, wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
+	wp_safe_redirect( $url );
 	exit;
 }
 


### PR DESCRIPTION
## Summary
- replace wp_redirect with wp_safe_redirect and esc_url_raw in admin header

## Testing
- `composer phpcs` *(fails: line indentation etc)*
- `vendor/bin/phpcs admin/views/header.php` *(fails: escaping and Yoda conditions)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2c6239b48333881826f6ca5fdc93