### PR TITLE
Fix redundant closing brace in demo reset helper

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -782,4 +782,3 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 
                 return true;
         }
-}


### PR DESCRIPTION
## Summary
- remove unnecessary closing brace from `bhg_reset_demo_and_seed`

## Testing
- `php -l includes/helpers.php`
- `vendor/bin/phpcs includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc4409696c83338d16cef8fb6c30c5