### PR TITLE
Display final balance and highlight winners in admin results

### DIFF
--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -25,12 +25,16 @@ if ( ! $hunt ) {
 		return;
 }
 $rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query.
-	$wpdb->prepare(
-		"SELECT g.id, g.user_id, g.guess, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is dynamic.
-		(float) $hunt->final_balance,
-		$hunt_id
-	)
+        $wpdb->prepare(
+                "SELECT g.id, g.user_id, g.guess, u.display_name, ABS(g.guess - %f) as diff FROM `$guesses` g JOIN `$wpdb->users` u ON u.ID=g.user_id WHERE g.hunt_id=%d ORDER BY diff ASC, g.id ASC", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is dynamic.
+                (float) $hunt->final_balance,
+                $hunt_id
+        )
 );
+$winner_count = (int) $hunt->winners_count;
+if ( $winner_count < 1 ) {
+        $winner_count = 3;
+}
 ?>
 <div class="wrap">
 		<h1>
@@ -47,25 +51,15 @@ $rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoC
 		<th><?php esc_html_e( 'Difference', 'bonus-hunt-guesser' ); ?></th>
 	</tr></thead>
 	<tbody>
-	<?php
-	$pos = 1;
-	foreach ( $rows as $r ) :
-			$wcount = (int) $hunt->winners_count;
-		if ( $wcount < 1 ) {
-				$wcount = 3;
-		}
-						$is_winner = $pos <= $wcount;
-		?>
-				<tr
-			<?php
-			if ( $is_winner ) {
-				echo 'class="bhg-winner-row"';
-			}
-			?>
-				>
-		<td><?php echo (int) $pos; ?></td>
-		<td><?php echo esc_html( $r->display_name ); ?></td>
-		<td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
+        <?php
+        $pos = 1;
+        foreach ( $rows as $r ) :
+                $is_winner = $pos <= $winner_count;
+                ?>
+                                <tr <?php echo $is_winner ? 'class="bhg-winner-row"' : ''; ?>>
+                <td><?php echo (int) $pos; ?></td>
+                <td><?php echo esc_html( $r->display_name ); ?></td>
+                <td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
 		<td><?php echo esc_html( number_format_i18n( (float) $r->diff, 2 ) ); ?></td>
 		</tr>
 		<?php

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -96,7 +96,15 @@ if ( 'list' === $view ) :
 				?>
 							"><?php echo esc_html( $h->title ); ?></a></td>
 			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
-					<td><?php echo null !== $h->final_balance ? esc_html( number_format_i18n( (float) $h->final_balance, 2 ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+                        <td>
+                                <?php
+                                if ( 'closed' === $h->status && null !== $h->final_balance ) {
+                                        echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
+                                } else {
+                                        echo esc_html__( '—', 'bonus-hunt-guesser' );
+                                }
+                                ?>
+                        </td>
 			<td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
 					<td><?php echo esc_html( $status_labels[ $h->status ] ?? $h->status ); ?></td>
 			<td>
@@ -126,8 +134,8 @@ if ( 'list' === $view ) :
 														);
 														?>
 														<a class="button" href="<?php echo esc_url( $close_url ); ?>"><?php echo esc_html__( 'Close Hunt', 'bonus-hunt-guesser' ); ?></a>
-												<?php elseif ( 'closed' === $h->status && null !== $h->final_balance ) : ?>
-														<a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
+                                                                                                <?php elseif ( 'closed' === $h->status ) : ?>
+                                                                                                                <a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=bhg-bonus-hunts-results&id=' . (int) $h->id ) ); ?>"><?php echo esc_html__( 'Results', 'bonus-hunt-guesser' ); ?></a>
 												<?php endif; ?>
 			</td>
 		</tr>


### PR DESCRIPTION
## Summary
- Show final balance or dash for open hunts and expose Results button when a hunt is closed
- Highlight winners in hunt results table using configurable `winners_count`

## Testing
- `composer install`
- `vendor/bin/phpcs admin/views/bonus-hunts.php admin/views/bonus-hunts-results.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc3f03000c833395f54058f1b9376d