### PR TITLE
Use prepared statements for bulk DELETE operations

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -590,7 +590,7 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 				continue;
 			}
 
-			$wpdb->query( "DELETE FROM `{$tbl}`" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', $tbl ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		}
 
 		// Seed affiliate websites (idempotent upsert by slug).
@@ -697,7 +697,7 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $t_tbl ) ) === $t_tbl ) {
 			// Wipe results only.
 			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $r_tbl ) ) === $r_tbl ) {
-				$wpdb->query( "DELETE FROM `{$r_tbl}`" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', $r_tbl ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 			}
 
 			$closed = $wpdb->get_results(


### PR DESCRIPTION
## Summary
- Harden table resets by replacing interpolated DELETE queries with prepared statements
- Apply same hardening to tournament results cleanup

## Testing
- `composer install`
- `vendor/bin/phpcs -p includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc48555fac8333b2b66218ae2f5730