### PR TITLE
docs: add demo data file header

### DIFF
--- a/admin/views/demo-data.php
+++ b/admin/views/demo-data.php
@@ -1,4 +1,8 @@
 <?php
-// phpcs:ignoreFile -- Legacy view requires refactoring for WordPress coding standards.
-// Demo data installer for Bonus Hunt Guesser
-// Seeds sample hunts, guesses, tournaments, ads, translations
+/**
+ * Demo data installer for Bonus Hunt Guesser.
+ *
+ * Seeds sample hunts, guesses, tournaments, ads, and translations.
+ *
+ * @package Bonus_Hunt_Guesser
+ */


### PR DESCRIPTION
## Summary
- remove phpcs ignore and add docblock to demo data view

## Testing
- `composer install`
- `./vendor/bin/phpcs -p --standard=WordPress admin/views/demo-data.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc4ee226b88333ace1c942955ca066