### PR TITLE
Align WordPress minimum version to 5.5.5

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,4 +27,4 @@ Date: 2025-09-03
 - User profile: Affiliate Websites section with per-site flags (bhg_affiliate_website_{ID}).
 - Frontend dot: consistent per-hunt/per-site affiliate status display.
 
-Compatibility: PHP 7.4, WordPress 6.3.5, MySQL 5.5.5
+Compatibility: PHP 7.4, WordPress 5.5.5, MySQL 5.5.5

--- a/README-Stage-A.txt
+++ b/README-Stage-A.txt
@@ -1,6 +1,6 @@
 Bonus Hunt Guesser — Stage A Patch
 Generated: 2025-09-05T03:13:45.120802
-Requires at least: 6.3.5
+Requires at least: 5.5.5
 
 WHAT THIS PATCH DELIVERS
 - Fixes parse error in admin/views/translations.php

--- a/README-Stage-B.txt
+++ b/README-Stage-B.txt
@@ -1,6 +1,6 @@
 Bonus Hunt Guesser — Stage B Patch
 Generated: 2025-09-05T03:18:38.706805
-Requires at least: 6.3.5
+Requires at least: 5.5.5
 
 WHAT THIS PATCH DELIVERS
 - Adds "Results" button to the hunts list (Admin → Bonus Hunts).

--- a/bonus-hunt-guesser.php
+++ b/bonus-hunt-guesser.php
@@ -7,7 +7,7 @@
  * Author: Bonus Hunt Guesser Development Team
  * Text Domain: bonus-hunt-guesser
  * Domain Path: /languages
- * Requires at least: 6.3.5
+ * Requires at least: 5.5.5
  * Requires PHP: 7.4
  * License: GPLv2 or later
  */
@@ -105,7 +105,7 @@ require_once __DIR__ . '/includes/class-bhg-db.php';
 
 // Define plugin constants
 define( 'BHG_VERSION', '8.0.08' );
-define( 'BHG_MIN_WP', '6.3.5' );
+define( 'BHG_MIN_WP', '5.5.5' );
 define( 'BHG_PLUGIN_FILE', __FILE__ );
 define( 'BHG_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BHG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- update plugin header to require WordPress 5.5.5
- synchronize minimum WordPress version across documentation and constants

## Testing
- `composer phpcs` *(fails: Line indented incorrectly; expected at least 6 tabs, found 5)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2c8c80dc83339b343a077d567c7c