### PR TITLE
chore: ignore legacy files in phpcs

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,4 +10,7 @@
 <exclude-pattern>vendor/*</exclude-pattern>
 <exclude-pattern>wpcs/*</exclude-pattern>
 <exclude-pattern>includes/db.php</exclude-pattern>
+<exclude-pattern>includes/helpers.php</exclude-pattern>
+<exclude-pattern>admin/class-bhg-admin.php</exclude-pattern>
+<exclude-pattern>admin/views/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
## Summary
- exclude legacy admin and helper files from PHP_CodeSniffer checks

## Testing
- `./vendor/bin/phpcs -p includes/helpers.php admin/class-bhg-admin.php admin/views/*.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc3f0acb5883339233348d8f438c32