### PR TITLE
Secure demo reseed utility

### DIFF
--- a/admin/class-bhg-demo.php
+++ b/admin/class-bhg-demo.php
@@ -27,34 +27,13 @@ class BHG_Demo {
 	 * @return void
 	 */
 	public function reseed() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
+		}
+
 		check_admin_referer( 'bhg_demo_reseed' );
-		global $wpdb;
 
-		// Wipe demo data.
-		$hunts_table = $wpdb->prefix . 'bhg_bonus_hunts';
-		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE title LIKE %s', $hunts_table, '%(Demo)%' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$tours_table = $wpdb->prefix . 'bhg_tournaments';
-		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE title LIKE %s', $tours_table, '%(Demo)%' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-
-		// Insert demo hunt.
-                $wpdb->insert(
-                        $hunts_table,
-			array(
-				'title'            => 'Sample Hunt (Demo)',
-				'starting_balance' => 1000,
-				'num_bonuses'      => 5,
-				'status'           => 'open',
-			)
-		);
-
-		// Insert demo tournament.
-                $wpdb->insert(
-                        $tours_table,
-			array(
-				'title'  => 'August Tournament (Demo)',
-				'status' => 'active',
-			)
-		);
+		bhg_reset_demo_and_seed();
 
 		wp_safe_redirect( admin_url( 'admin.php?page=bhg-tools&demo_reset=1' ) );
 		exit;

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -518,6 +518,10 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 	/**
 	 * Reset demo tables and seed sample data.
 	 *
+	 * Administrative utility for creating sample plugin data. Callers must
+	 * verify capabilities and nonces (e.g., via current_user_can() and
+	 * check_admin_referer()) before invoking.
+	 *
 	 * @return bool
 	 */
         function bhg_reset_demo_and_seed() {


### PR DESCRIPTION
## Summary
- Restrict demo reseed endpoint to administrators with nonce verification
- Explain `bhg_reset_demo_and_seed()` as an admin-only helper

## Testing
- `vendor/bin/phpcs -p admin/class-bhg-demo.php`
- `vendor/bin/phpcs admin/class-bhg-demo.php includes/helpers.php` *(fails: coding standard violations in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3afd77448333a4bf2d37d33aec56