### PR TITLE
Initialize database prefix in helper setup

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -561,14 +561,13 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 	 *
 	 * @return bool
 	 */
-	function bhg_reset_demo_and_seed() {
-		global $wpdb;
+       function bhg_reset_demo_and_seed() {
+               global $wpdb;
+               $p = $wpdb->prefix;
 
-		$p = $wpdb->prefix;
-
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return false;
-		}
+               if ( ! current_user_can( 'manage_options' ) ) {
+                       return false;
+               }
 
 		check_admin_referer( 'bhg_reset_demo_and_seed' );
 


### PR DESCRIPTION
## Summary
- ensure `bhg_reset_demo_and_seed` initializes `$wpdb` and DB prefix at function start

## Testing
- `php -l includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc4ee7ccb48333b42b433d0b73244f