### PR TITLE
Add guess management links on hunt edit screen

### DIFF
--- a/admin/class-bhg-admin.php
+++ b/admin/class-bhg-admin.php
@@ -205,7 +205,7 @@ class BHG_Admin {
         global $wpdb;
 
         $guesses_table = esc_sql( $wpdb->prefix . 'bhg_guesses' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table name.
-        $guess_id      = isset( $_POST['guess_id'] ) ? absint( wp_unslash( $_POST['guess_id'] ) ) : 0;
+        $guess_id      = isset( $_REQUEST['guess_id'] ) ? absint( wp_unslash( $_REQUEST['guess_id'] ) ) : 0;
 
         if ( 0 !== $guess_id ) {
             // Get the hunt ID associated with the guess for cache clearing.

--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -115,16 +115,23 @@ $base     = remove_query_arg( 'ppaged' );
 				<tr>
 					<td><a href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . (int) $r->user_id ) ); ?>"><?php echo esc_html( $name ); ?></a></td>
 					<td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
-					<td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
-					<td>
-						<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" onsubmit="return confirm('<?php echo esc_js( __( 'Delete this guess?', 'bonus-hunt-guesser' ) ); ?>');" class="bhg-inline-form">
-							<?php wp_nonce_field( 'bhg_delete_guess' ); ?>
-							<input type="hidden" name="action" value="bhg_delete_guess">
-							<input type="hidden" name="guess_id" value="<?php echo (int) $r->id; ?>">
-							<button type="submit" class="button-link-delete"><?php esc_html_e( 'Remove', 'bonus-hunt-guesser' ); ?></button>
-						</form>
-					</td>
-				</tr>
+                                       <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+                                       <td>
+                                               <?php
+                                               $delete_url = wp_nonce_url(
+                                                       add_query_arg(
+                                                               array(
+                                                                       'action'   => 'bhg_delete_guess',
+                                                                       'guess_id' => (int) $r->id,
+                                                               ),
+                                                               admin_url( 'admin-post.php' )
+                                                       ),
+                                                       'bhg_delete_guess'
+                                               );
+                                               ?>
+                                               <a href="<?php echo esc_url( $delete_url ); ?>" class="button-link-delete" onclick="return confirm('<?php echo esc_js( __( 'Delete this guess?', 'bonus-hunt-guesser' ) ); ?>');"><?php esc_html_e( 'Remove', 'bonus-hunt-guesser' ); ?></a>
+                                       </td>
+                                </tr>
 							<?php
 			endforeach;
 endif;


### PR DESCRIPTION
## Summary
- List hunt participants with links and removable guesses
- Allow deletion handler to accept guess ID from URL

## Testing
- `vendor/bin/phpcs admin/views/bonus-hunts-edit.php admin/class-bhg-admin.php` *(fails: coding standard violations remain)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3f0488b08333875c711a6a99d0aa