### PR TITLE
Use hyphen placeholder for unfinished balances

### DIFF
--- a/admin/views/bonus-hunts-edit.php
+++ b/admin/views/bonus-hunts-edit.php
@@ -76,7 +76,7 @@ $base     = remove_query_arg( 'ppaged' );
 				</tr>
 				<tr>
 					<th scope="row"><label for="bhg_final"><?php echo esc_html__( 'Final Balance', 'bonus-hunt-guesser' ); ?></label></th>
-					<td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '—', 'bonus-hunt-guesser' ) ); ?>"></td>
+                                       <td><input type="number" step="0.01" min="0" id="bhg_final" name="final_balance" value="<?php echo esc_attr( $hunt->final_balance ); ?>" placeholder="<?php echo esc_attr( esc_html__( '-', 'bonus-hunt-guesser' ) ); ?>"></td>
 				</tr>
 				<tr>
 					<th scope="row"><label for="bhg_status"><?php echo esc_html__( 'Status', 'bonus-hunt-guesser' ); ?></label></th>
@@ -116,7 +116,7 @@ $base     = remove_query_arg( 'ppaged' );
 				<tr>
 					<td><a href="<?php echo esc_url( admin_url( 'user-edit.php?user_id=' . (int) $r->user_id ) ); ?>"><?php echo esc_html( $name ); ?></a></td>
 					<td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>
-                                       <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '—', 'bonus-hunt-guesser' ); ?></td>
+                                       <td><?php echo $r->created_at ? esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $r->created_at ) ) ) : esc_html__( '-', 'bonus-hunt-guesser' ); ?></td>
                                        <td>
                                                <?php
                                                $delete_url = wp_nonce_url(

--- a/admin/views/bonus-hunts-results.php
+++ b/admin/views/bonus-hunts-results.php
@@ -57,7 +57,7 @@ if ( $winner_count < 1 ) {
         foreach ( $rows as $r ) :
                 $is_winner = $pos <= $winner_count;
                 ?>
-                                <tr <?php echo $is_winner ? 'class="bhg-winner-row"' : ''; ?>>
+                                <tr<?php echo $is_winner ? ' class="bhg-winner-row"' : ''; ?>>
                 <td><?php echo (int) $pos; ?></td>
                 <td><?php echo esc_html( $r->display_name ); ?></td>
                 <td><?php echo esc_html( number_format_i18n( (float) $r->guess, 2 ) ); ?></td>

--- a/admin/views/bonus-hunts.php
+++ b/admin/views/bonus-hunts.php
@@ -109,13 +109,13 @@ if ( 'list' === $view ) :
 			<td><?php echo esc_html( number_format_i18n( (float) $h->starting_balance, 2 ) ); ?></td>
 						<td>
 								<?php
-								if ( 'closed' === $h->status && null !== $h->final_balance ) {
-										echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
-								} else {
-										echo esc_html__( '—', 'bonus-hunt-guesser' );
-								}
-								?>
-						</td>
+                                                                if ( 'closed' === $h->status && null !== $h->final_balance ) {
+                                                                                echo esc_html( number_format_i18n( (float) $h->final_balance, 2 ) );
+                                                                } else {
+                                                                                echo esc_html__( '-', 'bonus-hunt-guesser' );
+                                                                }
+                                                                ?>
+                                                </td>
 			<td><?php echo (int) ( $h->winners_count ?? 3 ); ?></td>
 					<td><?php echo esc_html( $status_labels[ $h->status ] ?? $h->status ); ?></td>
 			<td>


### PR DESCRIPTION
## Summary
- Show a hyphen when a hunt's final balance is unset
- Use hyphen placeholders in edit and participant views
- Clean up winner-row markup for bonus hunt results

## Testing
- `vendor/bin/phpcs admin/views/bonus-hunts.php admin/views/bonus-hunts-edit.php admin/views/bonus-hunts-results.php`

------
https://chatgpt.com/codex/tasks/task_e_68bc52d731948333b2503ead25dd37d6