### PR TITLE
Rename main admin menu to Bonus Hunt Guesser

### DIFF
--- a/includes/class-bhg-menus.php
+++ b/includes/class-bhg-menus.php
@@ -92,8 +92,8 @@ if ( ! class_exists( 'BHG_Menus' ) ) {
 			$slug = 'bhg';
 
 			add_menu_page(
-				__( 'Bonus Hunt', 'bonus-hunt-guesser' ),
-				__( 'Bonus Hunt', 'bonus-hunt-guesser' ),
+				__( 'Bonus Hunt Guesser', 'bonus-hunt-guesser' ),
+				__( 'Bonus Hunt Guesser', 'bonus-hunt-guesser' ),
 				$cap,
 				$slug,
 				array( $this, 'render_dashboard' ),


### PR DESCRIPTION
## Summary
- Update main admin menu page and menu titles to "Bonus Hunt Guesser"
- Confirm dashboard submenu uses "Dashboard" for both page and menu titles

## Testing
- `vendor/bin/phpcs -p includes/class-bhg-menus.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc52ca69908333b6d73865f751cadf