### PR TITLE
Add security checks to demo reset utility

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -530,6 +530,12 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
                 global $wpdb;
                 $p = $wpdb->prefix;
 
+                if ( ! current_user_can( 'manage_options' ) ) {
+                        return false;
+                }
+
+                check_admin_referer( 'bhg_reset_demo_and_seed' );
+
                 // Ensure tables exist before touching
                 $tables = array(
                         esc_sql( "{$p}bhg_guesses" ),
@@ -726,12 +732,11 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
                                                         )
                                                 );
                                         }
-					}
-				}
-			}
-		}
+                                }
+                        }
+                }
 
-		// Seed translations (upsert)
+                // Seed translations (upsert)
                 $tr_tbl = esc_sql( "{$p}bhg_translations" );
                 if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $tr_tbl ) ) === $tr_tbl ) {
 			$pairs = array(


### PR DESCRIPTION
## Summary
- restrict demo data reset to privileged users and verified requests
- tidy closing braces in helpers

## Testing
- `php -l includes/helpers.php`
- `vendor/bin/phpcs includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc440b5d648333938f6dfc81e15d01