### PR TITLE
Document PHPCS ignores for dynamic tables

### DIFF
--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -27,8 +27,8 @@ if ( ! in_array( $hunts_table, $allowed_tables, true ) || ! in_array( $guesses_t
 				wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
 
-$hunts_table   = esc_sql( $hunts_table );
-$guesses_table = esc_sql( $guesses_table );
+$hunts_table   = esc_sql( $hunts_table ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table name escaped with esc_sql.
+$guesses_table = esc_sql( $guesses_table ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table name escaped with esc_sql.
 
 $view = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'list';
 
@@ -253,7 +253,7 @@ if ( 'add' === $view ) :
 			if ( ! in_array( $aff_table, $allowed_tables, true ) ) {
 					wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 			}
-						$aff_table = esc_sql( $aff_table );
+                                               $aff_table = esc_sql( $aff_table ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table name escaped with esc_sql.
 						$affs      = $wpdb->get_results(
 							$wpdb->prepare(
                                                                 "SELECT id, name FROM {$aff_table} WHERE %d = %d ORDER BY name ASC", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is dynamic and sanitized.

--- a/admin/views/tournaments.php
+++ b/admin/views/tournaments.php
@@ -14,14 +14,13 @@ if ( ! current_user_can( 'manage_options' ) ) {
 				wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bonus-hunt-guesser' ) );
 }
 
-// phpcs:disable WordPress.DB.DirectDatabaseQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Queries use dynamic, sanitized table names.
 global $wpdb;
 $table          = $wpdb->prefix . 'bhg_tournaments';
 $allowed_tables = array( $wpdb->prefix . 'bhg_tournaments' );
 if ( ! in_array( $table, $allowed_tables, true ) ) {
-		wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
+                wp_die( esc_html__( 'Invalid table.', 'bonus-hunt-guesser' ) );
 }
-$table = esc_sql( $table );
+$table = esc_sql( $table ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Table name escaped with esc_sql.
 
 $edit_id = absint( wp_unslash( $_GET['edit'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $row     = $edit_id


### PR DESCRIPTION
## Summary
- annotate esc_sql usage for bonus hunts tables and affiliates
- remove broad PHPCS disable in tournament view and document table name escaping

## Testing
- `composer install`
- `composer phpcs` *(fails: Processing form data without nonce verification; direct database call without caching)*


------
https://chatgpt.com/codex/tasks/task_e_68bc52d08c488333b0dd758883137489