### PR TITLE
Notify participants when hunt closes

### DIFF
--- a/admin/class-bhg-bonus-hunts-controller.php
+++ b/admin/class-bhg-bonus-hunts-controller.php
@@ -135,6 +135,15 @@ if ( ! class_exists( 'BHG_Bonus_Hunts_Controller' ) ) {
 						)
 					);
 
+					if ( $result && 'closed' === $status && null !== $final_balance ) {
+						if ( class_exists( 'BHG_Models' ) ) {
+							$winner_ids = BHG_Models::close_hunt( $id, $final_balance );
+							if ( function_exists( 'bhg_send_hunt_results_email' ) ) {
+								bhg_send_hunt_results_email( $id, $winner_ids );
+							}
+						}
+					}
+
 					$message = $result ? 'updated' : 'error';
 					break;
 


### PR DESCRIPTION
## Summary
- email participants and winners when a hunt closes
- allow customizing message via `bhg_email_subject` and `bhg_email_body`

## Testing
- `composer phpcs admin/class-bhg-bonus-hunts-controller.php includes/class-bhg-bonus-hunts-helpers.php`

------
https://chatgpt.com/codex/tasks/task_e_68bc5753d9108333ac7687ba3c4e4a33