### PR TITLE
Initialize DB prefix early in demo seeding helper

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -561,14 +561,14 @@ if ( ! function_exists( 'bhg_reset_demo_and_seed' ) ) {
          * @return bool False when capability checks fail.
          */
         function bhg_reset_demo_and_seed() {
+                global $wpdb;
+                $p = $wpdb->prefix;
+
                 if ( ! current_user_can( 'manage_options' ) ) {
                         return false;
                 }
 
                 check_admin_referer( 'bhg_demo_reseed_action', 'bhg_nonce' );
-
-                global $wpdb;
-                $p = $wpdb->prefix;
 
                 // Ensure tables exist before touching.
                 $tables = array(


### PR DESCRIPTION
## Summary
- Move `$wpdb` global and prefix setup to the start of `bhg_reset_demo_and_seed()` for consistent database access

## Testing
- `php -l includes/helpers.php`
- `vendor/bin/phpcs --standard=WordPress includes/helpers.php` *(fails: 203 errors, 48 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc643de7f08333bcbe42f6f67088a7