### PR TITLE
Refine dashboard hunt cards

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -53,9 +53,9 @@ $hunts = bhg_get_latest_closed_hunts( 3 );
 								?>
 								<li class="bhg-winner winner-<?php echo (int) $i + 1; ?>">
 									<span class="dashicons dashicons-awards bhg-icon" aria-hidden="true"></span>
-									<?php echo esc_html( $nm ); ?>
-									<?php esc_html_e( '—', 'bonus-hunt-guesser' ); ?>
-									<?php echo esc_html( number_format_i18n( (float) $w->guess, 2 ) ); ?>
+									<span class="bhg-winner-name"><?php echo esc_html( $nm ); ?></span>
+									<span class="bhg-winner-sep"><?php esc_html_e( '—', 'bonus-hunt-guesser' ); ?></span>
+									<span class="bhg-winner-guess"><?php echo esc_html( number_format_i18n( (float) $w->guess, 2 ) ); ?></span>
 									<span class="bhg-diff">
 										(<?php esc_html_e( 'diff', 'bonus-hunt-guesser' ); ?>
 										<?php echo esc_html( number_format_i18n( (float) $w->diff, 2 ) ); ?>)

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -69,6 +69,20 @@ body.wp-admin .bhg-admin {
     gap: 4px;
 }
 
+
+.bhg-winner-name {
+    font-weight: 600;
+    flex: 1;
+}
+
+.bhg-winner-sep {
+    margin: 0 4px;
+}
+
+.bhg-winner-guess {
+    font-weight: 600;
+}
+
 .bhg-winner .bhg-diff {
     color: #6b7280;
     font-size: 12px;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -90,6 +90,16 @@
     align-items:center;
     gap:4px;
 }
+.bhg-winner-name{
+    font-weight:600;
+    flex:1;
+}
+.bhg-winner-sep{
+    margin:0 4px;
+}
+.bhg-winner-guess{
+    font-weight:600;
+}
 .bhg-winner .bhg-icon{color:#f59e0b}
 .bhg-winner .bhg-diff{
     color:#6b7280;


### PR DESCRIPTION
## Summary
- ensure dashboard shows Latest Hunts section
- list winner name, guess, and difference for each hunt
- add CSS hooks for improved hunt card layout

## Testing
- `composer phpcs` *(fails: Processing form data without nonce verification; direct database call warnings)*
- `php -l admin/views/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc52d5cda08333a8ad90dbf0533b60