### PR TITLE
Use prepared delete helpers for dynamic table names

### DIFF
--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -30,11 +30,11 @@ class BHG_Demo {
 		check_admin_referer( 'bhg_demo_reseed' );
 		global $wpdb;
 
-                // Wipe demo data.
-                $hunts_table = esc_sql( $wpdb->prefix . 'bhg_bonus_hunts' );
-                $wpdb->query( $wpdb->prepare( "DELETE FROM {$hunts_table} WHERE title LIKE %s", '%(Demo)%' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-                $tours_table = esc_sql( $wpdb->prefix . 'bhg_tournaments' );
-                $wpdb->query( $wpdb->prepare( "DELETE FROM {$tours_table} WHERE title LIKE %s", '%(Demo)%' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// Wipe demo data.
+		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE title LIKE %s', $hunts_table, '%(Demo)%' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$tours_table = $wpdb->prefix . 'bhg_tournaments';
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE title LIKE %s', $tours_table, '%(Demo)%' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		// Insert demo hunt.
                 $wpdb->insert(

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -547,7 +547,7 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
                                 // keep existing; we'll upsert below
                                 continue;
                         }
-                        $wpdb->query( "DELETE FROM `{$tbl}`" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->delete( $tbl, array( 1 => 1 ), array( '%d' ) );
                 }
 
 		// Seed affiliate websites (idempotent upsert by slug)
@@ -649,7 +649,7 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
                 if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $t_tbl ) ) === $t_tbl ) {
 			// Wipe results only
                         if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $r_tbl ) ) === $r_tbl ) {
-                                $wpdb->query( "DELETE FROM `{$r_tbl}`" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$wpdb->delete( $r_tbl, array( 1 => 1 ), array( '%d' ) );
                         }
                                                 $closed = $wpdb->get_results(
                                                         $wpdb->prepare(


### PR DESCRIPTION
## Summary
- replace direct DELETE queries with prepared statements
- switch to `$wpdb->delete` for table wipes

## Testing
- `composer install`
- `./vendor/bin/phpcs admin/class-bhg-demo.php includes/helpers.php --standard=phpcs.xml` *(fails: existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3659ed1c8333989adc38c4600a80