### PR TITLE
Rename dashboard submenu and fix coding standards

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -50,7 +50,7 @@ class BHG_Admin {
 			55
 		);
 
-		add_submenu_page( $slug, __( 'Dashboard', 'bonus-hunt-guesser' ), __( 'Dashboard', 'bonus-hunt-guesser' ), $cap, $slug, array( $this, 'dashboard' ) );
+				add_submenu_page( $slug, __( 'Dashboard', 'bonus-hunt-guesser' ), __( 'Dashboard', 'bonus-hunt-guesser' ), $cap, 'bhg-dashboard', array( $this, 'dashboard' ) );
 		add_submenu_page( $slug, __( 'Bonus Hunts', 'bonus-hunt-guesser' ), __( 'Bonus Hunts', 'bonus-hunt-guesser' ), $cap, 'bhg-bonus-hunts', array( $this, 'bonus_hunts' ) );
 		add_submenu_page( $slug, __( 'Results', 'bonus-hunt-guesser' ), __( 'Results', 'bonus-hunt-guesser' ), $cap, 'bhg-bonus-hunts-results', array( $this, 'bonus_hunts_results' ) );
 		add_submenu_page( $slug, __( 'Tournaments', 'bonus-hunt-guesser' ), __( 'Tournaments', 'bonus-hunt-guesser' ), $cap, 'bhg-tournaments', array( $this, 'tournaments' ) );
@@ -190,47 +190,47 @@ class BHG_Admin {
 			echo '<div class="wrap"><h1>' . esc_html__( 'BHG Tools', 'bonus-hunt-guesser' ) . '</h1><p>' . esc_html__( 'No tools UI found.', 'bonus-hunt-guesser' ) . '</p></div>'; }
 	}
 
-    // -------------------- Handlers --------------------
+	// -------------------- Handlers --------------------
 
-    /**
-     * Handle deletion of a guess from the admin screen.
-     */
-    public function handle_delete_guess() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
-        }
+	/**
+	 * Handle deletion of a guess from the admin screen.
+	 */
+	public function handle_delete_guess() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'No permission', 'bonus-hunt-guesser' ) );
+		}
 
-        check_admin_referer( 'bhg_delete_guess' );
+		check_admin_referer( 'bhg_delete_guess' );
 
-        global $wpdb;
+		global $wpdb;
 
-        $guesses_table = esc_sql( $wpdb->prefix . 'bhg_guesses' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table name.
-        $guess_id      = isset( $_POST['guess_id'] ) ? absint( wp_unslash( $_POST['guess_id'] ) ) : 0;
+		$guesses_table = esc_sql( $wpdb->prefix . 'bhg_guesses' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table name.
+		$guess_id      = isset( $_POST['guess_id'] ) ? absint( wp_unslash( $_POST['guess_id'] ) ) : 0;
 
-        if ( 0 !== $guess_id ) {
-            // Get the hunt ID associated with the guess for cache clearing.
-            $hunt_id = (int) $wpdb->get_var(
-                $wpdb->prepare(
-                    "SELECT hunt_id FROM {$guesses_table} WHERE id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is escaped above.
-                    $guess_id
-                )
-            );
+		if ( 0 !== $guess_id ) {
+			// Get the hunt ID associated with the guess for cache clearing.
+			$hunt_id = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT hunt_id FROM {$guesses_table} WHERE id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table name is escaped above.
+					$guess_id
+				)
+			);
 
-            // Remove the guess from the database.
-            $wpdb->delete(
-                $guesses_table,
-                array( 'id' => $guess_id ),
-                array( '%d' )
-            );
+			// Remove the guess from the database.
+			$wpdb->delete(
+				$guesses_table,
+				array( 'id' => $guess_id ),
+				array( '%d' )
+			);
 
-            if ( $hunt_id ) {
-                bhg_flush_hunt_cache( $hunt_id );
-            }
-        }
+			if ( $hunt_id ) {
+				bhg_flush_hunt_cache( $hunt_id );
+			}
+		}
 
-        wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
-        exit;
-    }
+		wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=bhg-bonus-hunts' ) );
+		exit;
+	}
 
 	/**
 	 * Handle creation and updating of a bonus hunt.
@@ -275,8 +275,8 @@ class BHG_Admin {
 				$id = (int) $wpdb->insert_id;
 		}
 
-wp_cache_delete( "bhg_hunt_title_{$id}", 'bhg' );
-bhg_flush_hunt_cache( $id );
+		wp_cache_delete( "bhg_hunt_title_{$id}", 'bhg' );
+		bhg_flush_hunt_cache( $id );
 
 		if ( 'closed' === $status && null !== $final_balance ) {
 				$winners = BHG_Models::close_hunt( $id, $final_balance );


### PR DESCRIPTION
## Summary
- Rename first submenu to Dashboard and give it a distinct slug
- Clean up admin class to satisfy WordPress coding standards

## Testing
- `./vendor/bin/phpcs admin/class-bhg-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc3efef5a88333b924aa095b4a9f5d