### PR TITLE
Use wpdb placeholder for DELETE queries

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -596,12 +596,9 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 				continue;
 			}
 
-                        $wpdb->query(
-                                $wpdb->prepare(
-                                        "DELETE FROM {$tbl} WHERE 1 = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-                                        1
-                                )
-                        );
+                       $wpdb->query(
+                               $wpdb->prepare( 'DELETE FROM %i', $tbl )
+                       );
 		}
 
 		// Seed affiliate websites (idempotent upsert by slug).
@@ -713,12 +710,9 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
 		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $t_tbl ) ) === $t_tbl ) {
 			// Wipe results only.
 			if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $r_tbl ) ) === $r_tbl ) {
-                                $wpdb->query(
-                                        $wpdb->prepare(
-                                                "DELETE FROM {$r_tbl} WHERE 1 = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-                                                1
-                                        )
-                                );
+                               $wpdb->query(
+                                       $wpdb->prepare( 'DELETE FROM %i', $r_tbl )
+                               );
 			}
 
 			$closed = $wpdb->get_results(


### PR DESCRIPTION
## Summary
- replace direct `DELETE` queries with `$wpdb->prepare()` identifier placeholder
- drop unused `phpcs:ignore` comments for dynamic table names

## Testing
- `php -l includes/helpers.php`
- `composer phpcs` *(fails: 0 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4eeb7c2083338d85c2929f2cf55a